### PR TITLE
etl: convert_columns_to_str handle no types

### DIFF
--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -168,10 +168,16 @@ class ETL(object):
             `Parsons Table` and also updates self
         """
 
+        # If we don't have any rows, don't bother trying to convert things
+        if self.num_rows == 0:
+            return self
+
         cols = self.get_columns_type_stats()
 
         for col in cols:
-            if len(col['type']) > 1 or col['type'][0] != 'str':
+            # If there's more than one type (or no types), convert to str
+            # Also if there is one type and it's not str, convert to str
+            if len(col['type']) != 1 or col['type'][0] != 'str':
                 self.convert_column(col['name'], str)
 
         return self


### PR DESCRIPTION
This commit updates the `convert_columns_to_str` method in the
Parsons `Table` handle a case where `petl` was returning an
empty list for the types from the `typeset` function. The
Parsons code had assumed that the list returned from `typeset`
would always be non-empty, so when an empty value was returned
the code raised an index out of bounds exception.

It looks like the reason `typeset` was returning an empty list
of types is that the `Table` in question didn't have any rows,
so this commit exits early from the function if there's no data.
Also, to be safe, the commit updates the conditional check to
short circuit if there is less than one (no types) or more than
one (multiple types) value in the list.