### PR TITLE
Redshift.upsert() Fix

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -630,11 +630,12 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
 
         with self.connection() as connection:
 
-            # Copy to a staging table
-            logger.info(f'Building staging table: {staging_tbl}')
-            self.copy(table_obj, staging_tbl)
-
             try:
+
+                # Copy to a staging table
+                logger.info(f'Building staging table: {staging_tbl}')
+                self.copy(table_obj, staging_tbl)
+
                 # Delete rows
                 staging_primary_key = f"{staging_tbl.split('.')[1]}.{primary_key}"
                 target_primary_key = f"{target_table.split('.')[1]}.{primary_key}"


### PR DESCRIPTION
If the initial copy of the data takes place, it should drop the temporary table if it fails. This PR moves the copy statement into the try/finally block with the rest of the code.