### PR TITLE
Return additional data with get_columns

### DIFF
--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -361,16 +361,17 @@ class RedshiftTableUtilities(object):
         `Returns:`
             A dict mapping column name to a dict with extra info. The keys of the dict are ordered
             just like the columns in the table. The extra info is a dict with format
-            ``{'data_type': str, 'max_length': int or None, 'is_nullable': bool}``
+            ``{'data_type': str, 'max_length': int or None, 'max_precision': int or None,
+               'max_scale': int or None, 'is_nullable': bool}``
         """
 
         query = f"""
             select ordinal_position,
                    column_name,
                    data_type,
-                   case when character_maximum_length is not null
-                        then character_maximum_length
-                        else numeric_precision end as max_length,
+                   character_maximum_length as max_length,
+                   numeric_precision as max_precision,
+                   numeric_scale as max_scale,
                    is_nullable
             from information_schema.columns
             where table_name = '{table_name}'
@@ -382,6 +383,8 @@ class RedshiftTableUtilities(object):
             row['column_name']: {
                 'data_type': row['data_type'],
                 'max_length': row['max_length'],
+                'max_precision': row['max_precision'],
+                'max_scale': row['max_scale'],
                 'is_nullable': row['is_nullable'] == 'YES',
             }
             for row in self.query(query)

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -549,8 +549,12 @@ class TestRedshiftDB(unittest.TestCase):
 
         # id smallint,name varchar(5)
         expected_cols = {
-            'id':   {'data_type': 'smallint', 'max_length': 16, 'is_nullable': True},
-            'name': {'data_type': 'character varying', 'max_length': 5, 'is_nullable': True},
+            'id':   {
+                'data_type': 'smallint', 'max_length': 16,
+                'max_precision': None, 'max_scale': None, 'is_nullable': True},
+            'name': {
+                'data_type': 'character varying', 'max_length': 5,
+                'max_precision': None, 'max_scale': None, 'is_nullable': True},
         }
 
         self.assertEqual(cols, expected_cols)


### PR DESCRIPTION
[Decimal types in Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_Numeric_types201.html#r_Numeric_types201-decimal-or-numeric-type) are defined as `decimal(precision, scale)`. With this change, both the precision and the scale are returned.