### PR TITLE
Check if file is remote before check it has_data

### DIFF
--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -480,8 +480,13 @@ class ToFrom(object):
             Parsons Table
                 See :ref:`parsons-table` for output options.
         """  # noqa: W605
+        remote_prefixes = ["http://", "https://", "ftp://", "s3://"]
+        if any(map(local_path.startswith, remote_prefixes)):
+            is_remote_file = True
+        else:
+            is_remote_file = False
 
-        if not files.has_data(local_path):
+        if not is_remote_file and not files.has_data(local_path):
             raise ValueError('CSV file is empty')
 
         return cls(petl.fromcsv(local_path, **csvargs))


### PR DESCRIPTION
The `from_s3_csv` method appears to support reading from remote sources (since it uses `petl.fromcsv` [under the hood](https://petl.readthedocs.io/en/stable/io.html#extract-read)). In fact,  the `VAN` class uses it to [download saved lists](https://github.com/move-coop/parsons/blob/master/parsons/ngpvan/saved_lists.py#L65).

To avoid `FileNotFoundError`, we can bypass the `has_data` check if the file is from a remote source.