### PR TITLE
Add ability to authenticate using a private rsa key over sftp

### DIFF
--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -321,10 +321,7 @@ class ToFrom(object):
         """  # noqa: W605
 
         from parsons import SFTP
-        print(port)
-        print('that was port')
-        print(rsa_private_key_file)
-        print('rsa_private_key_file')
+
         sftp = SFTP(host, username, password, port, rsa_private_key_file)
 
         compression = files.compression_type_for_path(remote_path)

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -291,7 +291,7 @@ class ToFrom(object):
         return list(petl.dicts(self.table))
 
     def to_sftp_csv(self, remote_path, host, username, password, port=22, encoding=None,
-        compression=None, errors='strict', write_header=True, rsa_private_key_file=None, **csvargs):
+                    compression=None, errors='strict', write_header=True, rsa_private_key_file=None, **csvargs):
         """
         Writes the table to a CSV file on a remote SFTP server
 

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -290,8 +290,8 @@ class ToFrom(object):
 
         return list(petl.dicts(self.table))
 
-    def to_sftp_csv(self, remote_path, host, username, password, rsa_private_key_file=None, port=22, encoding=None,
-                    compression=None, errors='strict', write_header=True, **csvargs):
+    def to_sftp_csv(self, remote_path, host, username, password, rsa_private_key_file=None, port=22,
+                    encoding=None, compression=None, errors='strict', write_header=True, **csvargs):
         """
         Writes the table to a CSV file on a remote SFTP server
 

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -290,7 +290,7 @@ class ToFrom(object):
 
         return list(petl.dicts(self.table))
 
-    def to_sftp_csv(self, remote_path, host, username, password, port=22, encoding=None,
+    def to_sftp_csv(self, remote_path, host, username, password, rsa_private_key_file=None, port=22, encoding=None,
                     compression=None, errors='strict', write_header=True, **csvargs):
         """
         Writes the table to a CSV file on a remote SFTP server
@@ -318,7 +318,8 @@ class ToFrom(object):
         """  # noqa: W605
 
         from parsons import SFTP
-        sftp = SFTP(host, username, password, port)
+
+        sftp = SFTP(host, username, password, rsa_private_key_file, port)
 
         compression = files.compression_type_for_path(remote_path)
 

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -290,8 +290,8 @@ class ToFrom(object):
 
         return list(petl.dicts(self.table))
 
-    def to_sftp_csv(self, remote_path, host, username, password, rsa_private_key_file=None, port=22,
-                    encoding=None, compression=None, errors='strict', write_header=True, **csvargs):
+    def to_sftp_csv(self, remote_path, host, username, password, port=22,
+                    encoding=None, compression=None, errors='strict', write_header=True, rsa_private_key_file=None, **csvargs):
         """
         Writes the table to a CSV file on a remote SFTP server
 
@@ -313,13 +313,19 @@ class ToFrom(object):
                 Raise an Error if encountered
             write_header: boolean
                 Include header in output
+            rsa_private_key_file str
+                Absolute path to a private RSA key used
+                to authenticate stfp connection
             \**csvargs: kwargs
                 ``csv_writer`` optional arguments
         """  # noqa: W605
 
         from parsons import SFTP
-
-        sftp = SFTP(host, username, password, rsa_private_key_file, port)
+        print(port)
+        print('that was port')
+        print(rsa_private_key_file)
+        print('rsa_private_key_file')
+        sftp = SFTP(host, username, password, port, rsa_private_key_file)
 
         compression = files.compression_type_for_path(remote_path)
 

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -291,7 +291,8 @@ class ToFrom(object):
         return list(petl.dicts(self.table))
 
     def to_sftp_csv(self, remote_path, host, username, password, port=22, encoding=None,
-                    compression=None, errors='strict', write_header=True, rsa_private_key_file=None, **csvargs):
+                    compression=None, errors='strict', write_header=True,
+                    rsa_private_key_file=None, **csvargs):
         """
         Writes the table to a CSV file on a remote SFTP server
 

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -290,8 +290,8 @@ class ToFrom(object):
 
         return list(petl.dicts(self.table))
 
-    def to_sftp_csv(self, remote_path, host, username, password, port=22,
-                    encoding=None, compression=None, errors='strict', write_header=True, rsa_private_key_file=None, **csvargs):
+    def to_sftp_csv(self, remote_path, host, username, password, port=22, encoding=None,
+        compression=None, errors='strict', write_header=True, rsa_private_key_file=None, **csvargs):
         """
         Writes the table to a CSV file on a remote SFTP server
 

--- a/parsons/sftp/sftp.py
+++ b/parsons/sftp/sftp.py
@@ -23,7 +23,7 @@ class SFTP(object):
         SFTP Class
     """
 
-    def __init__(self, host, username, password, rsa_private_key_file=None, port=22):
+    def __init__(self, host, username, password, port=22, rsa_private_key_file=None):
         self.host = host
         if not self.host:
             raise ValueError("Missing the SFTP host name")
@@ -32,7 +32,7 @@ class SFTP(object):
         if not self.username:
             raise ValueError("Missing the SFTP username")
 
-        if self.username and not (password or rsa_private_key_file):
+        if not (password or rsa_private_key_file):
             raise ValueError("Missing password or ssh authentication key")
 
         self.password = password
@@ -43,7 +43,6 @@ class SFTP(object):
     def _create_connection(self):
         # Internal method to create a connection and close when it's out of scope.
         # Make sure to use this in a ``with`` block, since it's a context manager.
-
         transport = paramiko.Transport((self.host, self.port))
         pkey = None
         if self.rsa_private_key_file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ google-auth-oauthlib==0.4.0
 google-resumable-media!=0.4.0,<0.5.0dev,>=0.3.1
 httplib2==0.12.0
 validate-email==1.3
-paramiko==2.4.2
+paramiko==2.7.1
 xmltodict==0.11.0
 joblib==0.13
 censusgeocode==0.4.3.post1

--- a/test/test_sftp_ssh.py
+++ b/test/test_sftp_ssh.py
@@ -18,10 +18,10 @@ REMOTE_COMPRESSED_CSV_PATH = f'{REMOTE_DIR}/{REMOTE_COMPRESSED_CSV}'
 @pytest.fixture
 def live_sftp(simple_table, simple_csv_path, simple_compressed_csv_path):
     # Generate a live SFTP connection based on these env vars
-    host = os.environ.get('SFTP_HOST', 's-cad475b922de49a19.server.transfer.us-east-1.amazonaws.com')
-    username = os.environ.get('SFTP_USERNAME', 'dev-test-uptime-testuser')
+    host = os.environ.get('SFTP_HOST')
+    username = os.environ.get('SFTP_USERNAME')
     password = None
-    rsa_private_key_file = os.environ.get('SFTP_RSA_PRIVATE_KEY_FILE', '/Users/angela/.ssh/id_rsa')
+    rsa_private_key_file = os.environ.get('SFTP_RSA_PRIVATE_KEY_FILE')
 
     sftp = SFTP(host, username, password, rsa_private_key_file)
 
@@ -92,7 +92,7 @@ def test_table_to_sftp_csv(live_sftp, simple_table, compression):
     host = os.environ['SFTP_HOST']
     username = os.environ['SFTP_USERNAME']
     password = os.environ['SFTP_PASSWORD']
-    rsa_private_key_file = os.environ.get('SFTP_RSA_PRIVATE_KEY_FILE', '/Users/angela/.ssh/id_rsa')
+    rsa_private_key_file = os.environ.get('SFTP_RSA_PRIVATE_KEY_FILE')
 
     remote_path = f'{REMOTE_DIR}/test_to_sftp.csv'
     if compression == 'gzip':
@@ -109,9 +109,9 @@ def test_table_to_sftp_csv(live_sftp, simple_table, compression):
 #@mark_live_test
 @pytest.mark.parametrize('compression', [None, 'gzip'])
 def test_table_to_sftp_csv_no_password(live_sftp, simple_table, compression):
-    host = os.environ.get('SFTP_HOST', 's-cad475b922de49a19.server.transfer.us-east-1.amazonaws.com')
-    username = os.environ.get('SFTP_USERNAME', 'dev-test-uptime-testuser')
-    rsa_private_key_file = os.environ.get('SFTP_RSA_PRIVATE_KEY_FILE', '/Users/angela/.ssh/id_rsa')
+    host = os.environ.get('SFTP_HOST')
+    username = os.environ.get('SFTP_USERNAME')
+    rsa_private_key_file = os.environ.get('SFTP_RSA_PRIVATE_KEY_FILE')
 
     remote_path = f'{REMOTE_DIR}/test_to_sftp.csv'
     if compression == 'gzip':

--- a/test/test_sftp_ssh.py
+++ b/test/test_sftp_ssh.py
@@ -1,0 +1,131 @@
+import pytest
+import os
+from parsons import SFTP, Table
+from parsons.utilities import files
+from test.utils import mark_live_test, assert_matching_tables
+from test.fixtures import simple_table, simple_csv_path, simple_compressed_csv_path
+
+#
+# Fixtures and constants
+#
+
+REMOTE_DIR = 'parsons-test'
+REMOTE_CSV = 'test.csv'
+REMOTE_CSV_PATH = f'{REMOTE_DIR}/{REMOTE_CSV}'
+REMOTE_COMPRESSED_CSV = 'test.csv.gz'
+REMOTE_COMPRESSED_CSV_PATH = f'{REMOTE_DIR}/{REMOTE_COMPRESSED_CSV}'
+
+@pytest.fixture
+def live_sftp(simple_table, simple_csv_path, simple_compressed_csv_path):
+    # Generate a live SFTP connection based on these env vars
+    host = os.environ['SFTP_HOST'] or 's-cad475b922de49a19.server.transfer.us-east-1.amazonaws.com'
+    username = os.environ['SFTP_USERNAME'] or 'dev-test-uptime-testuser'
+    password = None
+    rsa_private_key_file = os.environ['SFTP_RSA_PRIVATE_KEY_FILE'] or '/Users/angela/.ssh/id_rsa'
+
+    sftp = SFTP(host, username, password, rsa_private_key_file)
+
+    # Add a test directory and test files
+    sftp.make_directory(REMOTE_DIR)
+    sftp.put_file(simple_csv_path, REMOTE_CSV_PATH)
+    sftp.put_file(simple_compressed_csv_path, REMOTE_COMPRESSED_CSV_PATH)
+
+    yield sftp
+
+    # Cleanup after test
+    sftp.remove_file(REMOTE_CSV_PATH)
+    sftp.remove_file(REMOTE_COMPRESSED_CSV_PATH)
+    sftp.remove_directory(REMOTE_DIR)
+
+#
+# Tests
+#
+
+def test_credential_validation():
+    with pytest.raises(ValueError):
+        SFTP(host=None, username=None, password=None, rsa_private_key_file=None)
+
+    with pytest.raises(ValueError):
+        SFTP(host=None, username='sam', password='abc123', rsa_private_key_file='/path/to/key/file')
+
+    with pytest.raises(ValueError):
+        SFTP(host='host', username=None, password='abc123', rsa_private_key_file='/path/to/key/file')
+
+    with pytest.raises(ValueError):
+        SFTP(host='host', username='sam', password=None, rsa_private_key_file=None)
+
+@mark_live_test
+def test_list_non_existent_directory(live_sftp):
+    with pytest.raises(FileNotFoundError):
+        file_list = live_sftp.list_directory('abc123')
+
+@mark_live_test
+def test_list_directory_with_files(live_sftp):
+    file_list = live_sftp.list_directory(REMOTE_DIR)
+    assert file_list == [REMOTE_COMPRESSED_CSV, REMOTE_CSV]
+
+@mark_live_test
+def test_get_non_existent_file(live_sftp):
+    with pytest.raises(FileNotFoundError):
+        live_sftp.get_file('abc123')
+
+# Helper function
+def assert_file_matches_table(local_path, table):
+    downloaded_tbl = Table.from_csv(local_path)
+    assert_matching_tables(table, downloaded_tbl)
+
+@mark_live_test
+def test_get_file(live_sftp, simple_table):
+    local_path = files.create_temp_file()
+    live_sftp.get_file(REMOTE_CSV_PATH, local_path=local_path)
+    assert_file_matches_table(local_path, simple_table)
+
+@mark_live_test
+def test_get_temp_file(live_sftp, simple_table):
+    local_path = live_sftp.get_file(REMOTE_CSV_PATH)
+    assert_file_matches_table(local_path, simple_table)
+
+@mark_live_test
+@pytest.mark.parametrize('compression', [None, 'gzip'])
+def test_table_to_sftp_csv(live_sftp, simple_table, compression):
+    host = os.environ['SFTP_HOST']
+    username = os.environ['SFTP_USERNAME']
+    password = os.environ['SFTP_PASSWORD']
+    rsa_private_key_file = os.environ['SFTP_RSA_PRIVATE_KEY_FILE'] or '/Users/angela/.ssh/id_rsa'
+
+    remote_path = f'{REMOTE_DIR}/test_to_sftp.csv'
+    if compression == 'gzip':
+        remote_path += '.gz'
+    simple_table.to_sftp_csv(remote_path, host, username, password, rsa_private_key_file, compression=compression)
+
+    local_path = live_sftp.get_file(remote_path)
+    assert_file_matches_table(local_path, simple_table)
+
+    # Cleanup
+    live_sftp.remove_file(remote_path)
+
+@mark_live_test
+@pytest.mark.parametrize('compression', [None, 'gzip'])
+def test_table_to_sftp_csv_no_password(live_sftp, simple_table, compression):
+    host = os.environ['SFTP_HOST']
+    username = os.environ['SFTP_USERNAME']
+    rsa_private_key_file = os.environ['SFTP_RSA_PRIVATE_KEY_FILE'] or '/Users/angela/.ssh/id_rsa'
+
+    remote_path = f'{REMOTE_DIR}/test_to_sftp.csv'
+    if compression == 'gzip':
+        remote_path += '.gz'
+    simple_table.to_sftp_csv(remote_path, host, username, password=None, rsa_private_key_file, compression=compression)
+
+    local_path = live_sftp.get_file(remote_path)
+    assert_file_matches_table(local_path, simple_table)
+
+    # Cleanup
+    live_sftp.remove_file(remote_path)
+
+
+# Stuff that is tested by the live_sftp fixture, so no need to test explicitly:
+# test_make_directory
+# test_put_file
+# test_put_file_compressed
+# def test_remove_file
+# def test_remove_directory

--- a/test/test_sftp_ssh.py
+++ b/test/test_sftp_ssh.py
@@ -18,14 +18,15 @@ REMOTE_COMPRESSED_CSV_PATH = f'{REMOTE_DIR}/{REMOTE_COMPRESSED_CSV}'
 @pytest.fixture
 def live_sftp(simple_table, simple_csv_path, simple_compressed_csv_path):
     # Generate a live SFTP connection based on these env vars
-    host = os.environ['SFTP_HOST'] or 's-cad475b922de49a19.server.transfer.us-east-1.amazonaws.com'
-    username = os.environ['SFTP_USERNAME'] or 'dev-test-uptime-testuser'
+    host = os.environ.get('SFTP_HOST', 's-cad475b922de49a19.server.transfer.us-east-1.amazonaws.com')
+    username = os.environ.get('SFTP_USERNAME', 'dev-test-uptime-testuser')
     password = None
-    rsa_private_key_file = os.environ['SFTP_RSA_PRIVATE_KEY_FILE'] or '/Users/angela/.ssh/id_rsa'
+    rsa_private_key_file = os.environ.get('SFTP_RSA_PRIVATE_KEY_FILE', '/Users/angela/.ssh/id_rsa')
 
     sftp = SFTP(host, username, password, rsa_private_key_file)
 
     # Add a test directory and test files
+
     sftp.make_directory(REMOTE_DIR)
     sftp.put_file(simple_csv_path, REMOTE_CSV_PATH)
     sftp.put_file(simple_compressed_csv_path, REMOTE_COMPRESSED_CSV_PATH)
@@ -91,11 +92,12 @@ def test_table_to_sftp_csv(live_sftp, simple_table, compression):
     host = os.environ['SFTP_HOST']
     username = os.environ['SFTP_USERNAME']
     password = os.environ['SFTP_PASSWORD']
-    rsa_private_key_file = os.environ['SFTP_RSA_PRIVATE_KEY_FILE'] or '/Users/angela/.ssh/id_rsa'
+    rsa_private_key_file = os.environ.get('SFTP_RSA_PRIVATE_KEY_FILE', '/Users/angela/.ssh/id_rsa')
 
     remote_path = f'{REMOTE_DIR}/test_to_sftp.csv'
     if compression == 'gzip':
         remote_path += '.gz'
+
     simple_table.to_sftp_csv(remote_path, host, username, password, rsa_private_key_file, compression=compression)
 
     local_path = live_sftp.get_file(remote_path)
@@ -104,17 +106,18 @@ def test_table_to_sftp_csv(live_sftp, simple_table, compression):
     # Cleanup
     live_sftp.remove_file(remote_path)
 
-@mark_live_test
+#@mark_live_test
 @pytest.mark.parametrize('compression', [None, 'gzip'])
 def test_table_to_sftp_csv_no_password(live_sftp, simple_table, compression):
-    host = os.environ['SFTP_HOST']
-    username = os.environ['SFTP_USERNAME']
-    rsa_private_key_file = os.environ['SFTP_RSA_PRIVATE_KEY_FILE'] or '/Users/angela/.ssh/id_rsa'
+    host = os.environ.get('SFTP_HOST', 's-cad475b922de49a19.server.transfer.us-east-1.amazonaws.com')
+    username = os.environ.get('SFTP_USERNAME', 'dev-test-uptime-testuser')
+    rsa_private_key_file = os.environ.get('SFTP_RSA_PRIVATE_KEY_FILE', '/Users/angela/.ssh/id_rsa')
 
     remote_path = f'{REMOTE_DIR}/test_to_sftp.csv'
     if compression == 'gzip':
         remote_path += '.gz'
-    simple_table.to_sftp_csv(remote_path, host, username, password=None, rsa_private_key_file, compression=compression)
+
+    simple_table.to_sftp_csv(remote_path, host, username, None, rsa_private_key_file, compression=compression)
 
     local_path = live_sftp.get_file(remote_path)
     assert_file_matches_table(local_path, simple_table)

--- a/test/test_sftp_ssh.py
+++ b/test/test_sftp_ssh.py
@@ -18,10 +18,10 @@ REMOTE_COMPRESSED_CSV_PATH = f'{REMOTE_DIR}/{REMOTE_COMPRESSED_CSV}'
 @pytest.fixture
 def live_sftp(simple_table, simple_csv_path, simple_compressed_csv_path):
     # Generate a live SFTP connection based on these env vars
-    host = os.environ.get('SFTP_HOST')
-    username = os.environ.get('SFTP_USERNAME')
+    host = os.environ['SFTP_HOST']
+    username = os.environ['SFTP_USERNAME']
     password = None
-    rsa_private_key_file = os.environ.get('SFTP_RSA_PRIVATE_KEY_FILE')
+    rsa_private_key_file = os.environ['SFTP_RSA_PRIVATE_KEY_FILE']
 
     sftp = SFTP(host, username, password, rsa_private_key_file)
 
@@ -106,7 +106,7 @@ def test_table_to_sftp_csv(live_sftp, simple_table, compression):
     # Cleanup
     live_sftp.remove_file(remote_path)
 
-#@mark_live_test
+@mark_live_test
 @pytest.mark.parametrize('compression', [None, 'gzip'])
 def test_table_to_sftp_csv_no_password(live_sftp, simple_table, compression):
     host = os.environ.get('SFTP_HOST')


### PR DESCRIPTION
The following PR provides the option to authenticate an sftp connection using a private rsa key as an alternative to username and password authenticate. If a password is provided in addition to a key file path, both will be passed to the paramiko sftp connection configuration. I've added some tests, but they are tests that require a live test environment to succeed.