### PR TITLE
VAN: Fix Bugs

### DIFF
--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -67,6 +67,14 @@ class People(object):
         Create or update a person record.
 
         .. note::
+            Person find must include the following minimum combinations.
+            - first_name, last_name, email
+            - first_name, last_name, phone
+            - first_name, last_name, zip5, date_of_birth
+            - first_name, last_name, street_number, street_name, zip5
+            - email_address
+
+        .. note::
             The arguments that can be passed are a selection of the possible values that
             can be used in a search. A full list of possible values can be found
             `here <https://developers.ngpvan.com/van-api#match-candidates>`_. To use these
@@ -100,18 +108,16 @@ class People(object):
         """
 
         return self._people_search(first_name, last_name, date_of_birth, email, phone,
-                                   street_number, street_name, zip, match_map, create=True,
-                                   validate=False)
+                                   street_number, street_name, zip, match_map, create=True)
 
     def _people_search(self, first_name=None, last_name=None, date_of_birth=None, email=None,
                        phone=None, street_number=None, street_name=None, zip=None, match_map=None,
-                       create=False, validate=True):
+                       create=False):
         # Internal method to hit the people find/create endpoints
 
         # Ensure that the minimum combination of fields were passed
-        if validate:
-            self._valid_search(first_name, last_name, email, phone, date_of_birth, street_number,
-                               street_name, zip, match_map)
+        self._valid_search(first_name, last_name, email, phone, date_of_birth, street_number,
+                           street_name, zip, match_map)
 
         # Check to see if a match map has been provided
         if not match_map:

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -67,15 +67,6 @@ class People(object):
         Create or update a person record.
 
         .. note::
-            Person find must include the following minimum combinations.
-
-            - first_name, last_name, email
-            - first_name, last_name, phone
-            - first_name, last_name, zip5, date_of_birth
-            - first_name, last_name, street_number, street_name, zip5
-            - email_address
-
-        .. note::
             The arguments that can be passed are a selection of the possible values that
             can be used in a search. A full list of possible values can be found
             `here <https://developers.ngpvan.com/van-api#match-candidates>`_. To use these
@@ -109,16 +100,18 @@ class People(object):
         """
 
         return self._people_search(first_name, last_name, date_of_birth, email, phone,
-                                   street_number, street_name, zip, match_map, create=True)
+                                   street_number, street_name, zip, match_map, create=True,
+                                   validate=False)
 
     def _people_search(self, first_name=None, last_name=None, date_of_birth=None, email=None,
                        phone=None, street_number=None, street_name=None, zip=None, match_map=None,
-                       create=False):
+                       create=False, validate=True):
         # Internal method to hit the people find/create endpoints
 
         # Ensure that the minimum combination of fields were passed
-        self._valid_search(first_name, last_name, email, phone, date_of_birth, street_number,
-                           street_name, zip, match_map)
+        if validate:
+            self._valid_search(first_name, last_name, email, phone, date_of_birth, street_number,
+                               street_name, zip, match_map)
 
         # Check to see if a match map has been provided
         if not match_map:
@@ -170,7 +163,7 @@ class People(object):
                    'codes', 'custom_fields', 'external_ids', 'preferences',
                    'recorded_addresses', 'reported_demographics', 'suppressions',
                    'cases', 'custom_properties', 'districts', 'election_records',
-                   'membership_statuses', 'notes', 'organization_roles', 'scores',
+                   'membership_statuses', 'notes', 'organization_roles',
                    'disclosure_field_values']):
         """
         Returns a single person record using their VANID or external id.

--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -86,7 +86,7 @@ class APIConnector(object):
 
         return r.json()
 
-    def post_request(self, url, params=None, data=None, json=None, success_codes=[204, 201]):
+    def post_request(self, url, params=None, data=None, json=None, success_codes=[200, 204, 201]):
         """
         Make a POST request.
 

--- a/test/test_van/test_people.py
+++ b/test/test_van/test_people.py
@@ -23,7 +23,7 @@ class TestNGPVAN(unittest.TestCase):
 
         self.assertEqual(person, find_people_response)
 
-    def test_upsert_person(self, m):
+    def test_upsert_person(self):
 
         pass
 

--- a/test/test_van/test_people.py
+++ b/test/test_van/test_people.py
@@ -23,13 +23,9 @@ class TestNGPVAN(unittest.TestCase):
 
         self.assertEqual(person, find_people_response)
 
-    @requests_mock.Mocker()
     def test_upsert_person(self, m):
 
-        m.post(self.van.connection.uri + 'people/findOrCreate', json=find_people_response, status_code=201)
-
-        # Assert that validation isn't required for upsert.
-        self.van.upsert_person(first_name='Bob', last_name='Smith')
+        pass
 
     def test_people_search(self):
 

--- a/test/test_van/test_people.py
+++ b/test/test_van/test_people.py
@@ -17,17 +17,19 @@ class TestNGPVAN(unittest.TestCase):
     @requests_mock.Mocker()
     def test_find_person(self, m):
 
-        json = find_people_response
-
-        m.post(self.van.connection.uri + 'people/find', json=json, status_code=201)
+        m.post(self.van.connection.uri + 'people/find', json=find_people_response, status_code=200)
 
         person = self.van.find_person(first_name='Bob', last_name='Smith', phone=4142020792)
 
-        self.assertEqual(person, json)
+        self.assertEqual(person, find_people_response)
 
-    def test_upsert_person(self):
+    @requests_mock.Mocker()
+    def test_upsert_person(self, m):
 
-        pass
+        m.post(self.van.connection.uri + 'people/findOrCreate', json=find_people_response, status_code=201)
+
+        # Assert that validation isn't required for upsert.
+        self.van.upsert_person(first_name='Bob', last_name='Smith')
 
     def test_people_search(self):
 


### PR DESCRIPTION
- ~~Remove validation requirement of `van_upsert_person()` per issue #10.~~ - Saving for a future PR. 

- Fix bug so that `van.find_person()` works properly. 

- Remove `scores` from default `van.get_person()` returned value. This is not a standard field which is permissioned to all users, so it was throwing an error with the default setting. (@dannyboy15 for viz)