### PR TITLE
Table: Attribute to return first value in table.

### DIFF
--- a/docs/table.rst
+++ b/docs/table.rst
@@ -112,6 +112,8 @@ Parsons Table Attributes
       - A list of column names in the table
     * - ``.data``
       - The actual data (rows) of the table, as a list of tuples (without field names)
+    * - ``.value``
+      - The first value in the table. Use for database queries where a single value is returned.
 
 A note on indexing and iterating over a table's data:
 If you need to iterate over the data, make sure to use the python iterator syntax, so any data transformations can be applied efficiently. An example:

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -112,7 +112,7 @@ Parsons Table Attributes
       - A list of column names in the table
     * - ``.data``
       - The actual data (rows) of the table, as a list of tuples (without field names)
-    * - ``.value``
+    * - ``.first``
       - The first value in the table. Use for database queries where a single value is returned.
 
 A note on indexing and iterating over a table's data:

--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -105,7 +105,7 @@ class Table(ETL, ToFrom):
         return list(petl.header(self.table))
 
     @property
-    def value(self):
+    def first(self):
         """
         Returns the first value in the table. Useful for database queries that only
         return a single value.

--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -104,6 +104,20 @@ class Table(ETL, ToFrom):
         """
         return list(petl.header(self.table))
 
+    @property
+    def value(self):
+        """
+        Returns the first value in the table. Useful for database queries that only
+        return a single value.
+        """
+
+        try:
+            return self.data[0][0]
+
+        # If first value is empty, return None
+        except IndexError:
+            return None
+
     def materialize(self):
         """
         "Materializes" a Table, meaning all data is loaded into memory and all pending

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -520,6 +520,14 @@ class TestParsonsTable(unittest.TestCase):
         # Test that there is only one row in the table
         self.assertEqual(self.tbl.num_rows, 1)
 
+    def test_value(self):
+        # Test that the first value in the table is returned.
+        self.assertEqual(self.tbl.value, 'Bob')
+
+        # Test empty value returns None
+        empty_tbl = Table([[1], [], [3]])
+        self.assertIsNone(empty_tbl.value)
+
     def test_stack(self):
         tbl1 = self.tbl
         tbl2 = Table([{'first': 'Mary', 'last': 'Nichols'}])

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -520,13 +520,13 @@ class TestParsonsTable(unittest.TestCase):
         # Test that there is only one row in the table
         self.assertEqual(self.tbl.num_rows, 1)
 
-    def test_value(self):
+    def test_first(self):
         # Test that the first value in the table is returned.
-        self.assertEqual(self.tbl.value, 'Bob')
+        self.assertEqual(self.tbl.first, 'Bob')
 
         # Test empty value returns None
         empty_tbl = Table([[1], [], [3]])
-        self.assertIsNone(empty_tbl.value)
+        self.assertIsNone(empty_tbl.first)
 
     def test_stack(self):
         tbl1 = self.tbl


### PR DESCRIPTION
This is a convenience method to return the first value in a Parsons Table. 

This is intended to be used with database queries in which a single value is expected to be returned. Ex: `tbl = rs.query('select count(*) from my_schema.my_table')`.

While this required accessing the index previously, now you just run `tbl.first` to access the first value in the table.

Not sure that `value` is the best name for this attribute and open to suggestions.

Intended to address Issue #55.