### PR TITLE
redshift: `nullas` -> `null as` in copy statement

### DIFF
--- a/parsons/databases/redshift/rs_copy_table.py
+++ b/parsons/databases/redshift/rs_copy_table.py
@@ -54,7 +54,7 @@ class RedshiftCopyTable(object):
         if blanksasnull:
             sql += "blanksasnull \n"
         if nullas:
-            sql += f"nullas {nullas}"
+            sql += f"null as {nullas}"
         if acceptinvchars:
             sql += "acceptinvchars \n"
         if truncatecolumns:


### PR DESCRIPTION
This commit updates the function in the Parson's Redshift client
for generating a copy statement when loading data from S3 into
Redshift. Previously, the statement generated used `nullas`
instead of `null as` when adding an optional null-as expression.
This commit fixes the typo.

---

Fixes #143 

cc @asonntag
