### PR TITLE
Fix broken links in useful_resources

### DIFF
--- a/useful_resources/README.md
+++ b/useful_resources/README.md
@@ -14,10 +14,8 @@ Text that appears like this `pwd` (appears surrounded by \` in the raw markdown)
 
 * [Terminal Setup](./computer_setup/terminal_app_setup.md) - Create a bash
   profile and customize how your terminal looks.
-* [Python 3 Setup](./computer_setup/python_setup.md) - Install Python 3 on your
+* [Python 3 Setup](./computer_setup/python3_setup.md) - Install Python 3 on your
   computer
-* [Local Development Setup](./computer_setup/local_dev_setup.md) - Download and
-  install common packages that we use.
 
 
 ## Tools


### PR DESCRIPTION
Fixes the broken link to Python 3 Setup and removes the link to Local Development Setup since it looks like that file was removed. Let me know if anything looks off, thanks!