### PR TITLE
Adding Pagination to List Methods

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,6 +167,7 @@ Indices and tables
 
    action_kit
    airtable
+   bill_com
    civis
    copper
    crowdtangle

--- a/parsons/bill_com/bill_com.py
+++ b/parsons/bill_com/bill_com.py
@@ -119,12 +119,12 @@ class BillCom(object):
         # Flag to simulate do-while
         first_run = True
 
-        while first_run or len(r) == max_ct:
+        while first_run or len(response) == max_ct:
             first_run = False
             data['start'] += max_ct
             data['max'] += max_ct
-            r = self.get_request_response(data, "List", object_name)
-            r_table.concat(Table(r))
+            response = self.get_request_response(data, "List", object_name)
+            r_table.concat(Table(response))
 
         return r_table
 

--- a/parsons/bill_com/bill_com.py
+++ b/parsons/bill_com/bill_com.py
@@ -101,6 +101,33 @@ class BillCom(object):
         """
         return self.post_request(data, action, object_name)[field]
 
+    def paginate_list(self, response, data, object_name):
+        """
+        Internal method to paginate through and concatenate results of lists larger than max
+        `Args:`
+            response: list of dicts
+                Data from an initial list call
+            data: dict
+                Start, max, and kwargs from initial list call
+            object_name: str
+                Name of the object being listed
+        """
+
+        r_table = Table(r)
+        max_ct = data['max']
+
+        # Flag to simulate do-while
+        first_run = True
+
+        while first_run or len(r) == max_ct:
+            first_run = False
+            data['start'] += max_ct
+            data['max'] += max_ct
+            r = self.get_request_response(data, "List", object_name)
+            r_table.concat(Table(r))
+
+        return r_table
+
     def get_user_list(self, start_user=0, max_user=999, **kwargs):
         """
         `Args:`
@@ -119,9 +146,12 @@ class BillCom(object):
            "max": max_user,
            **kwargs
         }
-        return Table(self.get_request_response(data, "List", "User"))
 
-    def get_customer_list(self, start_customer=1, max_customer=999, **kwargs):
+        r = self.get_request_response(data, "List", "User")
+
+        return paginate_list(self, r, data, "User")
+
+    def get_customer_list(self, start_customer=0, max_customer=999, **kwargs):
         """
         `Args:`
             start_customer: int
@@ -140,9 +170,12 @@ class BillCom(object):
            "max": max_customer,
            **kwargs
         }
-        return Table(self.get_request_response(data, "List", "Customer"))
 
-    def get_invoice_list(self, start_invoice=1, max_invoice=999, **kwargs):
+        r = self.get_request_response(data, "List", "Customer")
+
+        return paginate_list(self, r, data, "Customer")
+
+    def get_invoice_list(self, start_invoice=0, max_invoice=999, **kwargs):
         """
         `Args:`
             start_invoice: int
@@ -161,7 +194,10 @@ class BillCom(object):
            "max": max_invoice,
            **kwargs
         }
-        return Table(self.get_request_response(data, "List", "Invoice"))
+
+        r = self.get_request_response(data, "List", "Invoice")
+
+        return paginate_list(self, r, data, "Invoice")
 
     def read_customer(self, customer_id):
         """

--- a/parsons/bill_com/bill_com.py
+++ b/parsons/bill_com/bill_com.py
@@ -99,9 +99,14 @@ class BillCom(object):
         `Returns:`
             A dictionary containing the choosen field from the JSON response from the post request.
         """
-        return self._post_request(data, action, object_name)[field]
+        r = self._post_request(data, action, object_name)[field]
 
-    def _paginate_list(self, response, data, object_name):
+        if action == "List":
+            return self._paginate_list(r, data, object_name)
+
+        return r
+
+    def _paginate_list(self, response, data, object_name, field="response_data"):
         """
         Internal method to paginate through and concatenate results of lists larger than max
         `Args:`
@@ -123,7 +128,7 @@ class BillCom(object):
             first_run = False
             data['start'] += max_ct
             data['max'] += max_ct
-            response = self._get_request_response(data, "List", object_name)
+            response = self._post_request(data, "List", object_name)[field]
             r_table.concat(Table(response))
 
         return r_table
@@ -147,9 +152,7 @@ class BillCom(object):
            **kwargs
         }
 
-        r = self._get_request_response(data, "List", "User")
-
-        return self._paginate_list(r, data, "User")
+        return self._get_request_response(data, "List", "User")
 
     def get_customer_list(self, start_customer=0, max_customer=999, **kwargs):
         """
@@ -171,9 +174,7 @@ class BillCom(object):
            **kwargs
         }
 
-        r = self._get_request_response(data, "List", "Customer")
-
-        return self._paginate_list(r, data, "Customer")
+        return self._get_request_response(data, "List", "Customer")
 
     def get_invoice_list(self, start_invoice=0, max_invoice=999, **kwargs):
         """
@@ -195,9 +196,7 @@ class BillCom(object):
            **kwargs
         }
 
-        r = self._get_request_response(data, "List", "Invoice")
-
-        return self._paginate_list(r, data, "Invoice")
+        return self._get_request_response(data, "List", "Invoice")
 
     def read_customer(self, customer_id):
         """

--- a/parsons/bill_com/bill_com.py
+++ b/parsons/bill_com/bill_com.py
@@ -113,7 +113,7 @@ class BillCom(object):
                 Name of the object being listed
         """
 
-        r_table = Table(r)
+        r_table = Table(response)
         max_ct = data['max']
 
         # Flag to simulate do-while
@@ -149,7 +149,7 @@ class BillCom(object):
 
         r = self.get_request_response(data, "List", "User")
 
-        return paginate_list(self, r, data, "User")
+        return self.paginate_list(r, data, "User")
 
     def get_customer_list(self, start_customer=0, max_customer=999, **kwargs):
         """
@@ -173,7 +173,7 @@ class BillCom(object):
 
         r = self.get_request_response(data, "List", "Customer")
 
-        return paginate_list(self, r, data, "Customer")
+        return self.paginate_list(r, data, "Customer")
 
     def get_invoice_list(self, start_invoice=0, max_invoice=999, **kwargs):
         """
@@ -197,7 +197,7 @@ class BillCom(object):
 
         r = self.get_request_response(data, "List", "Invoice")
 
-        return paginate_list(self, r, data, "Invoice")
+        return self.paginate_list(r, data, "Invoice")
 
     def read_customer(self, customer_id):
         """

--- a/parsons/bill_com/bill_com.py
+++ b/parsons/bill_com/bill_com.py
@@ -234,6 +234,7 @@ class BillCom(object):
         customer = {"name": customer_name,
                     "email": customer_email,
                     **kwargs}
+
         # check if customer already exists
         customer_list = self.get_customer_list()
         for existing_customer in customer_list:

--- a/parsons/bill_com/bill_com.py
+++ b/parsons/bill_com/bill_com.py
@@ -35,7 +35,7 @@ class BillCom(object):
         self.api_url = api_url
         self.session_id = response.json()['response_data']['sessionId']
 
-    def get_payload(self, data):
+    def _get_payload(self, data):
         """
         `Args:`
             data: dict
@@ -51,7 +51,7 @@ class BillCom(object):
                 "sessionId": self.session_id,
                 "data": json.dumps(data)}
 
-    def post_request(self, data, action, object_name):
+    def _post_request(self, data, action, object_name):
         """
         `Args:`
             data: dict
@@ -77,11 +77,11 @@ class BillCom(object):
             url = "%s%s%s.json" % (self.api_url, action, object_name)
         else:
             url = "%s%s/%s.json" % (self.api_url, action, object_name)
-        payload = self.get_payload(data)
+        payload = self._get_payload(data)
         response = requests.post(url=url, data=payload, headers=self.headers)
         return response.json()
 
-    def get_request_response(self, data, action, object_name, field="response_data"):
+    def _get_request_response(self, data, action, object_name, field="response_data"):
         """
         `Args:`
             data: dict
@@ -99,9 +99,9 @@ class BillCom(object):
         `Returns:`
             A dictionary containing the choosen field from the JSON response from the post request.
         """
-        return self.post_request(data, action, object_name)[field]
+        return self._post_request(data, action, object_name)[field]
 
-    def paginate_list(self, response, data, object_name):
+    def _paginate_list(self, response, data, object_name):
         """
         Internal method to paginate through and concatenate results of lists larger than max
         `Args:`
@@ -123,7 +123,7 @@ class BillCom(object):
             first_run = False
             data['start'] += max_ct
             data['max'] += max_ct
-            response = self.get_request_response(data, "List", object_name)
+            response = self._get_request_response(data, "List", object_name)
             r_table.concat(Table(response))
 
         return r_table
@@ -147,9 +147,9 @@ class BillCom(object):
            **kwargs
         }
 
-        r = self.get_request_response(data, "List", "User")
+        r = self._get_request_response(data, "List", "User")
 
-        return self.paginate_list(r, data, "User")
+        return self._paginate_list(r, data, "User")
 
     def get_customer_list(self, start_customer=0, max_customer=999, **kwargs):
         """
@@ -171,9 +171,9 @@ class BillCom(object):
            **kwargs
         }
 
-        r = self.get_request_response(data, "List", "Customer")
+        r = self._get_request_response(data, "List", "Customer")
 
-        return self.paginate_list(r, data, "Customer")
+        return self._paginate_list(r, data, "Customer")
 
     def get_invoice_list(self, start_invoice=0, max_invoice=999, **kwargs):
         """
@@ -195,9 +195,9 @@ class BillCom(object):
            **kwargs
         }
 
-        r = self.get_request_response(data, "List", "Invoice")
+        r = self._get_request_response(data, "List", "Invoice")
 
-        return self.paginate_list(r, data, "Invoice")
+        return self._paginate_list(r, data, "Invoice")
 
     def read_customer(self, customer_id):
         """
@@ -211,7 +211,7 @@ class BillCom(object):
         data = {
             'id': customer_id
         }
-        return self.get_request_response(data, "Read", "Customer")
+        return self._get_request_response(data, "Read", "Customer")
 
     def read_invoice(self, invoice_id):
         """
@@ -225,7 +225,7 @@ class BillCom(object):
         data = {
            "id": invoice_id
         }
-        return self.get_request_response(data, "Read", "Invoice")
+        return self._get_request_response(data, "Read", "Invoice")
 
     def check_customer(self, customer1, customer2):
         """
@@ -280,7 +280,7 @@ class BillCom(object):
         data = {
             "obj": customer
         }
-        return self.get_request_response(data, "Create", "Customer")
+        return self._get_request_response(data, "Create", "Customer")
 
     def create_invoice(self, customer_id, invoice_number, invoice_date,
                        due_date, invoice_line_items, **kwargs):
@@ -317,7 +317,7 @@ class BillCom(object):
                     **kwargs
                     }
         }
-        return self.get_request_response(data, "Create", "Invoice")
+        return self._get_request_response(data, "Create", "Invoice")
 
     def send_invoice(self, invoice_id, from_user_id, to_email_addresses,
                      message_subject, message_body, **kwargs):
@@ -351,4 +351,4 @@ class BillCom(object):
             "body": message_body
           }
         }
-        return self.get_request_response(data, "Send", "Invoice")
+        return self._get_request_response(data, "Send", "Invoice")

--- a/test/test_bill_com/test_bill_com.py
+++ b/test/test_bill_com/test_bill_com.py
@@ -3,7 +3,6 @@ import requests_mock
 import json
 from parsons import Table
 from test.utils import assert_matching_tables
-from parsons.bill_com.bill_com import BillCom
 
 
 class TestBillCom(unittest.TestCase):

--- a/test/test_bill_com/test_bill_com.py
+++ b/test/test_bill_com/test_bill_com.py
@@ -160,7 +160,7 @@ class TestBillCom(unittest.TestCase):
 
     def test_get_payload(self):
         fake_json = {'fake_key': 'fake_data'}
-        payload = self.bc.get_payload(fake_json)
+        payload = self.bc._get_payload(fake_json)
         self.assertEqual(payload, {'devKey': self.bc.dev_key,
                                    'sessionId': self.bc.session_id,
                                    'data': json.dumps(fake_json)})
@@ -172,7 +172,7 @@ class TestBillCom(unittest.TestCase):
         }
         m.post(self.api_url + 'Crud/Read/Customer.json',
                text=json.dumps(self.fake_customer_read_json))
-        self.assertEqual(self.bc.post_request(data, 'Read', 'Customer'),
+        self.assertEqual(self.bc._post_request(data, 'Read', 'Customer'),
                          self.fake_customer_read_json)
 
     def paginate_callback(self, request, context):
@@ -220,7 +220,7 @@ class TestBillCom(unittest.TestCase):
         object_name = "Listme"
 
         m.post(self.api_url + f'List/{object_name}.json', json=self.paginate_callback)
-        assert_matching_tables(self.bc.paginate_list(r, data, object_name), r_table)
+        assert_matching_tables(self.bc._paginate_list(r, data, object_name), r_table)
 
     @requests_mock.Mocker()
     def test_get_request_response(self, m):
@@ -229,7 +229,7 @@ class TestBillCom(unittest.TestCase):
         }
         m.post(self.api_url + 'Crud/Read/Customer.json',
                text=json.dumps(self.fake_customer_read_json))
-        self.assertEqual(self.bc.get_request_response(data, 'Read', 'Customer', 'response_data'),
+        self.assertEqual(self.bc._get_request_response(data, 'Read', 'Customer', 'response_data'),
                          self.fake_customer_read_json['response_data'])
 
     @requests_mock.Mocker()


### PR DESCRIPTION
By default, the `max` for list calls was set to 999, but it turns out there can be more than 999 of a thing. So I introduced a method to paginate results for list methods, and a test method for it as well.