### PR TITLE
fix redash query_api_key accidentally set to query_id

### DIFF
--- a/parsons/redash/redash.py
+++ b/parsons/redash/redash.py
@@ -131,7 +131,7 @@ class Redash(object):
             Table Class
         """
         query_id = check('REDASH_QUERY_ID', query_id)
-        query_api_key = check('REDASH_QUERY_API_KEY', query_id)
+        query_api_key = check('REDASH_QUERY_API_KEY', query_api_key, optional=True)
         params = {}
         if not self.user_api_key and query_api_key:
             params['api_key'] = query_api_key

--- a/test/test_redash.py
+++ b/test/test_redash.py
@@ -20,9 +20,16 @@ class TestRedash(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_cached_query(self, m):
+        redash = Redash(BASE_URL)  # no user_api_key
         m.get(f'{BASE_URL}/api/queries/5/results.csv', text=self.mock_data)
-        assert_matching_tables(self.redash.get_cached_query_results(5, API_KEY),
+        assert_matching_tables(redash.get_cached_query_results(5, API_KEY),
                                self.mock_result)
+        self.assertEqual(m._adapter.last_request.path, '/api/queries/5/results.csv')
+        self.assertEqual(m._adapter.last_request.query, 'api_key=abc123')
+
+        assert_matching_tables(self.redash.get_cached_query_results(5),
+                               self.mock_result)
+        self.assertEqual(m._adapter.last_request.query, '')
 
     @requests_mock.Mocker()
     def test_refresh_query(self, m):


### PR DESCRIPTION
embarrassing typo from the initial PR.