### PR TITLE
googlecloudstorage: another attempt at downloading blobs

### DIFF
--- a/parsons/google/google_cloud_storage.py
+++ b/parsons/google/google_cloud_storage.py
@@ -232,13 +232,12 @@ class GoogleCloudStorage(object):
         if not local_path:
             local_path = files.create_temp_file_for_path('TEMPTHING')
 
-        blob_name = blob_name.lstrip('/')
-
-        blob_uri = f'gs://{bucket_name}/{blob_name}'
+        bucket = storage.Bucket(self.client, name=bucket_name)
+        blob = storage.Blob(blob_name, bucket)
 
         logger.info(f'Downloading {blob_name} from {bucket_name} bucket.')
         with open(local_path, 'wb') as f:
-            self.client.download_blob_to_file(blob_uri, f)
+            blob.download_to_file(f, client=self.client)
         logger.info(f'{blob_name} saved to {local_path}.')
 
         return local_path


### PR DESCRIPTION
This commit updates the `download_blob` method on the parsons
`GoogleCloudStorage` connector to take a different approach to
downloading blobs. Like the code being replaced, this commit
avoids having to fetch metadata about the bucket the blob is in
(and thus avoids unnecessary permission checks). Unlike the code
being replaced, this method seems more robust. The
`download_blob_to_file` function used by the old code seems to
not handle empty files well.

---
This seems to allow me to download files that you were having problems with, while still not requiring any access to the underlying bucket.