### PR TITLE
Table: Display Pretty Jupyter Notebook Tables

### DIFF
--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -78,6 +78,13 @@ class Table(ETL, ToFrom):
 
         return petl.dicts(self.table)[index]
 
+    def _repr_html_(self):
+        """
+        Leverage Petl functionality to display well formatted tables in Jupyter Notebook.
+        """
+
+        return self.table._repr_html_()
+
     @property
     def num_rows(self):
         """


### PR DESCRIPTION
Similar to pandas dataframes, Parson's tables can automatically be displayed as pretty tables in Jupyter Notebook.

![image](https://user-images.githubusercontent.com/5530043/69890824-9ec43880-12bd-11ea-82fa-ed01e9e8acd4.png)
