### PR TITLE
phone2action: manually pagination, update data model

### DIFF
--- a/parsons/phone2action/p2a.py
+++ b/parsons/phone2action/p2a.py
@@ -38,12 +38,18 @@ class Phone2Action(object):
         r.raise_for_status()
         return r
 
-    def _paginate_request(self, url, args=None):
+    def _paginate_request(self, url, args=None, page=None):
         # Internal pagination method
+
+        if page is not None:
+            args['page'] = page
 
         r = self._request(url, args=args)
 
         json = r.json()['data']
+
+        if page is not None:
+            return json
 
         # If count of items is less than the total allowed per page, paginate
         while r.json()['pagination']['count'] == r.json()['pagination']['per_page']:
@@ -53,9 +59,12 @@ class Phone2Action(object):
 
         return json
 
-    def get_advocates(self, state=None, campaign_id=None, updated_since=None):
+    def get_advocates(self, state=None, campaign_id=None, updated_since=None, page=None):
         """
         Return advocates (person records).
+
+        If no page is specified, the method will automatically paginate through the available
+        advocates.
 
         `Args:`
             state: str
@@ -66,6 +75,9 @@ class Phone2Action(object):
             updated_since: str
                 Fetch all advocates updated since UTC date time provided
                 using (ex. '2014-01-05 23:59:43')
+            page: int
+                Page number of data to fetch; if this is specified, call will only return one
+                page.
         `Returns:`
             A dict of parsons tables:
                 * emails
@@ -96,7 +108,9 @@ class Phone2Action(object):
         logger.info(f'Retrieved {tbl.num_rows} advocates...')
 
         # Unpack all of the single objects
-        for c in ['created_at', 'updated_at', 'address', 'districts']:
+        # The Phone2Action API docs says that created_at and updated_at are dictionaries, but
+        # the data returned from the server is a ISO8601 timestamp. - EHS, 05/21/2020
+        for c in ['address', 'districts']:
             tbl.unpack_dict(c)
 
         # Unpack all of the arrays

--- a/test/test_p2a.py
+++ b/test/test_p2a.py
@@ -20,16 +20,8 @@ adv_json = {
                 "register-to-vote-38511",
                 "registered-to-vote-for-2018-38511",
             ],
-            "created_at": {
-                "date": "2017-05-23 23:36:04.000000",
-                "timezone_type": 3,
-                "timezone": "UTC"
-            },
-            "updated_at": {
-                "date": "2018-12-17 21:55:24.000000",
-                "timezone_type": 3,
-                "timezone": "UTC"
-            },
+            "created_at": "2017-05-23 23:36:04.000000",
+            "updated_at": "2018-12-17 21:55:24.000000",
             "address": {
                 "street1": "25255 Maine Ave",
                 "street2": "",
@@ -54,22 +46,14 @@ adv_json = {
                     "campaignid": 25373,
                     "name": "20171121 Businesses for Responsible Tax Reform - Contact Congress",
                     "source": None,
-                    "created_at": {
-                        "date": "2017-11-21 23:28:30.000000",
-                        "timezone_type": 3,
-                        "timezone": "UTC"
-                    }
+                    "created_at": "2017-11-21 23:28:30.000000",
                 },
                 {
                     "id": 20025582,
                     "campaignid": 32641,
                     "name": "20180524 March for America",
                     "source": None,
-                    "created_at": {
-                        "date": "2018-05-24 21:09:49.000000",
-                        "timezone_type": 3,
-                        "timezone": "UTC"
-                    }
+                    "created_at": "2018-05-24 21:09:49.000000",
                 }
             ],
             "fields": [],
@@ -161,9 +145,7 @@ class TestP2A(unittest.TestCase):
 
         adv_exp = ['id', 'prefix', 'firstname', 'middlename',
                    'lastname', 'suffix', 'notes', 'stage', 'connections',
-                   'created_at_date', 'created_at_timezone',
-                   'created_at_timezone_type', 'updated_at_date',
-                   'updated_at_timezone', 'updated_at_timezone_type',
+                   'created_at', 'updated_at',
                    'address_city', 'address_county', 'address_latitude',
                    'address_longitude', 'address_state', 'address_street1',
                    'address_street2', 'address_zip4', 'address_zip5',


### PR DESCRIPTION
This commit updates the `Phone2Action` connector to:
 * Allow manual pagination of advocates
 * Stop calling `unpack_dict` on the `updated_at` and `created_at`
 columns to reflect the data returned from the API

---
Tested locally.