### PR TITLE
Redshift.upsert: default to compupdate=False because compression isn't useful for temp tables

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -731,6 +731,13 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             try:
                 # Copy to a staging table
                 logger.info(f'Building staging table: {staging_tbl}')
+                if 'compupdate' not in copy_args:
+                    # Especially with a lot of columns, compupdate=True can
+                    # cause a lot of processing/analysis by Redshift before upload.
+                    # Since this is a temporary table, setting compression for each
+                    # column is not impactful barely impactful
+                    # https://docs.aws.amazon.com/redshift/latest/dg/c_Loading_tables_auto_compress.html
+                    copy_args = dict(copy_args, compupdate=False)
                 self.copy(table_obj, staging_tbl,
                           template_table=target_table,
                           **copy_args)


### PR DESCRIPTION
Our Redshift CPU was starting to get quite stressed when we deployed something with parsons' redshift.upsert.  After investigation, it seemed that the default of compupdate=True in the `copy` command was causing very slow analysis (even with several thousand rows) -- but especially with tables with a lot of *columns* (ours had 109).

It seems that especially for temporary tables, like in upsert, leaving compupdate=True is unlikely to be helpful, since the table will be deleted soon.

I'm shy about suggesting that the default in `.copy()` change, but it seems that there are a lot of 'upload a temporary-ish table' that `.copy()` is/might be used for where compupdate=False is the better option/default.  Maybe, if nothing else, it would be worth documenting.

cc: @ydamit (after discussion)