### PR TITLE
Redshift upsert: auto resize column widths if necessary

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -704,7 +704,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             self.copy(table_obj, target_table)
             return None
 
-        # Make target table column width line up with incoming table, if needed
+        # Make target table column widths match incoming table, if necessary
         self.alter_varchar_column_widths(table_obj, target_table)
 
         noise = f'{random.randrange(0, 10000):04}'[:4]

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -704,6 +704,9 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             self.copy(table_obj, target_table)
             return None
 
+        # Make target table column width line up with incoming table, if needed
+        self.alter_varchar_column_widths(table_obj, target_table)
+
         noise = f'{random.randrange(0, 10000):04}'[:4]
         date_stamp = datetime.datetime.now().strftime('%Y%m%d_%H%M')
         # Generate a temp table like "table_tmp_20200210_1230_14212"


### PR DESCRIPTION
Resolves #250. Resizes the target table columns in Redshift based on the incoming Parsons table before creating the staging table in Redshift, so that when the staging table is created it already is at the correct column widths. This also means that an upsert will sometimes error out earlier if the incoming table doesn't match the columns of the target table, a side effect that could save some processing time on failed upserts.