### PR TITLE
Fix iso_to_unix function

### DIFF
--- a/parsons/utilities/date_convert.py
+++ b/parsons/utilities/date_convert.py
@@ -1,11 +1,20 @@
-import dateutil.parser as dp
+from dateutil.parser import parse
+from datetime import timezone
 
 
-def iso_to_unix(iso_date):
+def iso_to_unix(iso_date, tzinfo=None):
     # Convert an ISO date to a Unix time
 
     if iso_date:
-        parsed_date = dp.parse(iso_date)
-        return int(parsed_date.strftime('%s'))
+        parsed_date = parse(iso_date)
+
+        # if no timezone info is parsed or provided, use UTC
+        if not parsed_date.tzinfo:
+            if tzinfo:
+                parsed_date = parsed_date.replace(tzinfo=tzinfo)
+            else:
+                parsed_date = parsed_date.replace(tzinfo=timezone.utc)
+
+        return int(parsed_date.timestamp())
     else:
         return None

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+# raise ValueError
+xfail_value_error = pytest.mark.xfail(raises=ValueError, strict=True)

--- a/test/test_mobilize_america.py
+++ b/test/test_mobilize_america.py
@@ -15,10 +15,6 @@ class TestMobilizeAmerica(unittest.TestCase):
 
         pass
 
-    """
-    # Does not work locally due to some UTC issues, but works on CircleCI. Commenting
-    # out for the time being.
-
     def test_time_parse(self):
 
         # Test that Unix conversion works correctly
@@ -26,7 +22,6 @@ class TestMobilizeAmerica(unittest.TestCase):
 
         # Test that it throws an error when you put in an invalid filter
         self.assertRaises(ValueError, self.ma._time_parse, '=2018-12-01')
-    """
 
     @requests_mock.Mocker()
     def test_get_organizations(self, m):

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -8,18 +8,18 @@ from parsons.utilities import date_convert
 from parsons.utilities import files
 from parsons.utilities import check_env
 from parsons.utilities import json_format
+from test.conftest import xfail_value_error
 
 
-"""
-# Does not work locally due to some UTC issues, but works on CircleCI. Commenting
-# out for the time being.
-
-class TestDateConvert(unittest.TestCase):
-
-    def test_date_convert(self):
-
-        self.assertEqual(date_convert.iso_to_unix('2018-12-13'), 1544659200)
-"""
+@pytest.mark.parametrize(
+    ["date", "exp_ts"],
+    [pytest.param("2018-12-13", 1544659200),
+     pytest.param("2018-12-13T00:00:00-08:00", 1544688000),
+     pytest.param("", None),
+     pytest.param("2018-12-13 PST", None, marks=[xfail_value_error]),
+     ])
+def test_date_convert(date, exp_ts):
+    assert date_convert.iso_to_unix(date) == exp_ts
 
 #
 # File utility tests (pytest-style)
@@ -110,4 +110,3 @@ class TestCheckEnv(unittest.TestCase):
         """Test check env raises error"""
         with self.assertRaises(KeyError) as context:
             check_env.check('PARAM', None)
-


### PR DESCRIPTION
There was an issue where the test wasn't passing locally but was passing on the CI server. It appeared to be related to timezones. This fix adds support for timezones and sets the default timezone to UTC. Tests passed locally.