### PR TITLE
VAN.delete_supporter_group(), etc.

### DIFF
--- a/docs/ngpvan.rst
+++ b/docs/ngpvan.rst
@@ -12,8 +12,8 @@ additional details and information.
 
 .. note::
    API Keys
-      - API Keys are specific to each committee and state, so you might need many.
-      - Not all API Keys are provisioned for all endpoints. When requesting API keys, you should specify the endpoints that you need access to.
+      API Keys are specific to each committee and state, so you might need many. Not all API Keys are provisioned for all endpoints. When requesting API keys, you should specify the endpoints that you need access to. To learn more about
+      your api key run ``VAN.connection.api_key_profile``.
 
 .. warning::
    VANIDs

--- a/parsons/ngpvan/supporter_groups.py
+++ b/parsons/ngpvan/supporter_groups.py
@@ -41,7 +41,7 @@ class SupporterGroups(object):
 
     def create_supporter_group(self, name, description):
         """
-        Create a new supporter group
+        Create a new supporter group.
 
         `Args:`
             name: str
@@ -55,6 +55,21 @@ class SupporterGroups(object):
 
         json = {'name': name, 'description': description}
         r = self.connection.post_request('supporterGroups', json=json)
+        return r
+
+    def delete_supporter_group(self, supporter_group_id):
+        """
+        Delete a supporter group.
+
+        `Args:`
+            supporter_group_id: int
+                The supporter group id
+        `Returns:`
+            ``None``
+        """
+
+        r = self.connection.delete_request(f'supporterGroups/{supporter_group_id}')
+        logger.info(f'Deleted supporter group {supporter_group_id}.')
         return r
 
     def add_person_supporter_group(self, supporter_group_id, vanid):

--- a/parsons/ngpvan/van_connector.py
+++ b/parsons/ngpvan/van_connector.py
@@ -35,6 +35,15 @@ class VANConnector(object):
         self._soap_client = None
 
     @property
+    def api_key_profile(self):
+        """
+        Returns the API key profile with includes permissions and other 
+        meta data
+        """
+
+        return self.get_request('apiKeyProfiles')[0]
+
+    @property
     def soap_client(self):
 
         if not self._soap_client:

--- a/parsons/ngpvan/van_connector.py
+++ b/parsons/ngpvan/van_connector.py
@@ -37,8 +37,7 @@ class VANConnector(object):
     @property
     def api_key_profile(self):
         """
-        Returns the API key profile with includes permissions and other 
-        meta data
+        Returns the API key profile with includes permissions and other metadata.
         """
 
         return self.get_request('apiKeyProfiles')[0]

--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -81,8 +81,8 @@ class APIConnector(object):
         """
 
         r = self.request(url, 'GET', params=params)
-
         self.validate_response(r)
+        logger.debug(r.json())
 
         return r.json()
 

--- a/test/test_van/test_ngpvan.py
+++ b/test/test_van/test_ngpvan.py
@@ -115,6 +115,22 @@ class TestNGPVAN(unittest.TestCase):
         self.assertEqual(self.van.get_supporter_group(12), json)
 
     @requests_mock.Mocker()
+    def test_delete_supporter_group(self, m):
+
+        # Test good input
+        good_supporter_group_id = 5
+        good_ep = f'supporterGroups/{good_supporter_group_id}'
+        m.delete(self.van.connection.uri + good_ep, status_code=204)
+        self.van.delete_supporter_group(good_supporter_group_id)
+
+        # Test bad input raises
+        bad_supporter_group_id = 999
+        bad_vanid = 99999
+        bad_ep = f'supporterGroups/{bad_supporter_group_id}'
+        m.delete(self.van.connection.uri + bad_ep, status_code=404)
+        self.assertRaises(HTTPError, self.van.delete_supporter_group, bad_supporter_group_id)
+
+    @requests_mock.Mocker()
     def test_add_person_supporter_group(self, m):
 
         # Test good input


### PR DESCRIPTION
- `VAN.delete_supporter_group()` deletes a supporter group.
- `VAN.connection.api_key_profiles()` returns meta data associated with the api key.