### PR TITLE
Hustle: Return Lead Ids

### DIFF
--- a/parsons/hustle/column_map.py
+++ b/parsons/hustle/column_map.py
@@ -2,7 +2,7 @@
 
 LEAD_COLUMN_MAP = {'first_name': ['first', 'fn', 'firstname'],
                    'last_name': ['last', 'ln', 'lastname'],
-                   'phone_number': ['phone', 'cell', 'phonenumber'],
+                   'phone_number': ['phone', 'cell', 'phonenumber', 'cell_phone', 'cellphone'],
                    'email': ['email_address', 'emailaddress'],
                    'follow_up': ['followup']
                    }

--- a/parsons/hustle/hustle.py
+++ b/parsons/hustle/hustle.py
@@ -373,7 +373,8 @@ class Hustle(object):
             * - last_name
               - ``last_name``, ``last``, ``ln``, ``lastname``
             * - phone_number
-              - ``phone_number``, ``phone``, ``cell``, ``phonenumber``
+               - ``phone_number``, ``phone``, ``cell``, ``phonenumber``, ``cell_phone``
+                ``cellphone``
             * - email
               - ``email``, ``email_address``, ``emailaddress``
             * - follow_up
@@ -386,13 +387,15 @@ class Hustle(object):
                 The group id to assign the leads. If ``None``, must be passed as a column
                 value.
         `Returns:`
-            ``None``
+            A table of created ids with associated lead id.
         """
 
         table.map_columns(LEAD_COLUMN_MAP)
 
         arg_list = ['first_name', 'last_name', 'email', 'phone_number', 'follow_up',
                     'tag_id', 'group_id']
+
+        created_leads = []
 
         for row in table:
 
@@ -415,9 +418,10 @@ class Hustle(object):
             if group_id:
                 lead['group_id'] == group_id
 
-            self.create_lead(**lead)
+            created_leads.append(self.create_lead(**lead))
 
         logger.info(f"Created {table.num_rows} leads.")
+        return Table(created_leads)
 
     def update_lead(self, lead_id, first_name=None, last_name=None, email=None,
                     global_opt_out=None, notes=None, follow_up=None, tag_ids=None):

--- a/test/test_hustle/test_hustle.py
+++ b/test/test_hustle/test_hustle.py
@@ -63,10 +63,11 @@ class TestHustle(unittest.TestCase):
 
         m.post(HUSTLE_URI + 'groups/cMCH0hxwGt/leads', json=expected_json.leads_tbl_01)
 
-        tbl = Table([['phone_number', 'ln', 'first_name', 'address'],
-                     ['4435705355', 'Johnson', 'Lyndon', '123 Main Street'],
-                     ['4435705354', 'Richards', 'Ann', '124 Main Street']])
-        self.hustle.create_leads(tbl, group_id='cMCH0hxwGt')
+        tbl = Table([['phone_number', 'ln', 'first_name'],
+                     ['4435705355', 'Warren', 'Elizabeth'],
+                     ['5126993336', 'Obama', 'Barack']])
+        ids = self.hustle.create_leads(tbl, group_id='cMCH0hxwGt')
+        assert_matching_tables(ids, Table(expected_json.leads['items']))
 
     @requests_mock.Mocker()
     def test_update_lead(self, m):


### PR DESCRIPTION
Enhancement to `Hustle.create_leads()` method that returns a table of newly created lead_ids when creating new leads in the system.