### PR TITLE
SFTP.get_table() method

### DIFF
--- a/parsons/sftp/sftp.py
+++ b/parsons/sftp/sftp.py
@@ -1,6 +1,8 @@
 from contextlib import contextmanager
 import paramiko
+
 from parsons.utilities import files
+from parsons.etl import Table
 
 
 class SFTP(object):
@@ -119,6 +121,23 @@ class SFTP(object):
             conn.get(remote_path, local_path)
 
         return local_path
+
+    def get_table(self, remote_path):
+        """
+        Download a csv from the server and convert into a Parsons table.
+
+        The file may be compressed with gzip, or zip, but may not contain
+        multiple files in the archive.
+
+        `Args:`
+            remote_path: str
+                The remote path of the file to download
+        `Returns:`
+            Parsons Table
+                See :ref:`parsons-table` for output options.
+        """
+
+        return Table.from_csv(self.get_file(remote_path))
 
     def put_file(self, local_path, remote_path):
         """

--- a/parsons/sftp/sftp.py
+++ b/parsons/sftp/sftp.py
@@ -137,6 +137,9 @@ class SFTP(object):
                 See :ref:`parsons-table` for output options.
         """
 
+        if not files.valid_table_suffix(remote_path):
+            raise ValueError('File type cannot be converted to a Parsons table.')
+
         return Table.from_csv(self.get_file(remote_path))
 
     def put_file(self, local_path, remote_path):

--- a/parsons/utilities/files.py
+++ b/parsons/utilities/files.py
@@ -99,6 +99,10 @@ def is_zip_path(path):
     return (path[-4:] == '.zip')
 
 
+def is_csv_path(path):
+    return (path[-3:] == '.csv')
+
+
 def suffix_for_compression_type(compression):
     if compression == 'gzip':
         return '.gz'
@@ -114,6 +118,14 @@ def compression_type_for_path(path):
         return 'zip'
 
     return None
+
+def valid_table_suffix(path):
+    # Checks if the suffix is valid for conversions to a Parsons table.
+
+    if is_csv_path(path) or is_gzip_path(path) or is_zip_path(path):
+        return True
+    else:
+        return False
 
 
 def read_file(path):

--- a/parsons/utilities/files.py
+++ b/parsons/utilities/files.py
@@ -119,6 +119,7 @@ def compression_type_for_path(path):
 
     return None
 
+
 def valid_table_suffix(path):
     # Checks if the suffix is valid for conversions to a Parsons table.
 

--- a/test/test_sftp.py
+++ b/test/test_sftp.py
@@ -75,6 +75,12 @@ def test_get_file(live_sftp, simple_table):
     assert_file_matches_table(local_path, simple_table)
 
 @mark_live_test
+def test_get_table(live_sftp, simple_table):
+    local_path = files.create_temp_file()
+    tbl = live_sftp.get_table(REMOTE_CSV_PATH)
+    assert_matching_tables(tbl, simple_table)
+
+@mark_live_test
 def test_get_temp_file(live_sftp, simple_table):
     local_path = live_sftp.get_file(REMOTE_CSV_PATH)
     assert_file_matches_table(local_path, simple_table)


### PR DESCRIPTION
This method downloads a file from an SFTP server and returns a Parsons table. The file must be a csv, though may be compressed.

Issue #248.