### PR TITLE
Easy Table Indexing

### DIFF
--- a/docs/table.rst
+++ b/docs/table.rst
@@ -117,6 +117,26 @@ Parsons Table Attributes
     * - ``.first``
       - The first value in the table. Use for database queries where a single value is returned.
 
+======================
+Parsons Table Indexing
+======================
+
+To access rows and columns of data within a Parsons table, you can index on them. To access a column
+pass in the column name as a string (e.g. ``tbl['a']``) and to access a row, pass in the row index as
+an integer (e.g. ``tbl[1]``). 
+
+.. code-block:: python
+
+    tbl = Table([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}])
+
+    # Return a column as a list
+    tbl['a']
+    >> [1, 3] 
+
+    # Return a row as a dict
+    tbl[1]
+    >> {'a': 3, 'b': 4}
+
 A note on indexing and iterating over a table's data:
 If you need to iterate over the data, make sure to use the python iterator syntax, so any data transformations can be applied efficiently. An example:
 
@@ -195,16 +215,19 @@ Basic Pipelines
     van.events().to_s3_csv('my-van-bucket','myevents.csv')
 
 
-*****************
-To & From Methods
-*****************
+*************
+To & From API
+*************
 .. autoclass:: parsons.etl.tofrom.ToFrom
    :inherited-members:
 
-***
-ETL
-***
+*******
+ETL API
+*******
 The following methods allow you to manipulate the Parsons table data.
+
+.. autoclass:: parsons.etl.etl.ETL
+   :inherited-members:
 
 .. autoclass:: parsons.etl.etl.ETL
    :inherited-members:

--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -66,17 +66,17 @@ class Table(ETL, ToFrom):
 
     def __getitem__(self, index):
 
-        self._index_count += 1
-        if self._index_count >= DIRECT_INDEX_WARNING_COUNT:
-            logger.warning("""
-                You have indexed directly into this Table multiple times. This can be inefficient,
-                as data transformations you've made will be computed _each time_ you index into the
-                Table. If you are accessing many rows of data, consider switching to this style of
-                iteration, which is much more efficient:
-                `for row in table:`
-                """)
+        if isinstance(index, int):
 
-        return petl.dicts(self.table)[index]
+            return self.row_data(index)
+
+        elif isinstance(index, str):
+
+            return self.column_data(index)
+
+        else:
+
+            raise TypeError('You must pass a string or an index as a value.')
 
     def _repr_html_(self):
         """
@@ -125,15 +125,46 @@ class Table(ETL, ToFrom):
         except IndexError:
             return None
 
+    def row_data(self, row_index):
+        """
+        Returns a row in table
+
+        `Args:`
+            row_index: int
+        `Returns:`
+            dict
+                A dictionary of the row with the column as the key and the cell
+                as the value.
+        """
+
+        self._index_count += 1
+        if self._index_count >= DIRECT_INDEX_WARNING_COUNT:
+            logger.warning("""
+                You have indexed directly into this Table multiple times. This can be inefficient,
+                as data transformations you've made will be computed _each time_ you index into the
+                Table. If you are accessing many rows of data, consider switching to this style of
+                iteration, which is much more efficient:
+                `for row in table:`
+                """)
+
+        return petl.dicts(self.table)[row_index]
+
     def column_data(self, column_name):
         """
         Returns the data in the column as a list.
+
+        `Args:`
+            column_name: str
+                The name of the column
+        `Returns`:
+            list
+                A list of data in the column.
         """
 
-        try:
+        if column_name in self.columns:
             return list(self.table[column_name])
 
-        except petl.errors.FieldSelectionError:
+        else:
             raise ValueError('Column name not found.')
 
     def materialize(self):

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -532,12 +532,35 @@ class TestParsonsTable(unittest.TestCase):
         empty_tbl = Table([[1], [], [3]])
         self.assertIsNone(empty_tbl.first)
 
+    def test_get_item(self):
+        # Test indexing on table
+        
+        # Test a valid column
+        tbl = Table(self.lst)
+        lst = [1, 4, 7, 10, 13]
+        self.assertEqual(tbl['a'], lst)
+
+        # Test a valid row
+        row = {'a': 4, 'b': 5, 'c': 6}
+        self.assertEqual(tbl[1], row)
+
     def test_column_data(self):
         # Test that that the data in the column is returned as a list
 
+        # Test a valid column
         tbl = Table(self.lst)
         lst = [1, 4, 7, 10, 13]
         self.assertEqual(tbl.column_data('a'), lst)
+
+        # Test an invalid column
+        self.assertRaises(TypeError, tbl['c'])
+
+    def test_row_data(self):
+
+        # Test a valid column
+        tbl = Table(self.lst)
+        row = {'a': 4, 'b': 5, 'c': 6}
+        self.assertEqual(tbl.row_data(1), row)
 
     def test_stack(self):
         tbl1 = self.tbl


### PR DESCRIPTION
This allows the user to more easily index rows and columns in a Parsons table. Basically, if you put in a string that is a column name, it will grab the column. If you put in an int, then it will look for the row.

h/t @eliotst for the great idea.

```
tbl = Table([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}])

# Return a column as a list
tbl['a']
>> [1, 3]

# Return a row as a dict
tbl[1]
>> {'a': 3, 'b': 4}
```