### PR TITLE
VAN: Fix pagination for events.

### DIFF
--- a/parsons/ngpvan/events.py
+++ b/parsons/ngpvan/events.py
@@ -52,9 +52,11 @@ class Events(object):
                   'startingAfter': starting_after,
                   'startingBefore': starting_before,
                   'districtFieldValue': district_field,
-                  'top': 50,
+                  '$top': 50,
                   '$expand': expand_fields
                   }
+
+        params = {k: v for k, v in params.items() if v is not None}
 
         tbl = Table(self.connection.get_request('events', params=params))
         logger.info(f'Found {tbl.num_rows} events.')

--- a/parsons/ngpvan/events.py
+++ b/parsons/ngpvan/events.py
@@ -56,8 +56,6 @@ class Events(object):
                   '$expand': expand_fields
                   }
 
-        params = {k: v for k, v in params.items() if v is not None}
-
         tbl = Table(self.connection.get_request('events', params=params))
         logger.info(f'Found {tbl.num_rows} events.')
         return tbl

--- a/parsons/ngpvan/van_connector.py
+++ b/parsons/ngpvan/van_connector.py
@@ -26,8 +26,10 @@ class VANConnector(object):
         self.uri = URI
         self.db = db
         self.auth_name = auth_name
+        self.pagination_key = 'nextPageLink'
         self.auth = (self.auth_name, self.api_key + '|' + str(self.db_code))
-        self.api = APIConnector(self.uri, auth=self.auth, data_key='items')
+        self.api = APIConnector(self.uri, auth=self.auth, data_key='items',
+                                pagination_key=self.pagination_key)
 
         # We will not create the SOAP client unless we need to as this triggers checking for
         # valid credentials. As not all API keys are provisioned for SOAP, this keeps it from

--- a/parsons/ngpvan/van_connector.py
+++ b/parsons/ngpvan/van_connector.py
@@ -73,7 +73,7 @@ class VANConnector(object):
         data = self.api.data_parse(r)
 
         # Paginate
-        while self.api.next_page_check_url(r):
+        while isinstance(r, dict) and self.api.next_page_check_url(r):
             r = self.api.get_request(r[self.pagination_key], **kwargs)
             data.extend(self.api.data_parse(r))
 

--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -268,9 +268,6 @@ class APIConnector(object):
             boolean
         """
 
-        # To Do: Some response jsons are enclosed in a list. Need to deal with unpacking and/or
-        # not assuming that it is going to be a dict.
-
         if self.pagination_key and self.pagination_key in resp.keys():
             if resp[self.pagination_key]:
                 return True


### PR DESCRIPTION
The `VAN.get_events()` method was not paginating correctly. This fixes that bug.