### PR TITLE
fix salesforce import

### DIFF
--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -3,146 +3,34 @@
 # and then importing from specific libraries without parsons
 # breaking if dependent libraries are not available.
 
-try:
-    from parsons.ngpvan.van import VAN
-except ImportError:
-    VAN = None
-
-try:
-    from parsons.targetsmart.targetsmart_api import TargetSmartAPI
-except ImportError:
-    TargetSmartAPI = None
-
-try:
-    from parsons.targetsmart.targetsmart_automation import TargetSmartAutomation
-except ImportError:
-    TargetSmartAutomation = None
-
-try:
-    from parsons.databases.redshift.redshift import Redshift
-except ImportError:
-    Redshift = None
-
-try:
-    from parsons.aws.s3 import S3
-except ImportError:
-    S3 = None
-
-try:
-    from parsons.civis.civisclient import CivisClient
-except ImportError:
-    CivisClient = None
-
-try:
-    from parsons.etl.table import Table
-except ImportError:
-    Table = None
-
-try:
-    from parsons.notifications.gmail import Gmail
-except ImportError:
-    Gmail = None
-
-try:
-    from parsons.google.google_civic import GoogleCivic
-except ImportError:
-    GoogleCivic = None
-
-try:
-    from parsons.google.google_sheets import GoogleSheets
-except ImportError:
-    GoogleSheets = None
-
-try:
-    from parsons.google.google_cloud_storage import GoogleCloudStorage
-except ImportError:
-    GoogleCloudStorage = None
-
-try:
-    from parsons.google.google_bigquery import GoogleBigQuery
-except ImportError:
-    GoogleBigQuery = None
-
-try:
-    from parsons.phone2action.p2a import Phone2Action
-except ImportError:
-    Phone2Action = None
-
-try:
-    from parsons.mobilize_america.ma import MobilizeAmerica
-except ImportError:
-    MobilizeAmerica = None
-
-try:
-    from parsons.facebook_ads.facebook_ads import FacebookAds
-except ImportError:
-    FacebookAds = None
-
-try:
-    from parsons.notifications.slack import Slack
-except ImportError:
-    Slack = None
-
-try:
-    from parsons.turbovote.turbovote import TurboVote
-except ImportError:
-    TurboVote = None
-
-try:
-    from parsons.sftp.sftp import SFTP
-except ImportError:
-    SFTP = None
-
-try:
-    from parsons.action_kit.action_kit import ActionKit
-except ImportError:
-    ActionKit = None
-
-try:
-    from parsons.geocode.census_geocoder import CensusGeocoder
-except ImportError:
-    CensusGeocoder = None
-
-try:
-    from parsons.airtable.airtable import Airtable
-except ImportError:
-    Airtable = None
-
-try:
-    from parsons.copper.copper import Copper
-except ImportError:
-    Copper = None
-
-try:
-    from parsons.crowdtangle.crowdtangle import CrowdTangle
-except ImportError:
-    CrowdTangle = None
-
-try:
-    from parsons.hustle.hustle import Hustle
-except ImportError:
-    Hustle = None
-
-try:
-    from parsons.twilio.twilio import Twilio
-except ImportError:
-    Twilio = None
-
-try:
-    from parsons.salesforce.salesforce import Salesforce
-except ImportError:
-    Salesforce = None
-
-try:
-    from parsons.databases.postgres.postgres import Postgres
-except ImportError:
-    Postgres = None
-
-try:
-    from parsons.freshdesk.freshdesk import Freshdesk
-except ImportError:
-    Freshdesk = None
-
+from parsons.ngpvan.van import VAN
+from parsons.targetsmart.targetsmart_api import TargetSmartAPI
+from parsons.targetsmart.targetsmart_automation import TargetSmartAutomation
+from parsons.databases.redshift.redshift import Redshift
+from parsons.aws.s3 import S3
+from parsons.civis.civisclient import CivisClient
+from parsons.etl.table import Table
+from parsons.notifications.gmail import Gmail
+from parsons.google.google_civic import GoogleCivic
+from parsons.google.google_sheets import GoogleSheets
+from parsons.google.google_cloud_storage import GoogleCloudStorage
+from parsons.google.google_bigquery import GoogleBigQuery
+from parsons.phone2action.p2a import Phone2Action
+from parsons.mobilize_america.ma import MobilizeAmerica
+from parsons.facebook_ads.facebook_ads import FacebookAds
+from parsons.notifications.slack import Slack
+from parsons.turbovote.turbovote import TurboVote
+from parsons.sftp.sftp import SFTP
+from parsons.action_kit.action_kit import ActionKit
+from parsons.geocode.census_geocoder import CensusGeocoder
+from parsons.airtable.airtable import Airtable
+from parsons.copper.copper import Copper
+from parsons.crowdtangle.crowdtangle import CrowdTangle
+from parsons.hustle.hustle import Hustle
+from parsons.twilio.twilio import Twilio
+from parsons.salesforce.salesforce import Salesforce
+from parsons.databases.postgres.postgres import Postgres
+from parsons.freshdesk.freshdesk import Freshdesk
 
 __all__ = [
     'VAN',
@@ -173,7 +61,7 @@ __all__ = [
     'Salesforce',
     'Postgres',
     'Freshdesk'
-    ]
+]
 
 # Define the default logging config for Parsons and its submodules. For now the
 # logger gets a StreamHandler by default. At some point a NullHandler may be more

--- a/parsons/salesforce/__init__.py
+++ b/parsons/salesforce/__init__.py
@@ -1,5 +1,5 @@
-from parsons.salesforce.salesforce import SalesForce
+from parsons.salesforce.salesforce import Salesforce
 
 __all__ = [
-    'SalesForce'
+    'Salesforce'
 ]


### PR DESCRIPTION
This commit fixes a typo in the `parsons.salesforce` package
where the `Salesforce` client is erroneously imported as
`SalesForce`. This commit also removes the `try/except` guards
around imports at the root `parsons` package to prevent
`ImportError`s from being swallowed.

---
cc @schuyler1d 