### PR TITLE
resolve requirements.txt conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,6 @@ gspread==3.1.0
 oauth2client==4.1.3
 facebook-business==6.0.0
 google-api-python-client==1.7.7
-google-auth==1.6.2
-google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.4.0
 google-resumable-media!=0.4.0,<0.5.0dev,>=0.3.1
 httplib2==0.12.0
 validate-email==1.3
@@ -29,7 +26,7 @@ twilio==6.30.0
 simple-salesforce==0.74.3
 suds-py3==1.3.4.0
 newmode==0.1.6
-mysql-connector-python==8.0.19
+mysql-connector-python==8.0.18
 braintree==4.0.0
 
 # Testing Requirements


### PR DESCRIPTION
This commit fixes some issues with version conflicts in the
requirements.txt file for Parsons.
 * Changes version for `mysql-connector-python` from 8.0.19 to
   8.0.18 to resolve an issue with a hardcoded version number for
   the protobuf library.
 * Removes google-auth, google-auth-httplib2, and
   google-auth-oauthlib from requirements.txt, since they are all
   installed by other libraries used by Parsons.

cc @ydamit 