### PR TITLE
honor delimiter on redshift copy_s3

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -310,7 +310,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 local_path = s3.get_file(bucket, key)
 
                 if data_type == 'csv':
-                    tbl = Table.from_csv(local_path)
+                    tbl = Table.from_csv(local_path, delimiter=csv_delimiter)
                 else:
                     raise TypeError("Invalid data type provided")
 


### PR DESCRIPTION
This commit passes through the delimiter to the `from_csv` method
used to load a CSV file when copying from S3 to Redshift. The call
in question is part of Parsons' effort to reflect on the data
being copied to build a `create table` statement in the case where
the target Redshift table does not exist.