### PR TITLE
action_kit.bulk_upload_table: create an option not to overwrite on empty values

### DIFF
--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import requests
+
+from parsons.etl.table import Table
 from parsons.utilities import check_env
 
 logger = logging.getLogger(__name__)
@@ -514,7 +516,8 @@ class ActionKit(object):
               'progress_url': res.headers.get('Location')}
         return rv
 
-    def bulk_upload_table(self, table, import_page, autocreate_user_fields=0):
+    def bulk_upload_table(self, table, import_page, autocreate_user_fields=0,
+                          no_overwrite_on_empty=False):
         """
         Bulk upload a table of new users or user updates.
         See `ActionKit User Upload Documentation
@@ -537,23 +540,49 @@ class ActionKit(object):
                 When True columns starting with "user_" will be uploaded as user fields.
                 See the `autocreate_user_fields documentation
                   <https://roboticdogs.actionkit.com/docs/manual/api/rest/uploads.html#create-a-multipart-post-request>`
+            no_overwrite_on_empty: bool
+                When uploading user data, ActionKit will, by default, take a blank value
+                and overwrite existing data for that user.
+                This can be undesirable, if the goal is to only send updates.
+                Setting this to True will divide up the table into multiple upload
+                batches, changing the columns uploaded based on permutations of
+                empty columns.
         `Returns`:
             dict
-                success: whether upload was successful
-                progress_url: an API URL to get progress on upload processing
-                res: requests http response object
+                success: bool -- whether upload was successful (individual rows may not have been)
+                results: [dict] -- This is a list of the full results.
+                         progress_url and res for any results
         """
         import_page = check_env.check('ACTION_KIT_IMPORTPAGE', import_page)
-        compress_maybe = dict()
-        user_fields_only = int(not any([
-            h for h in table.table.header()
-            if h != 'email' and not h.startswith('user_')]))
-        if not user_fields_only or len(table.table) > 1_000_000:
-            # compression disables user_fields_only's fast processing
-            # but we'll disable that if there are so many rows that
-            # memory could be an issue.
-            compress_maybe = dict(temp_file_compression='gzip')
-        return self.bulk_upload_csv(table.to_csv(**compress_maybe),
-                                    import_page,
-                                    autocreate_user_fields=autocreate_user_fields,
-                                    user_fields_only=user_fields_only)
+        upload_tables = [table]
+        if no_overwrite_on_empty:
+            upload_tables = self._split_tables_no_empties(table)
+        results = []
+        for tbl in upload_tables:
+            user_fields_only = int(not any([
+                h for h in tbl.table.header()
+                if h != 'email' and not h.startswith('user_')]))
+            results.append(self.bulk_upload_csv(tbl.to_csv(),
+                                                import_page,
+                                                autocreate_user_fields=autocreate_user_fields,
+                                                user_fields_only=user_fields_only))
+        return {
+            'success': all([r['success'] for r in results]),
+            'results': results
+        }
+
+    def _split_tables_no_empties(self, table):
+        table_groups = {}
+        headers = table.table.header()
+        for row in table:
+            blanks = tuple(k for k in headers
+                           if row.get(k) in (None, ''))
+            grp = table_groups.setdefault(blanks, [])
+            grp.append(row)
+        results = []
+        for blanks, subset in table_groups.items():
+            subset_table = Table(subset)
+            if blanks:
+                subset_table.table = subset_table.table.cutout(*blanks)
+            results.append(subset_table)
+        return results

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -560,7 +560,7 @@ class ActionKit(object):
         results = []
         for tbl in upload_tables:
             user_fields_only = int(not any([
-                h for h in tbl.table.header()
+                h for h in tbl.columns
                 if h != 'email' and not h.startswith('user_')]))
             results.append(self.bulk_upload_csv(tbl.to_csv(),
                                                 import_page,
@@ -573,9 +573,8 @@ class ActionKit(object):
 
     def _split_tables_no_empties(self, table):
         table_groups = {}
-        headers = table.table.header()
         for row in table:
-            blanks = tuple(k for k in headers
+            blanks = tuple(k for k in table.columns
                            if row.get(k) in (None, ''))
             grp = table_groups.setdefault(blanks, [])
             grp.append(row)


### PR DESCRIPTION
This splits up a table into several tables based on empties.

Changes the API slightly -- return value is a dict with success:  but then an array of "results".  The API is sufficiently new, that I think this should be ok, but we can change it conditionally based on the option, if we want to preserve full backwards compatibility.

bikesheds on what to name the parameter welcome :-)