### PR TITLE
VAN Logging Notification

### DIFF
--- a/parsons/ngpvan/activist_codes.py
+++ b/parsons/ngpvan/activist_codes.py
@@ -46,8 +46,6 @@ class ActivistCodes(object):
         # Internal method to apply/remove activist codes. Was previously a public method,
         # but for the sake of simplicity, breaking out into two public methods.
 
-        logger.info(f'Method deprecated. Use apply_activist_code() or remove_activist_code().')
-
         response = {"activistCodeId": activist_code_id,
                     "action": action_parse(action),
                     "type": "activistCode"}


### PR DESCRIPTION
A false logging notification was being triggered. This removes it.