### PR TITLE
Redshift: Alter table width on Redshift.copy()

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -410,7 +410,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 target table. This will also fail if the target table has an `IDENTITY`
                 column and that column name is among the source table's columns.
             alter_table: boolean
-                Will check if the target table varchar widths are wide enough to copy in the 
+                Will check if the target table varchar widths are wide enough to copy in the
                 table data. If not, will attempt to alter the table to make it wide enough. This
                 will not work with tables that have dependent views.
             aws_access_key_id:

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -340,17 +340,17 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             self.query_with_connection(copy_sql, connection, commit=False)
             logger.info(f'Data copied to {table_name}.')
 
-    def copy(self, table_obj, table_name, if_exists='fail', max_errors=0, distkey=None,
+    def copy(self, tbl, table_name, if_exists='fail', max_errors=0, distkey=None,
              sortkey=None, padding=None, statupdate=False, compupdate=True, acceptanydate=True,
              emptyasnull=True, blanksasnull=True, nullas=None, acceptinvchars=True,
              dateformat='auto', timeformat='auto', varchar_max=None, truncatecolumns=False,
-             columntypes=None, specifycols=False,
+             columntypes=None, specifycols=None, alter_table=True,
              aws_access_key_id=None, aws_secret_access_key=None):
         """
         Copy a :ref:`parsons-table` to Redshift.
 
         `Args:`
-            table_obj: obj
+            tbl: obj
                 A Parsons Table.
             table_name: str
                 The destination table name (ex. ``my_schema.my_table``).
@@ -409,6 +409,9 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 This will fail if all of the source table's columns do not match a column in the
                 target table. This will also fail if the target table has an `IDENTITY`
                 column and that column name is among the source table's columns.
+            alter_table: boolean
+                Will check if the target table varchar widths are wide enough to copy in the 
+                table data. If not, will attempt to alter the table to make it wide enough.
             aws_access_key_id:
                 An AWS access key granted to the bucket where the file is located. Not required
                 if keys are stored as environmental variables.
@@ -420,32 +423,66 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 See :ref:`parsons-table` for output options.
         """
 
-        # To Do:
-        # Auto split big files to copy more quickly
-        # Consider a json for better stability
-
-        key = self.temp_s3_copy(table_obj)
-
-        cols = None
+        # Specify the columns for a copy statement.
         if specifycols:
-            cols = table_obj.columns
+            cols = tbl.columns
+        else:
+            cols = None
 
-        try:
+        key = None
 
-            self.copy_s3(table_name, self.s3_temp_bucket, key,
-                         if_exists=if_exists, max_errors=max_errors,
-                         distkey=distkey, sortkey=sortkey, padding=padding, ignoreheader=1,
-                         varchar_max=varchar_max, statupdate=statupdate, compupdate=compupdate,
-                         acceptanydate=acceptanydate, dateformat=dateformat, timeformat=timeformat,
-                         blanksasnull=blanksasnull, nullas=nullas, emptyasnull=emptyasnull,
-                         acceptinvchars=acceptinvchars, truncatecolumns=truncatecolumns,
-                         columntypes=columntypes, specifycols=cols,
-                         aws_access_key_id=aws_access_key_id,
-                         aws_secret_access_key=aws_secret_access_key, compression='gzip')
+        with self.connection() as connection:
 
-        finally:
+            try:
+                # Check to see if the table exists. If it does not or if_exists = drop, then
+                # create the new table.
+                if self._create_table_precheck(connection, table_name, if_exists):
+                    sql = self.create_statement(tbl, table_name, padding=padding,
+                                                distkey=distkey, sortkey=sortkey,
+                                                varchar_max=varchar_max,
+                                                columntypes=columntypes)
+                    self.query_with_connection(sql, connection, commit=False)
+                    logger.info(f'{table_name} created.')
 
-            self.temp_s3_delete(key)
+                # If alter_table is True, then alter table if the table column widths
+                # are wider than the existing table.
+                elif alter_table:
+                    self.alter_varchar_column_widths(tbl, table_name)
+
+                else:
+                    pass
+
+                # Upload the table to S3
+                key = self.temp_s3_copy(tbl, aws_access_key_id=aws_access_key_id,
+                                        aws_secret_access_key=aws_secret_access_key)
+
+                # Copy to Redshift database.
+                copy_args = {'max_errors': max_errors,
+                             'ignoreheader': 1,
+                             'statupdate': statupdate,
+                             'compupdate': compupdate,
+                             'acceptanydate': acceptanydate,
+                             'dateformat': dateformat,
+                             'timeformat': timeformat,
+                             'blanksasnull': blanksasnull,
+                             'nullas': nullas,
+                             'emptyasnull': emptyasnull,
+                             'acceptinvchars': acceptinvchars,
+                             'truncatecolumns': truncatecolumns,
+                             'specifycols': specifycols,
+                             'aws_access_key_id': aws_access_key_id,
+                             'aws_secret_access_key': aws_secret_access_key,
+                             'compression': 'gzip'}
+
+                # Copy from S3 to Redshift
+                sql = self.copy_statement(table_name, self.s3_temp_bucket, key, **copy_args)
+                self.query_with_connection(sql, connection, commit=False)
+                logger.info(f'Data copied to {table_name}.')
+
+            # Clean up the S3 bucket.
+            finally:
+                if key:
+                    self.temp_s3_delete(key)
 
     def unload(self, sql, bucket, key_prefix, manifest=True, header=True, compression='gzip',
                add_quotes=True, null_as=None, escape=True, allow_overwrite=True,

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -470,7 +470,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                              'emptyasnull': emptyasnull,
                              'acceptinvchars': acceptinvchars,
                              'truncatecolumns': truncatecolumns,
-                             'specifycols': specifycols,
+                             'specifycols': cols,
                              'aws_access_key_id': aws_access_key_id,
                              'aws_secret_access_key': aws_secret_access_key,
                              'compression': 'gzip'}

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -344,7 +344,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
              sortkey=None, padding=None, statupdate=False, compupdate=True, acceptanydate=True,
              emptyasnull=True, blanksasnull=True, nullas=None, acceptinvchars=True,
              dateformat='auto', timeformat='auto', varchar_max=None, truncatecolumns=False,
-             columntypes=None, specifycols=None, alter_table=True,
+             columntypes=None, specifycols=None, alter_table=False,
              aws_access_key_id=None, aws_secret_access_key=None):
         """
         Copy a :ref:`parsons-table` to Redshift.
@@ -411,7 +411,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 column and that column name is among the source table's columns.
             alter_table: boolean
                 Will check if the target table varchar widths are wide enough to copy in the 
-                table data. If not, will attempt to alter the table to make it wide enough.
+                table data. If not, will attempt to alter the table to make it wide enough. This
+                will not work with tables that have dependent views.
             aws_access_key_id:
                 An AWS access key granted to the bucket where the file is located. Not required
                 if keys are stored as environmental variables.

--- a/parsons/databases/redshift/rs_copy_table.py
+++ b/parsons/databases/redshift/rs_copy_table.py
@@ -117,4 +117,6 @@ class RedshiftCopyTable(object):
         return key
 
     def temp_s3_delete(self, key):
-        self.s3.remove_file(self.s3_temp_bucket, key)
+
+        if key:
+            self.s3.remove_file(self.s3_temp_bucket, key)

--- a/parsons/databases/redshift/rs_create_table.py
+++ b/parsons/databases/redshift/rs_create_table.py
@@ -208,6 +208,9 @@ class RedshiftCreateTable(object):
 
         for idx, c in enumerate(columns):
 
+            # Lowercase
+            c = c.lower()
+
             # Remove spaces. Technically allowed with double quotes
             # but I think that it is bad practice.
             c = c.replace(' ', '')

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -11,7 +11,7 @@ from test.utils import validate_list
 
 
 # The name of the schema and will be temporarily created for the tests
-TEMP_SCHEMA = 'parsons_test'
+TEMP_SCHEMA = 'parsons_test2'
 
 # These tests do not interact with the Redshift Database directly, and don't need real credentials
 

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -172,15 +172,11 @@ class TestRedshift(unittest.TestCase):
         # Scrub the keys
         sql = re.sub(r'id=.+;', '*id=HIDDEN*;', re.sub(r"key=.+'", "key=*HIDDEN*'", sql))
 
-        print(sql)
-
         expected_options = ['statupdate', 'compupdate', 'ignoreheader 1', 'acceptanydate',
                             "dateformat 'auto'", "timeformat 'auto'", "csv delimiter ','",
                             "copy test_schema.test(a, b, c) \nfrom 's3://buck/file.csv'",
                             "'aws_access_key_*id=HIDDEN*;aws_secret_access_key=*HIDDEN*'",
                             'emptyasnull', 'blanksasnull', 'acceptinvchars']
-        for o in expected_options:
-            print(o, sql.find(o))
 
         # Check that all of the expected options are there:
         [self.assertNotEqual(sql.find(o), -1) for o in expected_options]
@@ -408,9 +404,6 @@ class TestRedshiftDB(unittest.TestCase):
                'max_varchar', 'sortkey1_enc', 'sortkey_num', 'size', 'pct_used', 'empty',
                'unsorted', 'stats_off', 'tbl_rows', 'skew_sortkey1', 'skew_rows', 'estimated_visible_rows',
                'risk_event', 'vacuum_sort_benefit']
-
-        print (tbls_list)
-        print (exp)
 
         # Having some issues testing that the filter is working correctly, as it
         # takes a little bit of time for a table to show in this table and is beating

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -403,9 +403,14 @@ class TestRedshiftDB(unittest.TestCase):
     def test_get_table_stats(self):
 
         tbls_list = self.rs.get_table_stats(schema=self.temp_schema)
+
         exp = ['database', 'schema', 'table_id', 'table', 'encoded', 'diststyle', 'sortkey1',
                'max_varchar', 'sortkey1_enc', 'sortkey_num', 'size', 'pct_used', 'empty',
-               'unsorted', 'stats_off', 'tbl_rows', 'skew_sortkey1', 'skew_rows']
+               'unsorted', 'stats_off', 'tbl_rows', 'skew_sortkey1', 'skew_rows', 'estimated_visible_rows',
+               'risk_event', 'vacuum_sort_benefit']
+
+        print (tbls_list)
+        print (exp)
 
         # Having some issues testing that the filter is working correctly, as it
         # takes a little bit of time for a table to show in this table and is beating
@@ -546,8 +551,8 @@ class TestRedshiftDB(unittest.TestCase):
         # id smallint,name varchar(5)
         expected_cols = {
             'id':   {
-                'data_type': 'smallint', 'max_length': 16,
-                'max_precision': None, 'max_scale': None, 'is_nullable': True},
+                'data_type': 'smallint', 'max_length': None,
+                'max_precision': 16, 'max_scale': 0, 'is_nullable': True},
             'name': {
                 'data_type': 'character varying', 'max_length': 5,
                 'max_precision': None, 'max_scale': None, 'is_nullable': True},
@@ -676,8 +681,11 @@ class TestRedshiftDB(unittest.TestCase):
                             [5, 'John'],
                             [6, 'Joanna']])
 
+        # You can't alter column types if the table has a dependent view
+        self.rs.query(f"DROP VIEW {self.temp_schema}.test_view")
+
         # Base table 'Name' column has a width of 5. This should expand it to 6.
-        self.rs.alter_table_widths(append_tbl, f'{self.temp_schema}.test')
+        self.rs.alter_varchar_column_widths(append_tbl, f'{self.temp_schema}.test')
         self.assertEqual(self.rs.get_columns(self.temp_schema, 'test')['name']['max_length'], 6)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR does the following:

- Improves the performance of `Redshift.copy()`. Previously, it was leveraging the `Redshift.copy_s3()` method, which - when creating a new table - was causing it to download the file from S3 an additional time to scan the data. Now it scans the data prior to uploading to S3.

- Add an `alter_table` argument to Redshift.copy() which will alter the width of a target table columns if they are too narrow for the incoming data. This should significantly reduce failures on copy. Unfortunately, if the table has an associated dependent view, this will fail. Hence, for now, the default will be `False`, but we will consider shifting that in the future.

