### PR TITLE
Update and standardize expand_fields

### DIFF
--- a/parsons/ngpvan/events.py
+++ b/parsons/ngpvan/events.py
@@ -14,8 +14,9 @@ class Events(object):
 
     def get_events(self, code_ids=None, event_type_ids=None, rep_event_id=None,
                    starting_after=None, starting_before=None, district_field=None,
-                   expand=['locations', 'codes', 'shifts', 'roles', 'notes',
-                           'onlineForms']):
+                   expand_fields=['locations', 'codes', 'shifts', 'roles', 'notes',
+                                  'financialProgram', 'ticketCategories',
+                                  'onlineForms']):
         """
         Get events.
 
@@ -32,17 +33,18 @@ class Events(object):
                 Events beginning before ``iso8601`` formatted date.
             district_field: str
                 Filter by district field.
-            expand : list
-                A list of nested jsons to include in returned event
-                object. Can be ``locations``, ``codes``, ``shifts``,
-                ``roles``, ``notes``, ``onlineForms``.
+            expand_fields: list
+                A list of fields for which to include data. If a field is omitted,
+                ``None`` will be returned for that field. Can be ``locations``, ``codes``,
+                ``shifts``,``roles``, ``notes``, ``financialProgram``, ``ticketCategories``,
+                ``onlineForms``.
         `Returns:`
             Parsons Table
                 See :ref:`parsons-table` for output options.
         """
 
-        if expand:
-            expand = ','.join(expand)
+        if expand_fields:
+            expand_fields = ','.join(expand_fields)
 
         params = {'codeIds': code_ids,
                   'eventTypeIds': event_type_ids,
@@ -51,34 +53,36 @@ class Events(object):
                   'startingBefore': starting_before,
                   'districtFieldValue': district_field,
                   'top': 50,
-                  '$expand': expand
+                  '$expand': expand_fields
                   }
 
         tbl = Table(self.connection.get_request('events', params=params))
         logger.info(f'Found {tbl.num_rows} events.')
         return tbl
 
-    def get_event(self, event_id, expand=['locations', 'codes', 'shifts', 'roles',
-                                          'notes', 'onlineForms']):
+    def get_event(self, event_id, expand_fields=['locations', 'codes', 'shifts', 'roles',
+                                          'notes', 'financialProgram', 'ticketCategories',
+                                          'voterRegistrationBatches']):
         """
         Get an event.
 
         `Args:`
             event_id: int
                 The event id.
-            expand: list
-                A list of nested jsons to include in returned event
-                object. Can be ``locations``, ``codes``, ``shifts``,
-                ``roles``, ``notes``, ``onlineForms``.
+            expand_fields: list
+                A list of fields for which to include data. If a field is omitted,
+                ``None`` will be returned for that field. Can be ``locations``,
+                ``codes``, ``shifts``, ``roles``, ``notes``, ``financialProgram``,
+                ``ticketCategories``, ``voterRegistrationBatches`.`
         `Returns:`
             Parsons Table
                 See :ref:`parsons-table` for output options.
         """
 
-        if expand:
-            expand = ','.join(expand)
+        if expand_fields:
+            expand_fields = ','.join(expand_fields)
 
-        r = self.connection.get_request(f'events/{event_id}', params={'$expand': expand})
+        r = self.connection.get_request(f'events/{event_id}', params={'$expand': expand_fields})
         logger.info(f'Found event {event_id}.')
         return r
 

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -165,10 +165,13 @@ class People(object):
 
         return True
 
-    def get_person(self, id, id_type='vanid',
-                   fields=['emails', 'phones', 'custom_fields', 'external_ids', 'addresses',
-                           'recorded_addresses', 'preferences', 'suppressions',
-                           'reported_demographics', 'disclosure_field_values']):
+    def get_person(self, id, id_type='vanid', expand_fields=[
+                   'contribution_history', 'addresses', 'phones', 'emails',
+                   'codes', 'custom_fields', 'external_ids', 'preferences',
+                   'recorded_addresses', 'reported_demographics', 'suppressions',
+                   'cases', 'custom_properties', 'districts', 'election_records',
+                   'membership_statuses', 'notes', 'organization_roles', 'scores',
+                   'disclosure_field_values']):
         """
         Returns a single person record using their VANID or external id.
 
@@ -178,7 +181,14 @@ class People(object):
             id_type: str
                 A known person identifier type available on this VAN instance
                 such as ``dwid``
-            fields: The fields to return. Leave as default for all available fields
+            expand_fields: list
+                A list of fields for which to include data. If a field is omitted,
+                ``None`` will be returned for that field. Can be ``contribution_history``,
+                ``addresses``, ``phones``, ``emails``, ``codes``, ``custom_fields``,
+                ``external_ids``, ``preferences``, ``recorded_addresses``,
+                ``reported_demographics``, ``suppressions``, ``cases``, ``custom_properties``,
+                ``districts``, ``election_records``, ``membership_statuses``, ``notes``,
+                ``organization_roles``, ``scores``, ``disclosure_field_values``.
         `Returns:`
             A person dict
         """
@@ -189,10 +199,10 @@ class People(object):
         else:
             url = f'people/{id_type}:{id}'
 
-        fields = ','.join([json_format.arg_format(f) for f in fields])
+        expand_fields = ','.join([json_format.arg_format(f) for f in expand_fields])
 
         logger.info(f'Getting person with {id_type} of {id}')
-        return self.connection.get_request(url, params={'$expand': fields})
+        return self.connection.get_request(url, params={'$expand': expand_fields})
 
     def apply_canvass_result(self, id, result_code_id, id_type='vanid', contact_type_id=None,
                              input_type_id=None, date_canvassed=None):


### PR DESCRIPTION
- The `expand` list in `get_event` included a field that isn't supported for that endpoint. Updated the list to include only supported fields.
- Standardize the `expand`/`fields` params and description across methods. Now `expand_fields`.
- Update the `expand_fields` for `get_events` and `get_person` to include missing fields.