### PR TITLE
Handle nonexistent target table during upsert

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -721,6 +721,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 logger.info(f'Target rows inserted to {target_table}')
             
             except psycopg2.ProgrammingError:
+                self.query_with_connection('ROLLBACK', connection, commit=False)
                 create_statement = f"""
                                     CREATE TABLE {target_table}
                                     (LIKE {staging_tbl});

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -308,8 +308,8 @@ class TestRedshiftDB(unittest.TestCase):
 
     def test_upsert(self):
 
-        # Create a target table
-        self.rs.copy(self.tbl, f'{self.temp_schema}.test_copy')
+        # Create a target table when no target table exists
+        self.rs.upsert(self.tbl, f'{self.temp_schema}.test_copy', 'ID')
 
         # Run upsert
         upsert_tbl = Table([['id', 'name'], [1, 'Jane'], [5, 'Bob']])


### PR DESCRIPTION
Added functionality to catch a failed upsert due to a missing target table, roll back that query, and transfer the entirety of the staging table to a newly-created target table.