### PR TITLE
document low resource patterns

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,6 +93,66 @@ In your scripts that use Parsons, if you want to override the default Parsons lo
    # parsons_logger.addHandler(...)
    # parsons_logger.setFormatter(...)
 
+Minimizing Resource Utilization
+===============================
+
+A primary goal of Parsons is to make installing and using the library as easy as possible. Many
+of the patterns and examples that we document are meant to show how easy it can be to use Parsons,
+but sometimes these patterns trade accessibility for performance.
+
+In environments where efficiency is important, we recommend users take the following steps to
+minimize resource utilization:
+
+  1. Don't import classes from the root Parsons package
+  2. Install only the dependencies you need
+
+*** Don't import from the root Parsons package
+
+Throughout the Parsons documentation, users are encouraged to load Parsons classes like so:
+
+```python
+from parsons import Table
+```
+
+In order to support this pattern, Parsons imports all of its classes into the root `parsons`
+package. Due to how Python loads modules and packages, importing even one Parsons class results
+in ALL of them being loaded. In order to avoid the resource consumption associated with loading all
+of Parsons, we have created a mechanism to skip loading of call of the Parsons classes.
+
+If you set `PARSONS_SKIP_IMPORT_ALL` in your environment, Parsons will not import all of its classes
+into the root `parsons` package. Setting this environment variable means you will **NOT** be able to
+import using the `from parsons import X` pattern. Instead, you will need to import directly from the
+package where a class is defined (e.g. `from parsons.etl import Table`).
+
+If you use the `PARSONS_SKIP_IMPORT_ALL` and import directly from the appropriate sub-package,
+you will only load the classes that you need and will not consume extra resources. Using this
+method, you may see as much as an 8x decrease in memory usage for Parsons.
+
+*** Install only the dependencies you need
+
+Since Parsons needs to talk to so many different API's, it has a number of dependencies on other
+Python libraries. It may be preferable to only install those external dependencies that you will
+use.
+
+For example, if you are running on Google Cloud, you might not need to use any of Parsons' AWS
+connectors. If you don't use any of Parsons' AWS connectors, then you won't need to install the
+Amazon Boto3 library that Parsons uses to access the Amazon APIs.
+
+By default, installing Parsons will install all of its external dependencies. You can prevent
+these dependencies from being installed with Parsons by passing the `--no-deps` flag to pip
+when you install Parsons.
+
+```
+> pip install --no-deps parsons
+```
+
+Once you have Parsons installed without these external dependencies, you can then install
+the libraries as you need them. You can use the requirements.txt as a reference to figure
+out which version you need. At a minimum you will need to install the following libraries
+for Parsons to work at all:
+
+* petl
+
 Indices and tables
 ==================
 

--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -1,78 +1,82 @@
+import os
+import logging
+
 # Provide shortcuts to importing Parsons submodules
-# The try...except pattern allows installations with --no-deps
-# and then importing from specific libraries without parsons
-# breaking if dependent libraries are not available.
+# If you want to be more targeted in your imports, you can set the PARSONS_SKIP_IMPORT_ALL
+# environment variable and import classes directly from the Python module where they
+# are defined.
 
-from parsons.ngpvan.van import VAN
-from parsons.targetsmart.targetsmart_api import TargetSmartAPI
-from parsons.targetsmart.targetsmart_automation import TargetSmartAutomation
-from parsons.databases.redshift.redshift import Redshift
-from parsons.aws.s3 import S3
-from parsons.civis.civisclient import CivisClient
-from parsons.etl.table import Table
-from parsons.notifications.gmail import Gmail
-from parsons.google.google_civic import GoogleCivic
-from parsons.google.google_sheets import GoogleSheets
-from parsons.google.google_cloud_storage import GoogleCloudStorage
-from parsons.google.google_bigquery import GoogleBigQuery
-from parsons.phone2action.p2a import Phone2Action
-from parsons.mobilize_america.ma import MobilizeAmerica
-from parsons.facebook_ads.facebook_ads import FacebookAds
-from parsons.notifications.slack import Slack
-from parsons.turbovote.turbovote import TurboVote
-from parsons.sftp.sftp import SFTP
-from parsons.action_kit.action_kit import ActionKit
-from parsons.geocode.census_geocoder import CensusGeocoder
-from parsons.airtable.airtable import Airtable
-from parsons.copper.copper import Copper
-from parsons.crowdtangle.crowdtangle import CrowdTangle
-from parsons.hustle.hustle import Hustle
-from parsons.twilio.twilio import Twilio
-from parsons.salesforce.salesforce import Salesforce
-from parsons.databases.postgres.postgres import Postgres
-from parsons.freshdesk.freshdesk import Freshdesk
+if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
+    from parsons.ngpvan.van import VAN
+    from parsons.targetsmart.targetsmart_api import TargetSmartAPI
+    from parsons.targetsmart.targetsmart_automation import TargetSmartAutomation
+    from parsons.databases.redshift.redshift import Redshift
+    from parsons.aws.s3 import S3
+    from parsons.civis.civisclient import CivisClient
+    from parsons.etl.table import Table
+    from parsons.notifications.gmail import Gmail
+    from parsons.google.google_civic import GoogleCivic
+    from parsons.google.google_sheets import GoogleSheets
+    from parsons.google.google_cloud_storage import GoogleCloudStorage
+    from parsons.google.google_bigquery import GoogleBigQuery
+    from parsons.phone2action.p2a import Phone2Action
+    from parsons.mobilize_america.ma import MobilizeAmerica
+    from parsons.facebook_ads.facebook_ads import FacebookAds
+    from parsons.notifications.slack import Slack
+    from parsons.turbovote.turbovote import TurboVote
+    from parsons.sftp.sftp import SFTP
+    from parsons.action_kit.action_kit import ActionKit
+    from parsons.geocode.census_geocoder import CensusGeocoder
+    from parsons.airtable.airtable import Airtable
+    from parsons.copper.copper import Copper
+    from parsons.crowdtangle.crowdtangle import CrowdTangle
+    from parsons.hustle.hustle import Hustle
+    from parsons.twilio.twilio import Twilio
+    from parsons.salesforce.salesforce import Salesforce
+    from parsons.databases.postgres.postgres import Postgres
+    from parsons.freshdesk.freshdesk import Freshdesk
 
-__all__ = [
-    'VAN',
-    'TargetSmartAPI',
-    'TargetSmartAutomation',
-    'Redshift',
-    'S3',
-    'CivisClient',
-    'Table',
-    'Gmail',
-    'GoogleCivic',
-    'GoogleCloudStorage',
-    'GoogleBigQuery',
-    'GoogleSheets',
-    'Phone2Action',
-    'MobilizeAmerica',
-    'FacebookAds',
-    'Slack',
-    'TurboVote',
-    'SFTP',
-    'ActionKit',
-    'CensusGeocoder',
-    'Airtable',
-    'Copper',
-    'CrowdTangle',
-    'Hustle',
-    'Twilio',
-    'Salesforce',
-    'Postgres',
-    'Freshdesk'
-]
+    __all__ = [
+        'VAN',
+        'TargetSmartAPI',
+        'TargetSmartAutomation',
+        'Redshift',
+        'S3',
+        'CivisClient',
+        'Table',
+        'Gmail',
+        'GoogleCivic',
+        'GoogleCloudStorage',
+        'GoogleBigQuery',
+        'GoogleSheets',
+        'Phone2Action',
+        'MobilizeAmerica',
+        'FacebookAds',
+        'Slack',
+        'TurboVote',
+        'SFTP',
+        'ActionKit',
+        'CensusGeocoder',
+        'Airtable',
+        'Copper',
+        'CrowdTangle',
+        'Hustle',
+        'Twilio',
+        'Salesforce',
+        'Postgres',
+        'Freshdesk'
+    ]
 
 # Define the default logging config for Parsons and its submodules. For now the
 # logger gets a StreamHandler by default. At some point a NullHandler may be more
 # appropriate, so the end user must decide on logging behavior.
-import logging
-import os
+
 logger = logging.getLogger(__name__)
 _handler = logging.StreamHandler()
 _formatter = logging.Formatter('%(module)s %(levelname)s %(message)s')
 _handler.setFormatter(_formatter)
 logger.addHandler(_handler)
+
 if os.environ.get('TESTING'):
     # Log less stuff in automated tests
     logger.setLevel('WARNING')

--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -1,5 +1,5 @@
 from airtable import Airtable as AT
-from parsons import Table
+from parsons.etl import Table
 from parsons.utilities import check_env
 import logging
 

--- a/parsons/copper/copper.py
+++ b/parsons/copper/copper.py
@@ -2,7 +2,7 @@ from requests import request
 import math
 import json
 import time
-from parsons import Table
+from parsons.etl import Table
 from parsons.utilities import check_env
 import logging
 

--- a/parsons/crowdtangle/crowdtangle.py
+++ b/parsons/crowdtangle/crowdtangle.py
@@ -1,6 +1,6 @@
 from requests import request
 import time
-from parsons import Table
+from parsons.etl import Table
 from parsons.utilities import check_env
 import logging
 

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -728,7 +728,7 @@ class ETL(object):
             List of Parsons tables
         """
 
-        from parsons import Table  # Just trying to avoid recursive imports.
+        from parsons.etl import Table
         return [Table(petl.rowslice(self.table, i, i+rows)) for i in range(0, self.num_rows, rows)]
 
     @staticmethod
@@ -771,7 +771,7 @@ class ETL(object):
             `Parsons Table` and also updates self
         """
 
-        from parsons import Table  # Just trying to avoid recursive imports.
+        from parsons.etl import Table  # Just trying to avoid recursive imports.
 
         normalize_fn = Table.get_normalized_column_name if fuzzy_match else (lambda s: s)
 

--- a/parsons/freshdesk/freshdesk.py
+++ b/parsons/freshdesk/freshdesk.py
@@ -1,7 +1,7 @@
 from parsons.utilities import check_env
 from parsons.utilities.api_connector import APIConnector
 import re
-from parsons import Table
+from parsons.etl import Table
 import logging
 
 logger = logging.getLogger(__name__)

--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -1,4 +1,4 @@
-from parsons import Table
+from parsons.etl import Table
 import petl
 import censusgeocode
 import logging

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1,6 +1,6 @@
 from google.cloud import bigquery
 from google.cloud import exceptions
-from parsons import Table
+from parsons.etl import Table
 from parsons.google.utitities import setup_google_application_credentials
 from parsons.google.google_cloud_storage import GoogleCloudStorage
 from parsons.utilities import check_env

--- a/parsons/google/google_civic.py
+++ b/parsons/google/google_civic.py
@@ -1,6 +1,6 @@
 from parsons.utilities import check_env
 import requests
-from parsons import Table
+from parsons.etl import Table
 
 URI = 'https://www.googleapis.com/civicinfo/v2/'
 

--- a/parsons/hustle/hustle.py
+++ b/parsons/hustle/hustle.py
@@ -1,4 +1,4 @@
-from parsons import Table
+from parsons.etl import Table
 from requests import request
 from parsons.utilities import check_env, json_format
 import datetime

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -1,4 +1,4 @@
-from parsons import Table
+from parsons.etl import Table
 from slackclient import SlackClient
 from slackclient.exceptions import SlackClientError
 import os

--- a/parsons/phone2action/p2a.py
+++ b/parsons/phone2action/p2a.py
@@ -1,6 +1,6 @@
 import requests
 from requests.auth import HTTPBasicAuth
-from parsons import Table
+from parsons.etl import Table
 from parsons.utilities import check_env
 import logging
 

--- a/parsons/salesforce/salesforce.py
+++ b/parsons/salesforce/salesforce.py
@@ -1,6 +1,6 @@
 from simple_salesforce import Salesforce as _Salesforce
 from parsons.utilities import check_env
-from parsons import Table
+from parsons.etl import Table
 import logging
 
 logger = logging.getLogger(__name__)

--- a/parsons/turbovote/turbovote.py
+++ b/parsons/turbovote/turbovote.py
@@ -1,4 +1,4 @@
-from parsons import Table
+from parsons.etl import Table
 import requests
 import logging
 from parsons.utilities import check_env

--- a/parsons/twilio/twilio.py
+++ b/parsons/twilio/twilio.py
@@ -1,6 +1,6 @@
 from twilio.rest import Client
 from parsons.utilities import check_env, json_format
-from parsons import Table
+from parsons.etl import Table
 import logging
 
 

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -1,5 +1,5 @@
 import pytest
-from parsons import Table
+from parsons.etl import Table
 
 
 '''

--- a/test/test_google/test_google_bigquery.py
+++ b/test/test_google/test_google_bigquery.py
@@ -4,7 +4,7 @@ import unittest.mock as mock
 from google.cloud import bigquery
 from google.cloud import exceptions
 from parsons.google.google_bigquery import GoogleBigQuery
-from parsons import Table
+from parsons.etl import Table
 
 
 # Test class to fake the RowIterator interface for BigQuery job results

--- a/test/test_hustle/test_hustle.py
+++ b/test/test_hustle/test_hustle.py
@@ -2,7 +2,7 @@ import unittest
 import requests_mock
 from test.utils import assert_matching_tables
 from test.test_hustle import expected_json
-from parsons import Table
+from parsons.etl import Table
 from parsons.hustle import Hustle
 from parsons.hustle.hustle import HUSTLE_URI
 


### PR DESCRIPTION
This commit adds a section to the Parsons docs on utilizing
Parsons in environments where resource consumption is a concern.
The goal is to allow developers to avoid loading all of the
Parsons connectors (and dependent libraries) whenever loading
any of them. In order to make this possible, this commit
introduces an environment variable `PARSONS_SKIP_IMPORT_ALL`
that can be set to skip over importing all classes in the
root `parsons` package.

---
cc: @schuyler1d 