### PR TITLE
VAN: Add Custom Fields Endpoint

### DIFF
--- a/docs/ngpvan.rst
+++ b/docs/ngpvan.rst
@@ -242,7 +242,7 @@ Codes
 =============
 Custom Fields
 =============
-.. autoclass:: parsons.ngpvan.van.Codes
+.. autoclass:: parsons.ngpvan.van.CustomFields
    :inherited-members:
 
 ======

--- a/docs/ngpvan.rst
+++ b/docs/ngpvan.rst
@@ -215,40 +215,16 @@ People
 .. autoclass:: parsons.ngpvan.van.People
    :inherited-members:
 
-===========
-Bulk Import
-===========
-.. autoclass:: parsons.ngpvan.van.BulkImport
-   :inherited-members:
-
 ==============
 Activist Codes
 ==============
 .. autoclass:: parsons.ngpvan.van.ActivistCodes
    :inherited-members:
 
-================
-Survey Questions
-================
-.. autoclass:: parsons.ngpvan.van.SurveyQuestions
-   :inherited-members:
-
-======
-Events
-======
-.. autoclass:: parsons.ngpvan.van.Events
-   :inherited-members:
-
-=========
-Locations
-=========
-.. autoclass:: parsons.ngpvan.van.Locations
-   :inherited-members:
-
-=======
-Signups
-=======
-.. autoclass:: parsons.ngpvan.van.Signups
+=================
+Canvass Responses
+=================
+.. autoclass:: parsons.ngpvan.van.CanvassResponses
    :inherited-members:
 
 ================
@@ -263,26 +239,28 @@ Codes
 .. autoclass:: parsons.ngpvan.van.Codes
    :inherited-members:
 
-=================
-Canvass Responses
-=================
-.. autoclass:: parsons.ngpvan.van.CanvassResponses
+=============
+Custom Fields
+=============
+.. autoclass:: parsons.ngpvan.van.Codes
    :inherited-members:
 
-================
-Supporter Groups
-================
-.. autoclass:: parsons.ngpvan.van.SupporterGroups
+======
+Events
+======
+.. autoclass:: parsons.ngpvan.van.Events
    :inherited-members:
 
 ===========
-Saved Lists
+Export Jobs
 ===========
-.. note::
-   A saved list must be shared with the user associated with your API key to
-   be listed.
+.. autoclass:: parsons.ngpvan.van.ExportJobs
+   :inherited-members:
 
-.. autoclass:: parsons.ngpvan.van.SavedLists
+=================
+File Loading Jobs
+=================
+.. autoclass:: parsons.ngpvan.van.FileLoadingJobs
    :inherited-members:
 
 =======
@@ -295,10 +273,20 @@ Folders
 .. autoclass:: parsons.ngpvan.van.Folders
    :inherited-members:
 
+=========
+Locations
+=========
+.. autoclass:: parsons.ngpvan.van.Locations
+   :inherited-members:
+
 ===========
-Export Jobs
+Saved Lists
 ===========
-.. autoclass:: parsons.ngpvan.van.ExportJobs
+.. note::
+   A saved list must be shared with the user associated with your API key to
+   be listed.
+
+.. autoclass:: parsons.ngpvan.van.SavedLists
    :inherited-members:
 
 ======
@@ -318,8 +306,20 @@ a score slot.
 .. autoclass:: parsons.ngpvan.van.Scores
    :inherited-members:
 
-=================
-File Loading Jobs
-=================
-.. autoclass:: parsons.ngpvan.van.FileLoadingJobs
+=======
+Signups
+=======
+.. autoclass:: parsons.ngpvan.van.Signups
+   :inherited-members:
+
+================
+Supporter Groups
+================
+.. autoclass:: parsons.ngpvan.van.SupporterGroups
+   :inherited-members:
+
+================
+Survey Questions
+================
+.. autoclass:: parsons.ngpvan.van.SurveyQuestions
    :inherited-members:

--- a/parsons/ngpvan/codes.py
+++ b/parsons/ngpvan/codes.py
@@ -53,12 +53,9 @@ class Codes(object):
                 See :ref:`parsons-table` for output options.
         """
 
-        url = self.connection.uri + 'codes/{}'.format(code_id)
-
-        c = self.connection.request(url)
+        c = self.connection.request(f'codes/{code_id}')
         logger.debug(c)
         logger.info(f'Found code {code_id}.')
-
         return c
 
     def get_code_types(self):

--- a/parsons/ngpvan/custom_fields.py
+++ b/parsons/ngpvan/custom_fields.py
@@ -1,0 +1,54 @@
+from parsons.etl.table import Table
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CustomFields():
+
+    def __init__(self, van_connection):
+
+        self.connection = van_connection
+
+    def get_custom_fields(self):
+        """
+        Get custom fields.
+
+        `Args:`
+            name : str
+                Filter by name of code.
+            supported_entities: str
+                Filter by supported entities.
+            parent_code_id: str
+                Filter by parent code id.
+            code_type: str
+                Filter by code type.
+        `Returns:`
+            Parsons Table
+                See :ref:`parsons-table` for output options.
+        """
+
+        params = {}
+
+        tbl = Table(self.connection.get_request('customFields', params=params))
+        logger.info(f'Found {tbl.num_rows} custom fields.')
+        return tbl
+
+    def get_custom_field(self, custom_field_id):
+        """
+        Get a custom field.
+
+        `Args:`
+            custom_field_id: int
+                A valid custom field id.
+        `Returns:`
+            A json.
+        """
+
+        url = self.connection.uri + f'customFields/{custom_field_id}'
+
+        r = self.connection.request(url)
+        logger.debug(r)
+        logger.info(f'Found custom field {custom_field_id}.')
+
+        return r

--- a/parsons/ngpvan/custom_fields.py
+++ b/parsons/ngpvan/custom_fields.py
@@ -44,9 +44,14 @@ class CustomFields():
 
         tbl = self.get_custom_fields()
 
+        # Some custom fields do no have associated values. If this is the case then
+        # we should return an empty Table, but with the expected columns.
         if tbl.get_column_types('availableValues') == ['NoneType']:
             logger.info(f'Found 0 custom field values.')
-            return Table([{'customFieldId': None, 'name': None, 'parentValueId': None}])
+            return Table([{'customFieldId': None,
+                           'id': None,
+                           'name': None,
+                           'parentValueId': None}])
 
         else:
             logger.info(f'Found {tbl.num_rows} custom field values.')

--- a/parsons/ngpvan/van.py
+++ b/parsons/ngpvan/van.py
@@ -13,13 +13,14 @@ from parsons.ngpvan.signups import Signups
 from parsons.ngpvan.locations import Locations
 from parsons.ngpvan.bulk_import import BulkImport
 from parsons.ngpvan.changed_entities import ChangedEntities
+from parsons.ngpvan.custom_fields import CustomFields
 
 logger = logging.getLogger(__name__)
 
 
 class VAN(People, Events, SavedLists, Folders, ExportJobs, ActivistCodes, CanvassResponses,
           SurveyQuestions, Codes, Scores, FileLoadingJobs, SupporterGroups, Signups, Locations,
-          BulkImport, ChangedEntities):
+          BulkImport, ChangedEntities, CustomFields):
     """
     Returns the VAN class
 

--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -83,7 +83,6 @@ class APIConnector(object):
         r = self.request(url, 'GET', params=params)
         self.validate_response(r)
         logger.debug(r.json())
-        print (r.json())
 
         return r.json()
 

--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -83,6 +83,7 @@ class APIConnector(object):
         r = self.request(url, 'GET', params=params)
         self.validate_response(r)
         logger.debug(r.json())
+        print (r.json())
 
         return r.json()
 

--- a/test/test_van/test_custom_fields.py
+++ b/test/test_van/test_custom_fields.py
@@ -1,0 +1,58 @@
+import unittest
+import os
+import requests_mock
+from parsons.ngpvan.van import VAN
+from test.utils import validate_list, assert_matching_tables
+from requests.exceptions import HTTPError
+
+
+custom_field = [{
+    "customFieldId": 157,
+    "customFieldParentId": None,
+    "customFieldName": "Education level",
+    "customFieldGroupId": 52,
+    "customFieldGroupName": "Education",
+    "customFieldGroupType": "Contacts",
+    "customFieldTypeId": "S",
+    "isEditable": True,
+    "isExportable": False,
+    "maxTextboxCharacters": None,
+    "availableValues": [
+      {"id": 1, "name": "High School diploma", "parentValueId": None},
+      {"id": 2, "name": "College degree", "parentValueId": None},
+      {"id": 3, "name": "Postgraduate degree", "parentValueId": None},
+      {"id": 4, "name": "Doctorate", "parentValueId": None}]}]
+
+custom_field_values = [
+  {'customFieldId': 157, 'id': 1, 'name': 'High School diploma', 'parentValueId': None},
+  {'customFieldId': 157, 'id': 2, 'name': 'College degree', 'parentValueId': None},
+  {'customFieldId': 157, 'id': 3, 'name': 'Postgraduate degree', 'parentValueId': None},
+  {'customFieldId': 157, 'id': 4, 'name': 'Doctorate', 'parentValueId': None}
+  ]
+
+os.environ['VAN_API_KEY'] = 'SOME_KEY'
+
+
+class TestCustomFields(unittest.TestCase):
+
+    def setUp(self):
+
+        self.van = VAN(os.environ['VAN_API_KEY'], db="MyVoters")
+
+    @requests_mock.Mocker()
+    def test_get_custom_fields(self, m):
+
+        m.get(self.van.connection.uri + 'customFields', json=custom_field)
+        assert_matching_tables(custom_field, self.van.get_custom_fields())
+
+    @requests_mock.Mocker()
+    def test_get_custom_field_values(self, m):
+
+        m.get(self.van.connection.uri + 'customFields', json=custom_field)
+        assert_matching_tables(custom_field_values, self.van.get_custom_fields_values())
+
+    @requests_mock.Mocker()
+    def test_get_custom_field(self, m):
+
+        m.get(self.van.connection.uri + 'customFields/157', json=custom_field)
+        assert_matching_tables(custom_field, self.van.get_custom_field(157))


### PR DESCRIPTION
Adds the following methods:

`VAN.get_custom_field()` - Retrieve a single custom field object as a json.
`VAN.get_custom_fields()` - Retrieve all custom fields as a `Table` object.
`VAN.get_custom_fields_values()` - Retrieve a table of all custom fields values with their associated custom field id.

Also:

- Cleaned up some documentation for VAN.
- Fixed a bug for `VAN.get_code()`