### PR TITLE
materialize_to_file method

### DIFF
--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -78,6 +78,13 @@ class TestParsonsTable(unittest.TestCase):
 
         assert_matching_tables(self.tbl, tbl_materialized)
 
+    def test_materialize_to_file(self):
+        # Simple test that materializing doesn't change the table
+        tbl_materialized = Table(self.lst_dicts)
+        tbl_materialized.materialize_to_file()
+
+        assert_matching_tables(self.tbl, tbl_materialized)
+
     def test_empty_column(self):
         # Test that returns True on an empty column and False on a populated one.
 


### PR DESCRIPTION
This commit adds the `materialize_to_file` method, which allows
a user to apply any pending transformations to a table. The table
data is written to a temp file, which overcomes a limitation of
the current `materialize` method, which requires loading all of
the data from the table into memory.