### PR TITLE
Improve Redshift upsert staging table column types

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -691,6 +691,10 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
 
                 # Copy to a staging table
                 logger.info(f'Building staging table: {staging_tbl}')
+
+                sql = f'CREATE TABLE {staging_tbl} (LIKE {target_table})'
+                self.query_with_connection(sql, connection, commit=False)
+
                 self.copy(table_obj, staging_tbl)
 
                 staging_table_name = staging_tbl.split('.')[1]

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -339,6 +339,16 @@ class TestRedshiftDB(unittest.TestCase):
         self.assertRaises(ValueError, self.rs.upsert, upsert_tbl, f'{self.temp_schema}.test_copy',
                           ['ID', 'name'])
 
+        # Run upsert with nonmatching datatypes
+        upsert_tbl = Table([['id', 'name'], [3, 600], [6, 99999999999999999999999999999999999999999]])
+        self.rs.upsert(upsert_tbl, f'{self.temp_schema}.test_copy', 'ID')
+
+        # Make sure our table looks like we expect
+        expected_tbl = Table([['id', 'name'],
+                              [2, 'John'], [3, '600'], [5, 'Bob'], [1, 'Jim'], [1, 'Jane'], [6, '99999999999999999999999999999999999999999']])
+        updated_tbl = self.rs.query(f'select * from {self.temp_schema}.test_copy order by id;')
+        assert_matching_tables(expected_tbl, updated_tbl)
+
     def test_unload(self):
 
         # Copy a table to Redshift

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -340,12 +340,15 @@ class TestRedshiftDB(unittest.TestCase):
                           ['ID', 'name'])
 
         # Run upsert with nonmatching datatypes
-        upsert_tbl = Table([['id', 'name'], [3, 600], [6, 99999999999999999999999999999999999999999]])
+        upsert_tbl = Table([['id', 'name'], [3, 600],
+                            [6, 99999999999999999999999999999999999999999]])
         self.rs.upsert(upsert_tbl, f'{self.temp_schema}.test_copy', 'ID')
 
         # Make sure our table looks like we expect
         expected_tbl = Table([['id', 'name'],
-                              [2, 'John'], [3, '600'], [5, 'Bob'], [1, 'Jim'], [1, 'Jane'], [6, '99999999999999999999999999999999999999999']])
+                              [2, 'John'], [3, '600'], [5, 'Bob'], [1, 'Jim'],
+                              [1, 'Jane'],
+                              [6, '99999999999999999999999999999999999999999']])
         updated_tbl = self.rs.query(f'select * from {self.temp_schema}.test_copy order by id;')
         assert_matching_tables(expected_tbl, updated_tbl)
 


### PR DESCRIPTION
When a destination table already exists, this added code ensures that the staging table(s) created during a Redshfit upsert have columns that mirror those of the destination table. This helps avoid issues with copying data from table to table further on down the line.