### PR TITLE
MySQL: Add Table Object

### DIFF
--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -7,6 +7,7 @@ from parsons.utilities import files
 import pickle
 import logging
 import os
+from parsons.databases.table import BaseTable
 
 # Max number of rows that we query at a time, so we can avoid loading huge
 # data sets into memory.
@@ -185,3 +186,16 @@ class MySQL():
 
                 logger.debug(f'Query returned {final_tbl.num_rows} rows.')
                 return final_tbl
+
+    def table_exists(self, table_name):
+
+        if self.query(f"SHOW TABLES LIKE '{table_name}'").first == table_name:
+            return True
+        else:
+            return False
+
+
+class MySQLTable(BaseTable):
+    # MySQL table object.
+
+    pass

--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -198,4 +198,17 @@ class MySQL():
 class MySQLTable(BaseTable):
     # MySQL table object.
 
-    pass
+    def get_rows(self, offset=0, chunk_size=None):
+        """
+        Get rows from a table.
+        """
+
+        sql = f"SELECT * FROM {self.table}"
+
+        if chunk_size:
+            sql += f" LIMIT {chunk_size}"
+
+        if offset:
+            sql += f" ,{offset}"
+
+        return self.db.query(sql)

--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -212,3 +212,23 @@ class MySQLTable(BaseTable):
             sql += f" ,{offset}"
 
         return self.db.query(sql)
+
+    def get_new_rows(self, primary_key, cutoff_value, offset=0, chunk_size=None):
+        """
+        Get rows that have a greater primary key value than the one
+        provided.
+
+        It will select every value greater than the provided value.
+        """
+
+        sql = f"""
+               SELECT
+               *
+               FROM {self.table}
+               WHERE {primary_key} > {cutoff_value}
+               """
+
+        if chunk_size:
+            sql += f" LIMIT {chunk_size}, {offset};"
+
+        return self.db.query(sql)

--- a/parsons/databases/table.py
+++ b/parsons/databases/table.py
@@ -97,10 +97,12 @@ class BaseTable:
 
         return self.db.query(sql).first
 
-    def get_new_rows(self, primary_key, start_value, offset=0, chunk_size=None):
+    def get_new_rows(self, primary_key, cutoff_value, offset=0, chunk_size=None):
         """
         Get rows that have a greater primary key value than the one
         provided.
+
+        It will select every value greater than the provided value.
         """
 
         sql = f"""

--- a/parsons/databases/table.py
+++ b/parsons/databases/table.py
@@ -109,7 +109,7 @@ class BaseTable:
                SELECT
                *
                FROM {self.table}
-               WHERE {primary_key} > {start_value}
+               WHERE {primary_key} > {cutoff_value}
                OFFSET {offset}
                """
 

--- a/test/test_databases/test_mysql.py
+++ b/test/test_databases/test_mysql.py
@@ -1,20 +1,16 @@
-from parsons.databases.mysql.mysql import MySQL
+from parsons.databases.mysql.mysql import MySQL, MySQLTable
 from parsons.etl.table import Table
 from test.utils import assert_matching_tables
 import unittest
 import os
 
-# The name of the schema and will be temporarily created for the tests
-TEMP_SCHEMA = 'parsons_test'
 
-
-# These tests interact directly with the Postgres database. To run, set env variable "LIVE_TEST=True"
+# These tests interact directly with the MySQL database. To run, set env variable "LIVE_TEST=True"
 @unittest.skipIf(not os.environ.get('LIVE_TEST'), 'Skipping because not running live test')
 class TestMySQL(unittest.TestCase):
 
     def setUp(self):
 
-        self.temp_schema = TEMP_SCHEMA
         self.mysql = MySQL()
 
     def tearDown(self):
@@ -47,3 +43,69 @@ class TestMySQL(unittest.TestCase):
         r = self.mysql.query("select * from test")
 
         assert_matching_tables(Table([{'name': 'me', 'user_name': 'myuser'}]), r)
+
+
+# These tests interact directly with the MySQL database. To run, set env variable "LIVE_TEST=True"
+@unittest.skipIf(not os.environ.get('LIVE_TEST'), 'Skipping because not running live test')
+class TestMySQL(unittest.TestCase):
+
+    def setUp(self):
+
+        self.mysql = MySQL()
+
+        # Create tables
+        self.mysql.query("CREATE TABLE IF NOT EXISTS test (name VARCHAR(255), user_name VARCHAR(255), id INT)")
+        self.mysql.query("""
+                         INSERT INTO test (name, user_name, id) 
+                         VALUES ('me', 'myuser', '1'),
+                                ('you', 'hey', '2'),
+                                ('you', 'hey', '3')
+                         """)
+
+        self.tbl = MySQLTable(self.mysql, 'test')
+
+    def tearDown(self):
+
+        self.mysql.query("DROP TABLE IF EXISTS test;")
+
+    def test_num_rows(self):
+
+        self.assertEqual(self.tbl.num_rows, 3)
+
+    def test_max_primary_key(self):
+
+        self.assertEqual(self.tbl.max_primary_key('id'), 3)
+
+    def test_distinct_primary_key(self):
+
+        self.assertTrue(self.tbl.distinct_primary_key('id'))
+        self.assertFalse(self.tbl.distinct_primary_key('user_name'))
+
+    def test_columns(self):
+
+        self.assertEqual(self.tbl.columns, ['name', 'user_name', 'id'])
+
+    def test_exists(self):
+
+        self.assertTrue(self.tbl.exists)
+
+        tbl_bad = MySQLTable(self.mysql, 'bad_test')
+        self.assertFalse(tbl_bad.exists)
+
+    def test_drop(self):
+
+        self.tbl.drop()
+        self.assertFalse(self.tbl.exists)
+
+    def test_truncate(self):
+
+        self.tbl.truncate()
+        self.assertEqual(self.tbl.num_rows, 0)
+
+    def test_get_rows(self):
+
+        pass
+
+    def test_get_new_rows(self):
+
+        pass

--- a/test/test_databases/test_mysql.py
+++ b/test/test_databases/test_mysql.py
@@ -104,8 +104,27 @@ class TestMySQL(unittest.TestCase):
 
     def test_get_rows(self):
 
-        pass
+        data = [['name', 'user_name', 'id'],
+                ['me', 'myuser', '1'],
+                ['you', 'hey', '2'],
+                ['you', 'hey', '3']]
+        tbl = Table(data)
+
+        assert_matching_tables(self.tbl.get_rows(), tbl)
 
     def test_get_new_rows(self):
 
-        pass
+        data = [['name', 'user_name', 'id'],
+                ['you', 'hey', '2'],
+                ['you', 'hey', '3']]
+        tbl = Table(data)
+
+        # Basic
+        assert_matching_tables(self.tbl.get_new_rows('id', 1), tbl) 
+
+        # Chunking
+        assert_matching_tables(self.tbl.get_new_rows('id', 1, chunk_size=1), tbl)
+
+    def test_get_new_rows_count(self):
+
+        self.assertEqual(self.tbl.get_new_rows_count('id', 1), 2) 


### PR DESCRIPTION
This PR creates the MySQL Table object. This is needed in order to eventually add MySQL DBSync functionality.