### PR TITLE
HOTFIX: elif to if inside Redshift copy to account for upsert staging table issues

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -482,7 +482,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
 
             # If alter_table is True, then alter table if the table column widths
             # are wider than the existing table.
-            elif alter_table:
+            if alter_table:
                 self.alter_varchar_column_widths(tbl, table_name)
 
             # Upload the table to S3


### PR DESCRIPTION
Passing copyargs through the Redshift upsert function occasionally runs into issues with the alter_table logic not running when it naturally should. Specifically, this happens when the copy function is leveraged to create a staging table based on the DDL of the destination table. By simply changing an elif to an if, we can resolve this issue.