### PR TITLE
Pass view in Airtable get_records()

### DIFF
--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -84,7 +84,7 @@ class Airtable(object):
         """
 
         # Raises an error if sort is None type. Thus, only adding if populated.
-        kwargs = {'fields': fields, 'max_records': max_records, 'formula': formula}
+        kwargs = {'fields': fields, 'max_records': max_records, 'view': view, 'formula': formula}
         if sort:
             kwargs['sort'] = sort
 


### PR DESCRIPTION
I think it was just a simple omission while creating the `kwargs` dict!