### PR TITLE
fix up exception message from APIConnector

### DIFF
--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -130,11 +130,16 @@ class APIConnector(object):
 
         if resp.status_code >= 400:
 
+            if resp.reason:
+                message = f'HTTP error occurred ({resp.status_code}): {resp.reason}'
+            else:
+                message = f'HTTP error occurred ({resp.status_code})'
+
             # Some errors return JSONs with useful info about the error. Return it if exists.
             if self.json_check(resp):
-                raise HTTPError(f'HTTP error occurred: {HTTPError}, {resp.json()}')
+                raise HTTPError(f'{message}, json: {resp.json()}')
             else:
-                raise HTTPError(f'HTTP error occurred: {HTTPError}')
+                raise HTTPError(message)
 
     def data_parse(self, resp):
         """


### PR DESCRIPTION
This commit fixes the message passed to the `HTTPError` exception
being raised when the 
`parsons.utilities.api_connector.APIConnector` validates an HTTP
response. The new exception message includes the status code and
reason (if provided), along with the body of the response if it
is JSON data.