### PR TITLE
Van people

### DIFF
--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -11,8 +11,7 @@ class People(object):
         self.connection = van_connection
 
     def find_person(self, first_name=None, last_name=None, date_of_birth=None, email=None,
-                    phone=None, phone_type=None, street_number=None, street_name=None, zip=None,
-                    match_map=None):
+                    phone=None, phone_type=None, street_number=None, street_name=None, zip=None):
         """
         Find a person record.
 
@@ -25,12 +24,6 @@ class People(object):
             - first_name, last_name, zip5, date_of_birth
             - first_name, last_name, street_number, street_name, zip5
             - email_address
-
-        .. note::
-            The arguments that can be passed are a selection of the possible values that
-            can be used in a search. A full list of possible values can be found
-            `here <https://developers.ngpvan.com/van-api#match-candidates>`_. To use these
-            values, pass in a dictionary using the match_map argument.
 
         `Args:`
             first_name: str
@@ -49,6 +42,34 @@ class People(object):
                 Street Name
             zip: str
                 5 digit zip code
+        `Returns:`
+            A person dict
+        """
+
+        logger.info(f'Finding {first_name} {last_name}.')
+
+        return self._people_search(first_name, last_name, date_of_birth, email, phone,
+                                   phone_type, street_number, street_name, zip)
+
+    def find_person_json(self, match_map):
+        """
+        Find a person record based on json data.
+
+        .. note::
+            Person find must include the following minimum combinations to conduct
+            a search.
+
+            - first_name, last_name, email
+            - first_name, last_name, phone
+            - first_name, last_name, zip5, date_of_birth
+            - first_name, last_name, street_number, street_name, zip5
+            - email_address
+
+        .. note::
+            A full list of possible values for the json, and its structure can be found
+            `here <https://developers.ngpvan.com/van-api#match-candidates>`_.
+
+        `Args:`
             match_map: dict
                 A dictionary of values to match against. Will override all
                 other arguments if provided.
@@ -57,14 +78,12 @@ class People(object):
             A person dict
         """
 
-        logger.info(f'Finding {first_name} {last_name}.')
+        logger.info(f'Finding a match for json details.')
 
-        return self._people_search(first_name, last_name, date_of_birth, email, phone,
-                                   phone_type, street_number, street_name, zip, match_map)
+        return self._people_search(match_map=match_map)
 
     def upsert_person(self, first_name=None, last_name=None, date_of_birth=None, email=None,
-                      phone=None, phone_type=None, street_number=None, street_name=None, zip=None,
-                      match_map=None):
+                      phone=None, phone_type=None, street_number=None, street_name=None, zip=None):
         """
         Create or update a person record.
 
@@ -75,12 +94,6 @@ class People(object):
             - first_name, last_name, zip5, date_of_birth
             - first_name, last_name, street_number, street_name, zip5
             - email_address
-
-        .. note::
-            The arguments that can be passed are a selection of the possible values that
-            can be used in a search. A full list of possible values can be found
-            `here <https://developers.ngpvan.com/van-api#match-candidates>`_. To use these
-            values, pass in a dictionary using the match_map argument.
 
         .. warning::
             This method can only be run on MyMembers, EveryAction, MyCampaign databases.
@@ -105,6 +118,34 @@ class People(object):
                 Street Name
             zip: str
                 5 digit zip code
+        `Returns:`
+            A person dict
+        """
+
+        return self._people_search(first_name, last_name, date_of_birth, email, phone, phone_type,
+                                   street_number, street_name, zip, create=True)
+
+    def upsert_person_json(self, match_map):
+        """
+        Create or update a person record.
+
+        .. note::
+            Person find must include the following minimum combinations.
+            - first_name, last_name, email
+            - first_name, last_name, phone
+            - first_name, last_name, zip5, date_of_birth
+            - first_name, last_name, street_number, street_name, zip5
+            - email_address
+
+        .. note::
+            A full list of possible values for the json, and its structure can be found
+            `here <https://developers.ngpvan.com/van-api#match-candidates>`_. `vanId` can
+            be passed to ensure the correct record is updated.
+
+        .. warning::
+            This method can only be run on MyMembers, EveryAction, MyCampaign databases.
+
+        `Args:`
             match_map: dict
                 A dictionary of values to match against. Will override all
                 other arguments if provided.
@@ -112,8 +153,7 @@ class People(object):
             A person dict
         """
 
-        return self._people_search(first_name, last_name, date_of_birth, email, phone, phone_type,
-                                   street_number, street_name, zip, match_map, create=True)
+        return self._people_search(match_map=match_map, create=True)
 
     def _people_search(self, first_name=None, last_name=None, date_of_birth=None, email=None,
                        phone=None, phone_type='H', street_number=None, street_name=None,

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -124,12 +124,11 @@ class People(object):
         if street_name and street_number:
             addressLine1 = f'{street_number} {street_name}'
 
-        match_flat = json_format.flatten_json(match_map)
-
+        simples = {k: v for k, v in locals().items() if k != 'match_map' and k != 'self'}
+        match_flat = json_format.flatten_json(match_map) if match_map else {}
+        logger.info({**simples, **match_flat})
         # Ensure that the minimum combination of fields were passed, match_map overrides
-        self._valid_search(firstName=first_name, lastName=last_name, email=email,
-                           phoneNumber=phone, dateOfBirth=date_of_birth, addressLine1=addressLine1,
-                           zipOrPostalCode=zip, **match_flat)
+        self._valid_search(**{**simples, **match_flat})
 
         # Check to see if a match map has been provided
         if not match_map:
@@ -158,9 +157,9 @@ class People(object):
 
         return self.connection.post_request(url, json=json)
 
-    def _valid_search(self, firstName, lastName, email, phoneNumber, dateOfBirth, addressLine1,
-                      zipOrPostalCode):
-        # Internal method to check if a search is valid
+    def _valid_search(self, firstName=None, lastName=None, email=None, phoneNumber=None,
+                      dateOfBirth=None, addressLine1=None, zipOrPostalCode=None, **kwargs):
+        # Internal method to check if a search is valid, kwargs are ignored
 
         if (None in [firstName, lastName, email] and
             None in [firstName, lastName, phoneNumber] and

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -11,7 +11,8 @@ class People(object):
         self.connection = van_connection
 
     def find_person(self, first_name=None, last_name=None, date_of_birth=None, email=None,
-                    phone=None, street_number=None, street_name=None, zip=None, match_map=None):
+                    phone=None, phone_type=None, street_number=None, street_name=None, zip=None,
+                    match_map=None):
         """
         Find a person record.
 
@@ -59,7 +60,7 @@ class People(object):
         logger.info(f'Finding {first_name} {last_name}.')
 
         return self._people_search(first_name, last_name, date_of_birth, email, phone,
-                                   street_number, street_name, zip, match_map)
+                                   phone_type, street_number, street_name, zip, match_map)
 
     def upsert_person(self, first_name=None, last_name=None, date_of_birth=None, email=None,
                       phone=None, phone_type=None, street_number=None, street_name=None, zip=None,
@@ -118,7 +119,7 @@ class People(object):
                        phone=None, phone_type='H', street_number=None, street_name=None,
                        zip=None, match_map=None, create=False):
         # Internal method to hit the people find/create endpoints
-
+        logger.info(match_map)
         # Ensure that the minimum combination of fields were passed
         self._valid_search(first_name, last_name, email, phone, date_of_birth, street_number,
                            street_name, zip, match_map)
@@ -143,7 +144,7 @@ class People(object):
         url = 'people/find'
         if create:
             url = url + 'orCreate'
-
+        logger.info(f'json: {json}')
         return self.connection.post_request(url, json=json)
 
     def _valid_search(self, first_name, last_name, email, phone, dob, street_number,

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -43,7 +43,7 @@ class People(object):
             zip: str
                 5 digit zip code
         `Returns:`
-            A person dict
+            A person dict object
         """
 
         logger.info(f'Finding {first_name} {last_name}.')
@@ -83,7 +83,7 @@ class People(object):
                 A dictionary of values to match against.
             fields: The fields to return. Leave as default for all available fields
         `Returns:`
-            A person dict
+            A person dict object
         """
 
         logger.info(f'Finding a match for json details.')
@@ -94,7 +94,8 @@ class People(object):
                       date_of_birth=None, email=None, phone=None, phone_type=None,
                       street_number=None, street_name=None, zip=None):
         """
-        Update a person record based on a provided ID.
+        Update a person record based on a provided ID. All other arguments provided will be
+        updated on the record.
 
         .. warning::
             This method can only be run on MyMembers, EveryAction, MyCampaign databases.

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -284,9 +284,10 @@ class People(object):
         if id:
 
             if create:
-                url += str(id)
+                id_type = '' if id_type in ('vanid', None) else f"{id_type}:"
+                url += id_type + str(id)
             else:
-                return self.get_person(id)
+                return self.get_person(id, id_type=id_type)
 
         else:
             url += 'find'
@@ -351,14 +352,14 @@ class People(object):
         """
 
         # Change end point based on id type
-        if id_type == 'vanid':
-            url = f'people/{id}'
-        else:
-            url = f'people/{id_type}:{id}'
+        url = 'people/'
+
+        id_type = '' if id_type in ('vanid', None) else f"{id_type}:"
+        url += id_type + str(id)
 
         expand_fields = ','.join([json_format.arg_format(f) for f in expand_fields])
 
-        logger.info(f'Getting person with {id_type} of {id}')
+        logger.info(f'Getting person with {id_type} of {id} at url {url}')
         return self.connection.get_request(url, params={'$expand': expand_fields})
 
     def apply_canvass_result(self, id, result_code_id, id_type='vanid', contact_type_id=None,

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -146,17 +146,16 @@ class People(object):
 
         url = 'people/'
 
-        id = None
         if 'vanid' in [k.lower() for k in json]:
             id = {k.lower(): v for k, v in match_map.items()}['vanid']
 
             if create:
-                url += id
+                url += str(id)
             else:
                 return self.get_person(id)
 
-        if id is None:
-            
+        else:
+
             json_flat = json_format.flatten_json(json)
             url += 'find'
 

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -119,7 +119,7 @@ class People(object):
                        phone=None, phone_type='H', street_number=None, street_name=None,
                        zip=None, match_map=None, create=False):
         # Internal method to hit the people find/create endpoints
-        logger.info(match_map)
+
         # Ensure that the minimum combination of fields were passed
         self._valid_search(first_name, last_name, email, phone, date_of_birth, street_number,
                            street_name, zip, match_map)
@@ -136,7 +136,10 @@ class People(object):
             if date_of_birth:
                 json['dateOfBirth'] = date_of_birth
             if zip:
-                json['addresses'] = [{'zipOrPostalCode': zip}]
+                json['addresses'] = [{
+                    'zipOrPostalCode': zip,
+                    'addressLine1': f'{street_number} {street_name}'
+                }]
         else:
             json = match_map
 
@@ -144,7 +147,7 @@ class People(object):
         url = 'people/find'
         if create:
             url = url + 'orCreate'
-        logger.info(f'json: {json}')
+
         return self.connection.post_request(url, json=json)
 
     def _valid_search(self, first_name, last_name, email, phone, dob, street_number,

--- a/parsons/utilities/json_format.py
+++ b/parsons/utilities/json_format.py
@@ -27,6 +27,7 @@ def remove_empty_keys(dirty_dict):
 
     return clean_dict
 
+
 def flatten_json(json):
     """
     Flatten nested json to return a dict without nested values. Lists without nested values will

--- a/parsons/utilities/json_format.py
+++ b/parsons/utilities/json_format.py
@@ -26,3 +26,24 @@ def remove_empty_keys(dirty_dict):
             clean_dict[k] = v
 
     return clean_dict
+
+def flatten_json(json):
+    """
+    Flatten nested json to return a dict without nested values. Lists without nested values will
+    be ignored, and lists of dicts will only return the first key value pair for each key. Useful
+    for passing nested json to validation methods.
+    """
+    out = {}
+
+    def flatten(x, name=''):
+        if type(x) is dict:
+            for k, v in x.items():
+                flatten(v, k)
+        elif type(x) is list:
+            for a in x:
+                flatten(a)
+        elif name != '' and name not in out:
+            out[name] = x
+
+    flatten(json)
+    return out

--- a/test/test_van/test_people.py
+++ b/test/test_van/test_people.py
@@ -23,7 +23,28 @@ class TestNGPVAN(unittest.TestCase):
 
         self.assertEqual(person, find_people_response)
 
+    @requests_mock.Mocker()
+    def test_find_person_json(self, m):
+
+        json = {
+            "firstName": "Bob",
+            "lastName": "Smith",
+            "phones": [{
+                "phoneNumber": 4142020792
+            }]
+        }
+
+        m.post(self.van.connection.uri + 'people/find', json=find_people_response, status_code=200)
+
+        person = self.van.find_person_json(match_map=json)
+
+        self.assertEqual(person, find_people_response)
+
     def test_upsert_person(self):
+
+        pass
+
+    def test_upsert_person_json(self):
 
         pass
 

--- a/test/test_van/test_people.py
+++ b/test/test_van/test_people.py
@@ -36,7 +36,7 @@ class TestNGPVAN(unittest.TestCase):
 
         m.post(self.van.connection.uri + 'people/find', json=find_people_response, status_code=200)
 
-        person = self.van.find_person_json(match_map=json)
+        person = self.van.find_person_json(match_json=json)
 
         self.assertEqual(person, find_people_response)
 
@@ -45,6 +45,14 @@ class TestNGPVAN(unittest.TestCase):
         pass
 
     def test_upsert_person_json(self):
+
+        pass
+
+    def test_update_person(self):
+
+        pass
+
+    def test_update_person_json(self):
 
         pass
 

--- a/test/test_van/test_people.py
+++ b/test/test_van/test_people.py
@@ -36,27 +36,27 @@ class TestNGPVAN(unittest.TestCase):
 
         # Fails with FN / LN Only
         self.assertRaises(ValueError, self.van._valid_search, 'Barack',
-                          'Obama', None, None, None, None, None, None, None)
+                          'Obama', None, None, None, None, None)
 
         # Fails with only Zip
         self.assertRaises(ValueError, self.van._valid_search, 'Barack',
-                          'Obama', None, None, None, None, None, 60622, None)
+                          'Obama', None, None, None, None, 60622)
 
         # Fails with no street number
         self.assertRaises(ValueError, self.van._valid_search, 'Barack',
-                          'Obama', None, None, None, None, 'Pennsylvania Ave', None, None)
+                          'Obama', None, None, None, 'Pennsylvania Ave', None)
 
         # Successful with FN/LN/Email
         self.van._valid_search('Barack', 'Obama', 'barack@email.com', None, None, None,
-                               None, None, None)
+                               None)
 
         # Successful with FN/LN/DOB/ZIP
-        self.van._valid_search('Barack', 'Obama', 'barack@email.com', None, None, '2000-01-01',
-                               None, 20009, None)
+        self.van._valid_search('Barack', 'Obama', 'barack@email.com', None, '2000-01-01',
+                               None, 20009)
 
         # Successful with FN/LN/Phone
         self.van._valid_search('Barack', 'Obama', None, 2024291000, None, None,
-                               None, None, None)
+                               None)
 
     @requests_mock.Mocker()
     def test_get_person(self, m):


### PR DESCRIPTION
This PR is an attempt to allow for updating VAN records using VANIDs. This also necessitated cleaning up the `_person_search()` and `_valid_search()` methods, and resolving the confusion of how street name/number map to actual address data.

This was done in a way that hopefully remains backwards-compatible. Leaving the prospect of VAN ID as a named arg in the `upsert_person()` for a subsequent PR (`find_person()` may not require this since there's `get_person()`).

Successfully tested in the following scenarios:
- find_person() using match_map with `firstName`, `lastName`, `addressLine1`, `zipOrPostalCode`
- find_person() using the same match_map but with a different record's email in the `email` arg (to prove that match_map overrides)
- find_person() with `first_name`, `last_name`, `street_number`, `street_name`, and `zip` args (to prove that using args without match_map still works)
- find_person() using match_map that only has `vanId`
- upsert_person() using match_map that only has `vanId` and `middleName`
- upsert_person() using the same match_map but with a different record's email in the `email` arg (to prove that match_map overrides)
- upsert_person() with `first_name`, `last_name`, `street_number`, `street_name`, `zip`, and `phone` args (to update phone)