### PR TITLE
bill_com: add missing __init__.py

### DIFF
--- a/parsons/bill_com/__init__.py
+++ b/parsons/bill_com/__init__.py
@@ -1,0 +1,5 @@
+from parsons.bill_com.bill_com import BillCom
+
+__all__ = [
+    'BillCom'
+]


### PR DESCRIPTION
A user found this. Not sure why we didn't hit it during the release testing. I can reproduce the error locally while still (in the same virtualenv) pass all of the tests. Python import paths are odd.

We will need to cut a new release (v0.11.1) after this is merged.