### PR TITLE
Table.column_data()

### DIFF
--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -134,7 +134,7 @@ class Table(ETL, ToFrom):
             return list(self.table[column_name])
 
         except petl.errors.FieldSelectionError:
-            raise ValueError('Column name not found.') 
+            raise ValueError('Column name not found.')
 
     def materialize(self):
         """

--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -125,6 +125,17 @@ class Table(ETL, ToFrom):
         except IndexError:
             return None
 
+    def column_data(self, column_name):
+        """
+        Returns the data in the column as a list.
+        """
+
+        try:
+            return list(self.table[column_name])
+
+        except petl.errors.FieldSelectionError:
+            raise ValueError('Column name not found.') 
+
     def materialize(self):
         """
         "Materializes" a Table, meaning all data is loaded into memory and all pending

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -532,6 +532,13 @@ class TestParsonsTable(unittest.TestCase):
         empty_tbl = Table([[1], [], [3]])
         self.assertIsNone(empty_tbl.first)
 
+    def test_column_data(self):
+        # Test that that the data in the column is returned as a list
+
+        tbl = Table(self.lst)
+        lst = [1, 4, 7, 10, 13]
+        self.assertEqual(tbl.column_data('a'), lst)
+
     def test_stack(self):
         tbl1 = self.tbl
         tbl2 = Table([{'first': 'Mary', 'last': 'Nichols'}])


### PR DESCRIPTION
This method returns the rows in a column as a list.

```
tbl = Table([['a', 'b'],['1', 2], ['2', 1]])
lst = tbl.column_data('a')
print (lst)
>>> ['1', '2']
```

Potentially, the most elegant solution would be to be able to use the Pandas pattern for column selection, such as (`tbl['a']`). I'm interested in feedback on this one.