### PR TITLE
Fixed bug where params arg wasn't passed into request call

### DIFF
--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -80,7 +80,7 @@ class APIConnector(object):
                 A requests response object
         """
 
-        r = self.request(url, 'GET', params=None)
+        r = self.request(url, 'GET', params=params)
 
         self.validate_response(r)
 


### PR DESCRIPTION
Found this bug while trying to use your VAN Score Helper. In `approve_scores()`, you're using the Parsons VAN method `get_score_updates()`, passing `score_id` as an argument. But because of this bug, that argument never gets passed as parameters to the actual request, and so the results aren't actually filtered and we get ALL the score updates. 

We could just filter the Parsons Table it returns, but I figure we'll need to be able to pass parameters to GET requests in the future, and this was such a simple fix.