### PR TITLE
google cloud storage: don't get bucket before dling blob

### DIFF
--- a/parsons/google/google_cloud_storage.py
+++ b/parsons/google/google_cloud_storage.py
@@ -232,11 +232,13 @@ class GoogleCloudStorage(object):
         if not local_path:
             local_path = files.create_temp_file_for_path('TEMPTHING')
 
-        blob = self.get_blob(bucket_name, blob_name)
+        blob_name = blob_name.lstrip('/')
+
+        blob_uri = f'gs://{bucket_name}/{blob_name}'
 
         logger.info(f'Downloading {blob_name} from {bucket_name} bucket.')
         with open(local_path, 'wb') as f:
-            blob.download_to_file(f)
+            self.client.download_blob_to_file(blob_uri, f)
         logger.info(f'{blob_name} saved to {local_path}.')
 
         return local_path


### PR DESCRIPTION
This commit updates the `GoogleCloudStorage` connector to not call
`get_bucket` when downloading a blob to a local file. It is
possible in Cloud Storage to have access to a blob in a bucket
without actually having access to get the bucket metadata (which
is what `get_bucket` does). The underlying Cloud Storage Python
client has a `download_blob_to_file` method which does not require
that we call `get_bucket`, so this commit switches the Parsons
`GoogleCloudStorage`'s `download_blob` method to use that.

---
Tested locally using a test GCS bucket and blob.

Fixes #115 . Just FYI, `get_bucket` will need the proper permission. This PR doesn't change that. It just makes it so `download_blob` doesn't call `get_bucket`.

cc @jburchard 