### PR TITLE
add noise to upsert staging table name

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -13,6 +13,7 @@ import pickle
 import petl
 from contextlib import contextmanager
 import datetime
+import random
 
 # Max number of rows that we query at a time, so we can avoid loading huge
 # data sets into memory.
@@ -620,7 +621,10 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 Check if the primary key column is distinct. Raise error if not.
         """
 
-        staging_tbl = '{}_{}'.format(target_table, datetime.datetime.now().strftime('%Y%m%d_%M%S'))
+        noise = f'{random.randrange(0, 10000):04}'[:4]
+        date_stamp = datetime.datetime.now().strftime('%Y%m%d_%H%M')
+        # Generate a temp table like "table_tmp_20200210_1230_14212"
+        staging_tbl = '{}_stg_{}_{}'.format(target_table, date_stamp, noise)
 
         if distinct_check:
             sql = f'SELECT COUNT(*)-COUNT(DISTINCT {primary_key}) C FROM {target_table};'


### PR DESCRIPTION
This commit changes the naming convention for the staging table
used by the `Redshift.upsert` method. This commit adds `stg` to
the name of the table. It also adds some random noise to the
end of the table. Before this commit, running the `upsert` command
in parallel against the same table could result in errors from
Redshift from trying to create the same table at the same time.