### PR TITLE
phone2action: handle empty advocates results

### DIFF
--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -78,6 +78,10 @@ class Table(ETL, ToFrom):
 
             raise TypeError('You must pass a string or an index as a value.')
 
+    def __bool__(self):
+
+        return self.num_rows > 0
+
     def _repr_html_(self):
         """
         Leverage Petl functionality to display well formatted tables in Jupyter Notebook.

--- a/parsons/phone2action/p2a.py
+++ b/parsons/phone2action/p2a.py
@@ -103,7 +103,18 @@ class Phone2Action(object):
     def _advocates_tables(self, tbl):
         # Convert the advocates nested table into multiple tables
 
-        tbls = {}
+        tbls = {
+            'advocates': tbl,
+            'emails': Table(),
+            'phones': Table(),
+            'memberships': Table(),
+            'tags': Table(),
+            'ids': Table(),
+            'fields': Table(),
+        }
+
+        if not tbl:
+            return tbls
 
         logger.info(f'Retrieved {tbl.num_rows} advocates...')
 
@@ -114,11 +125,9 @@ class Phone2Action(object):
             tbl.unpack_dict(c)
 
         # Unpack all of the arrays
-        for c in ['emails', 'phones', 'memberships', 'tags', 'ids', 'fields']:
+        child_tables = [child for child in tbls.keys() if child != 'advocates']
+        for c in child_tables:
             tbls[c] = tbl.long_table(['id'], c, key_rename={'id': 'advocate_id'})
-
-        # Add to tbls list
-        tbls['advocates'] = tbl
 
         return tbls
 

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -747,3 +747,10 @@ class TestParsonsTable(unittest.TestCase):
         new_tbl = tbl.set_header(['one'])
 
         self.assertEqual(new_tbl[0], {'one': 1})
+
+    def test_bool(self):
+        empty = Table()
+        not_empty = Table([{'one': 1, 'two': 2}])
+
+        self.assertEqual(not empty, True)
+        self.assertEqual(not not_empty, False)

--- a/test/test_p2a.py
+++ b/test/test_p2a.py
@@ -175,7 +175,7 @@ class TestP2A(unittest.TestCase):
         self.assertTrue(validate_list(fields_exp, self.p2a.get_advocates()['fields']))
 
     @requests_mock.Mocker()
-    def test_get_advocates(self, m):
+    def test_get_advocates__by_page(self, m):
 
         response = copy.deepcopy(adv_json)
         # Make it look like there's more data
@@ -185,7 +185,20 @@ class TestP2A(unittest.TestCase):
         m.get(self.p2a.uri + 'advocates?page=2', exc=Exception('Should only call once'))
 
         results = self.p2a.get_advocates(page=1)
-        self.assertTrue(len(results), 1)
+        self.assertTrue(results['advocates'].num_rows, 1)
+
+    @requests_mock.Mocker()
+    def test_get_advocates__empty(self, m):
+
+        response = copy.deepcopy(adv_json)
+        response['data'] = []
+        # Make it look like there's more data
+        response['pagination']['count'] = 0
+
+        m.get(self.p2a.uri + 'advocates', json=adv_json)
+
+        results = self.p2a.get_advocates()
+        self.assertTrue(results['advocates'].num_rows, 0)
 
     @requests_mock.Mocker()
     def test_get_campaigns(self, m):


### PR DESCRIPTION
This commit updates the `Phone2Action` connector to handle an
empty list from the call to the advocates endpoint on the P2A API.
Before the commit, the call to get advocates was failing when
trying to unpack the advocates data.

This commit also adds the `__bool__` magic method to the Parsons
`Table` class to support simple bool checks on the emptiness of
a table (e.g. `if not tbl:` instead of `if tbl.num_rows > 0`)