### PR TITLE
actionkit bulk_user_upload with user_fields_only optimization

### DIFF
--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -464,7 +464,8 @@ class ActionKit(object):
                                return_full_json=True,
                                **kwargs)
 
-    def bulk_upload_csv(self, csv_file, import_page, autocreate_user_fields=0, user_fields_only=0):
+    def bulk_upload_csv(self, csv_file, import_page,
+                        autocreate_user_fields=False, user_fields_only=False):
         """
         Bulk upload a csv file of new users or user updates.
         If you are uploading a table object, use bulk_upload_table instead.
@@ -519,6 +520,8 @@ class ActionKit(object):
         See `ActionKit User Upload Documentation
              <https://roboticdogs.actionkit.com/docs/manual/api/rest/uploads.html>`
         Be careful that blank values in columns will overwrite existing data.
+        Tables with only an identifying column (user_id/email) and user_ user fields
+        will be fast-processed -- this is useful for setting/updating user fields.
 
         .. note::
             If you get a 500 error, try sending a much smaller file (say, one row),

--- a/test/test_action_kit.py
+++ b/test/test_action_kit.py
@@ -279,11 +279,26 @@ class TestActionKit(unittest.TestCase):
         type(resp_mock.post()).status_code = mock.PropertyMock(return_value=201)
         self.actionkit._conn = lambda self: resp_mock
         self.actionkit.bulk_upload_table(
+            Table([('user_id', 'user_customfield1', 'action_foo'), (5, 'yes', '123 Main St')]),
+            'fake_page')
+        self.assertEqual(resp_mock.post.call_count, 2)
+        name, args, kwargs = resp_mock.method_calls[1]
+        self.assertEqual(kwargs['data'],
+                         {'page': 'fake_page', 'autocreate_user_fields': 0, 'user_fields_only': 0})
+        upload_data = gzip.open(kwargs['files']['upload']).read()
+        self.assertEqual(upload_data.decode(),
+                         'user_id,user_customfield1,action_foo\r\n5,yes,123 Main St\r\n')
+
+    def test_bulk_upload_table_userfields(self):
+        resp_mock = mock.MagicMock()
+        type(resp_mock.post()).status_code = mock.PropertyMock(return_value=201)
+        self.actionkit._conn = lambda self: resp_mock
+        self.actionkit.bulk_upload_table(
             Table([('user_id', 'user_customfield1'), (5, 'yes')]),
             'fake_page')
         self.assertEqual(resp_mock.post.call_count, 2)
         name, args, kwargs = resp_mock.method_calls[1]
-        self.assertEqual(kwargs['data'], {'page': 'fake_page', 'autocreate_user_fields': 0})
-        upload_data = gzip.open(kwargs['files']['upload']).read()
-        self.assertEqual(upload_data.decode(),
+        self.assertEqual(kwargs['data'],
+                         {'page': 'fake_page', 'autocreate_user_fields': 0, 'user_fields_only': 1})
+        self.assertEqual(kwargs['files']['upload'].read().decode(),
                          'user_id,user_customfield1\r\n5,yes\r\n')


### PR DESCRIPTION
This preserves an optimization which ActionKit has for user_field-only uploads.

From @jburchard 's flag of max-ing out memory, I switch away from using the optimization if the record length exceeds a million.  Happy to use another arbitrary number to balance parson's users -- maybe something worth documenting and/or deciding in-terms of when/what to keep in-memory.

Also, I'm dribbling out changes, as I start to use my own e.g. past PR -- lmk, if it's better to 'fully bake' things.  This is a pretty low-priority change, so no rush on review.