### PR TITLE
HOTFIX: make Freshdesk transform_table function a passthrough when no data is present

### DIFF
--- a/parsons/freshdesk/freshdesk.py
+++ b/parsons/freshdesk/freshdesk.py
@@ -55,11 +55,11 @@ class Freshdesk():
 
     def transform_table(self, tbl, expand_custom_fields=None):
         # Internal method to transform a table prior to returning
-
-        tbl.move_column('id', 0)
-        tbl.sort()
-        if expand_custom_fields:
-            tbl.unpack_dict('custom_fields', prepend=False)
+        if tbl.num_rows > 0:
+            tbl.move_column('id', 0)
+            tbl.sort()
+            if expand_custom_fields:
+                tbl.unpack_dict('custom_fields', prepend=False)
 
         return tbl
 


### PR DESCRIPTION
In any code that uses the current Freshdesk connector, evaluation of an empty table after running one of the getter functions will fail. This is because when the table is created, transform_table is called. That function should only move or expand columns when data is present, since there is no explicit data model to rely upon in this connector. With no data present, the function attempts to move standard columns that aren't there.