### PR TITLE
bigquery: DB sync

### DIFF
--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -35,6 +35,7 @@ Database Sync
 Sync tables between two databases with just a few lines of code. Currently supported
 database types are:
 
+* Google BigQuery
 * MySQL
 * Postgres
 * Redshift
@@ -45,7 +46,7 @@ Examples
 
 **Full Sync Of Tables**
 
-Copy all data from a source table to a destination table. 
+Copy all data from a source table to a destination table.
 
 .. code-block:: python
 

--- a/docs/google_cloud.rst
+++ b/docs/google_cloud.rst
@@ -21,6 +21,5 @@ Google BigQuery is a cloud data warehouse solution. Data is stored in tables, an
 BigQuery uses datasets as top level containers for tables, and datasets are themselves contained within
 Google Cloud projects.
 
-
 .. autoclass:: parsons.GoogleBigQuery
    :inherited-members:

--- a/parsons/databases/db_sync.py
+++ b/parsons/databases/db_sync.py
@@ -133,35 +133,41 @@ class DBSync:
         dest_max_pk = destination_tbl.max_primary_key(primary_key)
 
         # Check for a mismatch in row counts.
-        if dest_max_pk > source_max_pk:
+        if dest_max_pk and dest_max_pk > source_max_pk:
             raise ValueError('Destination DB primary key greater than source DB primary key.')
 
         # Do not copied if row counts are equal.
         elif dest_max_pk == source_max_pk:
             logger.info('Tables are in sync.')
             return None
-            # Question: Should I check that the row counts match too?
 
         else:
             # Get count of rows to be copied.
-            new_row_count = source_tbl.get_new_rows_count(primary_key, dest_max_pk)
+            if dest_max_pk is not None:
+                new_row_count = source_tbl.get_new_rows_count(primary_key, dest_max_pk)
+            else:
+                new_row_count = source_tbl.num_rows
+
             logger.info(f'Found {new_row_count} new rows in source table.')
 
-            # Copy rows in chunks.
             copied_rows = 0
-            while copied_rows < new_row_count:
-
+            # Copy rows in chunks.
+            while True:
                 # Get a chunk
                 rows = source_tbl.get_new_rows(primary_key=primary_key,
-                                               start_value=dest_max_pk,
+                                               cutoff_value=dest_max_pk,
                                                offset=copied_rows,
                                                chunk_size=self.chunk_size)
+
+                row_count = rows.num_rows if rows else 0
+                if row_count == 0:
+                    break
 
                 # Copy the chunk
                 self.dest_db.copy(rows, destination_table, if_exists='append', **kwargs)
 
                 # Update the counter
-                copied_rows += rows.num_rows
+                copied_rows += row_count
 
         self._row_count_verify(source_tbl, destination_tbl)
 

--- a/parsons/databases/db_sync.py
+++ b/parsons/databases/db_sync.py
@@ -132,8 +132,9 @@ class DBSync:
         source_max_pk = source_tbl.max_primary_key(primary_key)
         dest_max_pk = destination_tbl.max_primary_key(primary_key)
 
-        # Check for a mismatch in row counts.
-        if dest_max_pk and dest_max_pk > source_max_pk:
+        # Check for a mismatch in row counts; if dest_max_pk is None, or destination is empty
+        # and we don't have to worry about this check.
+        if dest_max_pk is not None and dest_max_pk > source_max_pk:
             raise ValueError('Destination DB primary key greater than source DB primary key.')
 
         # Do not copied if row counts are equal.

--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -307,6 +307,11 @@ class MySQL(MySQLCreateTable):
         else:
             return False
 
+    def table(self, table_name):
+        # Return a MySQL table object
+
+        return MySQLTable(self, table_name)
+
 
 class MySQLTable(BaseTable):
     # MySQL table object.

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -101,16 +101,20 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         conn = psycopg2.connect(user=self.username, password=self.password,
                                 host=self.host, dbname=self.db, port=self.port,
                                 connect_timeout=self.timeout)
-        yield conn
+        try:
+            yield conn
 
-        conn.commit()
-        conn.close()
+            conn.commit()
+        finally:
+            conn.close()
 
     @contextmanager
     def cursor(self, connection):
         cur = connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
-        yield cur
-        cur.close()
+        try:
+            yield cur
+        finally:
+            cur.close()
 
     def query(self, sql, parameters=None):
         """


### PR DESCRIPTION
This commit updates the Parsons BigQuery connector to support DB
syncs to/from BigQuery. In order to make this change, the commit
also modifies the `query` method in the connector to use the
BigQuery
[DB-API](https://googleapis.dev/python/bigquery/latest/dbapi.html)
interface.

The commit also updates the BigQuery connector API to
require users to qualify their table names with the name of the
dataset, so align the BigQuery API with the more standard SQL
connectors (Redshift, MySQL).

This commit also makes a few minor changes to the DB sync class
to fix some small bugs, namely:
 * Add the `table` method to MySQL to allow using MySQL for with
 `DBSync`
 * Ensure that the connection and cursor in the Redshift connector
 are closed, even if the query raises an exception.
 * Fixes a bug where the DB sync API wouldn't support incremental
 table syncs where the primary key wasn't an integer.
 * Work around a limitation in BigQuery where the `autodetect`
 of a copy job would confuse headers for a data row in the case
 where the table data was all strings.
 * Fix DB Sync `table_sync_incremental` so it works even if the
 destination table is empty.