### PR TITLE
Improve template table schema use, add testing for Redshift upsert

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -466,8 +466,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             # create the new table.
             if self._create_table_precheck(connection, table_name, if_exists):
                 if template_table:
-                    # Copy the schema with AS, but 1=0 copies no rows
-                    sql = f"CREATE TABLE {table_name} AS SELECT * FROM {template_table} WHERE 1=0"
+                    # Copy the schema from the template table
+                    sql = f'CREATE TABLE {table_name} (LIKE {template_table})'
                 else:
                     sql = self.create_statement(tbl, table_name, padding=padding,
                                                 distkey=distkey, sortkey=sortkey,

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -338,17 +338,18 @@ class TestRedshiftDB(unittest.TestCase):
         self.rs.query(f"INSERT INTO {self.temp_schema}.test_copy VALUES (1, 'Jim')")
         self.assertRaises(ValueError, self.rs.upsert, upsert_tbl, f'{self.temp_schema}.test_copy',
                           ['ID', 'name'])
-        
+
+        self.rs.query(f'truncate table {self.temp_schema}.test_copy')
+
         # Run upsert with nonmatching datatypes
         upsert_tbl = Table([['id', 'name'], [3, 600],
-                            [6, 99999999999999999999999999999999999999999]])
+                            [6, 9999]])
         self.rs.upsert(upsert_tbl, f'{self.temp_schema}.test_copy', 'ID')
 
         # Make sure our table looks like we expect
         expected_tbl = Table([['id', 'name'],
-                              [2, 'John'], [3, '600'], [5, 'Bob'], [1, 'Jim'],
-                              [1, 'Jane'],
-                              [6, '99999999999999999999999999999999999999999']])
+                              [3, '600'],
+                              [6, '9999']])
         updated_tbl = self.rs.query(f'select * from {self.temp_schema}.test_copy order by id;')
         assert_matching_tables(expected_tbl, updated_tbl)
 

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -338,6 +338,19 @@ class TestRedshiftDB(unittest.TestCase):
         self.rs.query(f"INSERT INTO {self.temp_schema}.test_copy VALUES (1, 'Jim')")
         self.assertRaises(ValueError, self.rs.upsert, upsert_tbl, f'{self.temp_schema}.test_copy',
                           ['ID', 'name'])
+        
+        # Run upsert with nonmatching datatypes
+        upsert_tbl = Table([['id', 'name'], [3, 600],
+                            [6, 99999999999999999999999999999999999999999]])
+        self.rs.upsert(upsert_tbl, f'{self.temp_schema}.test_copy', 'ID')
+
+        # Make sure our table looks like we expect
+        expected_tbl = Table([['id', 'name'],
+                              [2, 'John'], [3, '600'], [5, 'Bob'], [1, 'Jim'],
+                              [1, 'Jane'],
+                              [6, '99999999999999999999999999999999999999999']])
+        updated_tbl = self.rs.query(f'select * from {self.temp_schema}.test_copy order by id;')
+        assert_matching_tables(expected_tbl, updated_tbl)
 
     def test_unload(self):
 


### PR DESCRIPTION
Working off of discussion in #205, I changed the query used to generate a matching DDL for a specific template table in the Redshift copy function. Then, I added some testing to cover a case where this functionality is used: when an incoming Parsons table has different datatypes than the destination table.