### PR TITLE
Adds an option to delete original files when transferring between buckets

### DIFF
--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -351,7 +351,7 @@ class S3(object):
             if remove_original:
                 try:
                     self.remove_file(origin_bucket, origin_key)
-                except:
+                except Exception:
                     pass
 
             if public_read:

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -351,8 +351,8 @@ class S3(object):
             if remove_original:
                 try:
                     self.remove_file(origin_bucket, origin_key)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.error('Failed to delete original key: ' + str(e))
 
             if public_read:
                 object_acl = self.s3.ObjectAcl(destination_bucket, destination_key)

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -292,7 +292,7 @@ class S3(object):
     def transfer_bucket(self, origin_bucket, origin_key, destination_bucket,
                         destination_key=None, suffix=None, regex=None,
                         date_modified_before=None, date_modified_after=None,
-                        public_read=False):
+                        public_read=False, remove_original=False):
         """Transfer files between s3 buckets
         `Args:`
             origin_bucket: str
@@ -314,6 +314,8 @@ class S3(object):
                 Limits the response to keys with date modified after
             public_read: bool
                 If the keys should be set to `public-read`
+            remove_original: bool
+                If the original keys should be removed after transfer
         `Returns:`
             ``None``
         """
@@ -346,6 +348,11 @@ class S3(object):
 
             copy_source = {'Bucket': origin_bucket, 'Key': key}
             self.client.copy(copy_source, destination_bucket, dest_key)
+            if remove_original:
+                try:
+                    self.remove_file(origin_bucket, origin_key)
+                except:
+                    pass
 
             if public_read:
                 object_acl = self.s3.ObjectAcl(destination_bucket, destination_key)

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -141,12 +141,14 @@ class TestS3(unittest.TestCase):
         # Test that you can download from URL
         url = self.s3.get_url(self.test_bucket, self.test_key)
         csv_table = Table.from_csv(url)
+        assert_matching_tables(self.tbl, csv_table)
 
         # Test that the url expires
         url_short = self.s3.get_url(self.test_bucket, self.test_key, expires_in=1)
         time.sleep(2)
-        tbl = Table.from_csv(url_short)
-        self.assertRaises(urllib.error.HTTPError, print, tbl)
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            Table.from_csv(url_short)
+        self.assertEqual(cm.exception.code, 403)
 
     def test_transfer_bucket(self):
 


### PR DESCRIPTION
Adds an additional arg `remove_original` to the `transfer_bucket` method. Default is set to False.

See #122 