### PR TITLE
Hot Fix: Fix Offset Code in DB Sync

### DIFF
--- a/parsons/databases/table.py
+++ b/parsons/databases/table.py
@@ -80,7 +80,7 @@ class BaseTable:
         if chunk_size:
             sql += f" LIMIT {chunk_size}"
 
-        sql += " OFFSET {offset}"
+        sql += f" OFFSET {offset}"
 
         return self.db.query(sql)
 


### PR DESCRIPTION
Was missing an "f" string and thus, failing.