### PR TITLE
GoogleSheets Refactor

### DIFF
--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -55,7 +55,10 @@ class GoogleSheets:
 
         elif isinstance(worksheet, str):
             idx = self.list_worksheets(spreadsheet_id).index(worksheet)
-            return self.gspread_client.open_by_key(spreadsheet_id).get_worksheet(idx)
+            try:
+                return self.gspread_client.open_by_key(spreadsheet_id).get_worksheet(idx)
+            except:  # noqa: E722
+                raise ValueError(f"Couldn't find worksheet {worksheet}")
 
         else:
             raise ValueError(f"Couldn't find worksheet index or title {worksheet}")
@@ -244,11 +247,9 @@ class GoogleSheets:
         """
 
         # This is in here to ensure backwards compatibility with previous versions of Parsons.
-        try:
+        if 'sheet_index' in kwargs:
             worksheet = kwargs['sheet_index']
             logger.warning('Argument deprecated. Use worksheet instead.')
-        except:  # noqa: E722
-            pass
 
         sheet = self._get_worksheet(spreadsheet_id, worksheet)
 
@@ -296,11 +297,9 @@ class GoogleSheets:
         """
 
         # This is in here to ensure backwards compatibility with previous versions of Parsons.
-        try:
+        if 'sheet_index' in kwargs:
             worksheet = kwargs['sheet_index']
             logger.warning('Argument deprecated. Use worksheet instead.')
-        except:  # noqa: E722
-            pass
 
         sheet = self._get_worksheet(spreadsheet_id, worksheet)
         sheet.clear()
@@ -337,5 +336,5 @@ class GoogleSheets:
     def get_sheet_index_with_title(self, spreadsheet_id, title):
         # Deprecated method v0.14 of Parsons.
 
-        logger.warning('Deprecated method. Use get_worksheet_index_with_title() instead.')
-        return self.get_worksheet_index_with_title(spreadsheet_id, title)
+        logger.warning('Deprecated method. Use get_worksheet_index   instead.')
+        return self.get_worksheet_index(spreadsheet_id, title)

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -99,7 +99,7 @@ class GoogleSheets:
 
         worksheet = self._get_worksheet(spreadsheet_id, worksheet)
         tbl = Table(worksheet.get_all_values())
-        logger.info('Retrieved worksheet with {tbl.num_rows} rows.')
+        logger.info(f'Retrieved worksheet with {tbl.num_rows} rows.')
         return tbl
 
     def share_spreadsheet(self, spreadsheet_id, sharee, share_type='user', role='reader',
@@ -211,7 +211,7 @@ class GoogleSheets:
         logger.info('Created worksheet.')
         return (sheet_count-1)
 
-    def append_to_sheet(self, spreadsheet_id, table, worksheet=0, user_entered_value=False):
+    def append_to_sheet(self, spreadsheet_id, table, worksheet=0, user_entered_value=False, **kwargs):
         """
         Append data from a Parsons table to a Google sheet. Note that the table's columns are
         ignored, as we'll be keeping whatever header row already exists in the Google sheet.
@@ -228,6 +228,13 @@ class GoogleSheets:
                 If True, will submit cell values as entered (required for entering formulas).
                 Otherwise, values will be entered as strings or numbers only.
         """
+
+        # This is in here to ensure backwards compatibility with previous versions of Parsons.
+        try:
+            worksheet = kwargs['sheet_index']
+            logger.warning('Argument deprecated. Use worksheet instead.')
+        except:
+            pass
 
         sheet = self._get_worksheet(spreadsheet_id, worksheet)
 
@@ -253,6 +260,7 @@ class GoogleSheets:
 
         # Update the data in one batch
         sheet.update_cells(cells, value_input_option=value_input_option)
+        logger.info(f'Appended {table.num_rows} rows to worksheet.')
 
     def overwrite_sheet(self, spreadsheet_id, table, worksheet=0, user_entered_value=False):
         """
@@ -271,6 +279,13 @@ class GoogleSheets:
                 If True, will submit cell values as entered (required for entering formulas).
                 Otherwise, values will be entered as strings or numbers only.
         """
+
+        # This is in here to ensure backwards compatibility with previous versions of Parsons.
+        try:
+            worksheet = kwargs['sheet_index']
+            logger.warning('Argument deprecated. Use worksheet instead.')
+        except:
+            pass
 
         sheet = self._get_worksheet(spreadsheet_id, worksheet)
         sheet.clear()

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -52,14 +52,27 @@ class GoogleSheets:
         # Check if the worksheet is an integer, if so find the sheet by index
         if isinstance(worksheet, int):
             return self.gspread_client.open_by_key(spreadsheet_id).get_worksheet(worksheet)
-        
-        # If not, then retrieve it by the title
+
+        elif isinstance(worksheet, str):
+            idx = self.list_worksheets(spreadsheet_id).index(worksheet)
+            return self.gspread_client.open_by_key(spreadsheet_id).get_worksheet(idx)
+
         else:
-            sheets = self.gspread_client.open_by_key(spreadsheet_id).worksheets()
-            for index, sheet in enumerate(sheets):
-                if sheet.title == worksheet:
-                    return self.gspread_client.open_by_key(spreadsheet_id).get_worksheet(worksheet)
-                raise ValueError(f"Couldn't find sheet with title {worksheet}")
+            raise ValueError(f"Couldn't find worksheet index or title {worksheet}")
+
+    def list_worksheets(self, spreadsheet_id):
+        """
+        Return a list of worksheets in the spreadsheet.
+
+        `Args:`
+            spreadsheet_id: str
+                The ID of the spreadsheet (Tip: Get this from the spreadsheet URL)
+        `Returns:`
+            list
+                A List of worksheets order by their index
+        """
+        worksheets = self.gspread_client.open_by_key(spreadsheet_id).worksheets()
+        return [w.title for w in worksheets]
 
     def get_worksheet_index(self, spreadsheet_id, title):
         """
@@ -211,7 +224,8 @@ class GoogleSheets:
         logger.info('Created worksheet.')
         return (sheet_count-1)
 
-    def append_to_sheet(self, spreadsheet_id, table, worksheet=0, user_entered_value=False, **kwargs):
+    def append_to_sheet(self, spreadsheet_id, table, worksheet=0, user_entered_value=False,
+                        **kwargs):
         """
         Append data from a Parsons table to a Google sheet. Note that the table's columns are
         ignored, as we'll be keeping whatever header row already exists in the Google sheet.
@@ -233,7 +247,7 @@ class GoogleSheets:
         try:
             worksheet = kwargs['sheet_index']
             logger.warning('Argument deprecated. Use worksheet instead.')
-        except:
+        except:  # noqa: E722
             pass
 
         sheet = self._get_worksheet(spreadsheet_id, worksheet)
@@ -262,7 +276,7 @@ class GoogleSheets:
         sheet.update_cells(cells, value_input_option=value_input_option)
         logger.info(f'Appended {table.num_rows} rows to worksheet.')
 
-    def overwrite_sheet(self, spreadsheet_id, table, worksheet=0, user_entered_value=False, 
+    def overwrite_sheet(self, spreadsheet_id, table, worksheet=0, user_entered_value=False,
                         **kwargs):
         """
         Replace the data in a Google sheet with a Parsons table, using the table's columns as the
@@ -285,7 +299,7 @@ class GoogleSheets:
         try:
             worksheet = kwargs['sheet_index']
             logger.warning('Argument deprecated. Use worksheet instead.')
-        except:
+        except:  # noqa: E722
             pass
 
         sheet = self._get_worksheet(spreadsheet_id, worksheet)

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -262,7 +262,8 @@ class GoogleSheets:
         sheet.update_cells(cells, value_input_option=value_input_option)
         logger.info(f'Appended {table.num_rows} rows to worksheet.')
 
-    def overwrite_sheet(self, spreadsheet_id, table, worksheet=0, user_entered_value=False):
+    def overwrite_sheet(self, spreadsheet_id, table, worksheet=0, user_entered_value=False, 
+                        **kwargs):
         """
         Replace the data in a Google sheet with a Parsons table, using the table's columns as the
         first row.

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -90,8 +90,8 @@ class GoogleSheets:
             spreadsheet_id: str
                 The ID of the spreadsheet (Tip: Get this from the spreadsheet URL)
             worksheet: str or int
-                The index or the title of the worksheet. Defaults to first
-                sheet in the index.
+                The index or the title of the worksheet. The index begins with
+                0.
         `Returns:`
             Parsons Table
                 See :ref:`parsons-table` for output options.
@@ -221,9 +221,9 @@ class GoogleSheets:
                 The ID of the spreadsheet (Tip: Get this from the spreadsheet URL)
             table: obj
                 Parsons table
-            worksheet: str or int 
-                The index or the title of the worksheet. Defaults to first
-                sheet in the index.
+            worksheet: str or int
+                The index or the title of the worksheet. The index begins with
+                0.
             user_entered_value: bool (optional)
                 If True, will submit cell values as entered (required for entering formulas).
                 Otherwise, values will be entered as strings or numbers only.
@@ -264,9 +264,9 @@ class GoogleSheets:
                 The ID of the spreadsheet (Tip: Get this from the spreadsheet URL)
             table: obj
                 Parsons table
-            worksheet: str or int 
-                The index or the title of the worksheet. Defaults to first
-                sheet in the index.
+            worksheet: str or int
+                The index or the title of the worksheet. The index begins with
+                0.
             user_entered_value: bool (optional)
                 If True, will submit cell values as entered (required for entering formulas).
                 Otherwise, values will be entered as strings or numbers only.
@@ -302,7 +302,7 @@ class GoogleSheets:
         # Deprecated method v0.14 of Parsons.
 
         logger.warning('Deprecated method. Use get_worksheet() instead.')
-        return self._get_worksheet(spreadsheet_id, title)
+        return self.get_worksheet(spreadsheet_id, title)
 
     def get_sheet_index_with_title(self, spreadsheet_id, title):
         # Deprecated method v0.14 of Parsons.

--- a/test/test_google/test_google_sheets.py
+++ b/test/test_google/test_google_sheets.py
@@ -14,7 +14,7 @@ class TestGoogleSheets(unittest.TestCase):
 
         self.google_sheets = GoogleSheets()
 
-        self.spreadsheet_id = self.google_sheets.create_spreadsheet('Parsons Test')
+        self.spreadsheet_id = self.google_sheets.create_spreadsheet('parsons_test_01')
         self.test_table = Table([
             {'first': 'Bob', 'last': 'Smith'},
             {'first': 'Sue', 'last': 'Doe'},
@@ -29,10 +29,19 @@ class TestGoogleSheets(unittest.TestCase):
         ])
         self.google_sheets.overwrite_sheet(self.spreadsheet_id, self.second_test_table, 1)
 
+
     def tearDown(self):
-        self.google_sheets.delete_spreadsheet(self.spreadsheet_id)
+        # self.google_sheets.delete_spreadsheet(self.spreadsheet_id)
+        pass
+
+    def test_read_worksheet(self):
+        # This is the spreadsheet called "Legislators 2017 (Test sheet for Parsons)"
+        table = self.google_sheets.get_worksheet('1Y_pZxz-8JZ9QBdq1pXuIk2js_VXeymOUoZhUp1JVEg8')
+        self.assertEqual(541, table.num_rows)
 
     def test_read_sheet(self):
+        # Deprecated in Parsons v0.14
+
         # This is the spreadsheet called "Legislators 2017 (Test sheet for Parsons)"
         table = self.google_sheets.read_sheet('1Y_pZxz-8JZ9QBdq1pXuIk2js_VXeymOUoZhUp1JVEg8')
         self.assertEqual(541, table.num_rows)
@@ -58,8 +67,8 @@ class TestGoogleSheets(unittest.TestCase):
             self.google_sheets.get_sheet_index_with_title, self.spreadsheet_id, 'abc123'
             )
 
-    def test_read_sheet_with_title(self):
-        table = self.google_sheets.read_sheet_with_title(self.spreadsheet_id, self.second_sheet_title)
+    def test_read_worksheet_with_title(self):
+        table = self.google_sheets.get_worksheet(self.spreadsheet_id, self.second_sheet_title)
         self.assertEqual(self.second_test_table.columns, table.columns)
 
     def test_append_to_spreadsheet(self):
@@ -122,7 +131,7 @@ class TestGoogleSheets(unittest.TestCase):
             self.assertEqual(new_table.data[i], result_table.data[i])
 
     def test_share_spreadsheet(self):
-        # Teat that sharing of spreadsheet works as intended.
+        # Test that sharing of spreadsheet works as intended.
 
         self.google_sheets.share_spreadsheet(self.spreadsheet_id, 'bob@bob.com', role='reader', notify=True)
         permissions = self.google_sheets.get_spreadsheet_permissions(self.spreadsheet_id)

--- a/test/test_google/test_google_sheets.py
+++ b/test/test_google/test_google_sheets.py
@@ -116,7 +116,6 @@ class TestGoogleSheets(unittest.TestCase):
         self.assertEqual(formula_vals[1], 'Budapest')
 
     def test_overwrite_spreadsheet(self):
-        # BROKEN TEST!
         new_table = Table([
             {'city': 'San Francisco', 'state': 'CA'},
             {'city': 'Miami', 'state': 'FL'},


### PR DESCRIPTION
This PR does some significant refactoring to the GoogleSheets class and reflects new patterns developed since that time. 

- Previously, there were separate methods to read worksheets, depending on whether you passed the worksheet index or the title of the worksheet. The methods have now been combined and it determines whether it is a title of an index based on the value passed.

- The old methods have been removed from the documentation, but still exist and throw a deprecation warning in the log.

- Adds ``**kwargs`` to a few methods to make them backward compatible.

- Renames some methods that referred to worksheets as `sheets`, which could easily be confused with `spreadsheets`. 

- Adds a method `list_worksheets()` that returns a list of worksheets in a given spreadsheet.
