### PR TITLE
Add Azure Blob Storage connector

### DIFF
--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -1,0 +1,74 @@
+Azure
+======
+
+************
+Blob Storage
+************
+
+========
+Overview
+========
+Azure Blob Storage is a cloud file storage system. It uses storage accounts to organize containers (similar to
+"buckets" for other storage providers) in which to store arbitrary files referred to as blobs.
+
+This connector currently only implements block blobs and not page or append blobs.
+
+==========
+Quickstart
+==========
+
+**List containers and blobs**
+
+.. code-block:: python
+
+  from parsons import AzureBlobStorage
+
+  azure_blob = AzureBlobStorage()
+
+  # Get all container names for a storage account
+  container_names = azure_blob.list_containers()
+
+  # Get all blob names for a storage account and container
+  blob_names = azure_blob.list_blobs(container_names[0])
+
+
+**Create a blob from a file or ``Table``**
+
+.. code-block:: python
+
+  from parsons import AzureBlobStorage, Table
+
+  azure_blob = AzureBlobStorage()
+
+  container_name = 'testcontainer'
+
+  # Upload a CSV file from a local file path and set the content type
+  azure_blob.put_blob(container_name, 'test1.csv', './test1.csv', content_type='text/csv')
+
+  # Create a Table and upload it as a JSON blob
+  table = Table([{'first': 'Test', 'last': 'Person'}])
+  azure_blob.upload_table(table, container_name, 'test2.json', data_type='json')
+
+
+**Download a blob**
+
+.. code-block:: python
+
+  from parsons import AzureBlobStorage
+
+  azure_blob = AzureBlobStorage()
+
+  container_name = 'testcontainer'
+
+  # Download to a temporary file path
+  temp_file_path = azure_blob.download_blob(container_name, 'test.csv')
+
+  # Download to a specific file path
+  azure_blob.download_blob(container_name, 'test.csv', local_path='/tmp/test.csv')
+
+
+===
+API
+===
+.. autoclass:: parsons.AzureBlobStorage
+   :inherited-members:

--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -1,5 +1,5 @@
 Azure
-======
+=====
 
 ************
 Blob Storage
@@ -12,6 +12,11 @@ Azure Blob Storage is a cloud file storage system. It uses storage accounts to o
 "buckets" for other storage providers) in which to store arbitrary files referred to as blobs.
 
 This connector currently only implements block blobs and not page or append blobs.
+
+You'll need credentials for an Azure Blob Storage storage account to use this connector. The ``azure-storage-blob``
+library is used for this connector, and `examples of how to create and use multiple types of credentials
+<https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/storage/azure-storage-blob#types-of-credentials>`_
+are included in the documentation.
 
 ==========
 Quickstart

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -169,6 +169,7 @@ Indices and tables
    action_network
    airtable
    aws
+   azure
    bill_com
    braintree
    civis

--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -45,6 +45,7 @@ if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
     from parsons.zoom.zoom import Zoom
     from parsons.action_network.action_network import ActionNetwork
     from parsons.pdi.pdi import PDI
+    from parsons.azure.azure_blob_storage import AzureBlobStorage
 
     __all__ = [
         'VAN',
@@ -84,6 +85,7 @@ if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
         'Zoom',
         'ActionNetwork',
         'PDI',
+        'AzureBlobStorage',
     ]
 
 # Define the default logging config for Parsons and its submodules. For now the

--- a/parsons/azure/__init__.py
+++ b/parsons/azure/__init__.py
@@ -1,0 +1,5 @@
+from parsons.azure.azure_blob_storage import AzureBlobStorage
+
+__all__ = [
+    'AzureBlobStorage'
+]

--- a/parsons/azure/azure_blob_storage.py
+++ b/parsons/azure/azure_blob_storage.py
@@ -35,11 +35,11 @@ class AzureBlobStorage(object):
 
     def __init__(self, account_name=None, credential=None, account_domain='blob.core.windows.net',
                  account_url=None):
-        self.account_name = check_env.check('AZURE_ACCOUNT_NAME', account_name)
-        self.credential = check_env.check('AZURE_CREDENTIAL', credential)
-        self.account_domain = check_env.check('AZURE_ACCOUNT_DOMAIN', account_domain)
         self.account_url = os.getenv('AZURE_ACCOUNT_URL', account_url)
+        self.credential = check_env.check('AZURE_CREDENTIAL', credential)
         if not self.account_url:
+            self.account_name = check_env.check('AZURE_ACCOUNT_NAME', account_name)
+            self.account_domain = check_env.check('AZURE_ACCOUNT_DOMAIN', account_domain)
             self.account_url = f'https://{self.account_name}.{self.account_domain}/'
         else:
             if not self.account_url.startswith('http'):

--- a/parsons/azure/azure_blob_storage.py
+++ b/parsons/azure/azure_blob_storage.py
@@ -1,0 +1,390 @@
+import logging
+import os
+from urllib.parse import urlparse
+
+from azure.core.exceptions import ResourceNotFoundError
+from azure.storage.blob import BlobServiceClient, ContentSettings, generate_blob_sas
+
+from parsons.utilities import check_env, files
+
+logger = logging.getLogger(__name__)
+
+
+class AzureBlobStorage(object):
+    """
+    Instantiate AzureBlobStorage Class for a given Azure storage account.
+
+    `Args:`
+        account_name: str
+            The name of the Azure storage account to use. Not required if ``AZURE_ACCOUNT_NAME``
+            environment variable is set, or if ``account_url`` is supplied.
+        credential: str
+            An account shared access key with access to the Azure storage account, an SAS token
+            string, or an instance of a TokenCredentials class. Not required if ``AZURE_CREDENTIAL``
+            environment variable is set.
+        account_domain: str
+            The domain of the Azure storage account, defaults to "blob.core.windows.net".
+            Not required if ``AZURE_ACCOUNT_DOMAIN`` environment variable is set or if
+            ``account_url`` is supplied.
+        account_url: str
+            The account URL for the Azure storage account including the account name and domain.
+            Not required if ``AZURE_ACCOUNT_URL`` environment variable is set.
+    `Returns:`
+        `AzureBlobStorage`
+    """
+
+    def __init__(self, account_name=None, credential=None, account_domain='blob.core.windows.net',
+                 account_url=None):
+        self.account_name = check_env.check('AZURE_ACCOUNT_NAME', account_name)
+        self.credential = check_env.check('AZURE_CREDENTIAL', credential)
+        self.account_domain = check_env.check('AZURE_ACCOUNT_DOMAIN', account_domain)
+        self.account_url = os.getenv('AZURE_ACCOUNT_URL', account_url)
+        if not self.account_url:
+            self.account_url = f'https://{self.account_name}.{self.account_domain}/'
+        else:
+            if not self.account_url.startswith('http'):
+                self.account_url = f'https://{self.account_url}'
+            # Update the account name and domain if a URL is supplied
+            parsed_url = urlparse(self.account_url)
+            self.account_name = parsed_url.netloc.split(".")[0]
+            self.account_domain = ".".join(parsed_url.netloc.split(".")[1:])
+        self.client = BlobServiceClient(account_url=self.account_url, credential=self.credential)
+
+    def list_containers(self):
+        """
+        Returns a list of container names for the storage account
+
+        `Returns:`
+            list[str]
+                List of container names
+        """
+
+        container_names = [container.name for container in self.client.list_containers()]
+        logger.info(f'Found {len(container_names)} containers.')
+        return container_names
+
+    def container_exists(self, container_name):
+        """
+        Verify that a container exists within the storage account
+
+        `Args:`
+            container_name: str
+                The name of the container
+        `Returns:`
+            bool
+        """
+
+        container_client = self.get_container(container_name)
+        try:
+            container_client.get_container_properties()
+            logger.info(f'{container_name} exists.')
+            return True
+        except ResourceNotFoundError:
+            logger.info(f'{container_name} does not exist.')
+            return False
+
+    def get_container(self, container_name):
+        """
+        Returns a container client
+
+        `Args:`
+            container_name: str
+                The name of the container
+        `Returns:`
+            `ContainerClient`
+        """
+
+        logger.info(f'Returning {container_name} container client')
+        return self.client.get_container_client(container_name)
+
+    def create_container(self, container_name, metadata=None, public_access=None, **kwargs):
+        """
+        Create a container
+
+        `Args:`
+            container_name: str
+                The name of the container
+            metadata: Optional[dict[str, str]]
+                A dict with metadata to associated with the container.
+            public_access: Optional[Union[PublicAccess, str]]
+                Settings for public access on the container, can be 'container' or 'blob' if not
+                ``None``
+            kwargs:
+                Additional arguments to be supplied to the Azure Blob Storage API. See `Azure Blob
+                Storage SDK documentation <https://docs.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.blobserviceclient?view=azure-python#create-container-name--metadata-none--public-access-none----kwargs->`_
+                for more info.
+        `Returns:`
+            `ContainerClient`
+        """  # noqa
+
+        container_client = self.client.create_container(
+            container_name, metadata=metadata, public_access=public_access, **kwargs
+        )
+        logger.info(f'Created {container_name} container.')
+        return container_client
+
+    def delete_container(self, container_name):
+        """
+        Delete a container.
+
+        `Args:`
+            container_name: str
+                The name of the container
+        `Returns:`
+            ``None``
+        """
+
+        self.client.delete_container(container_name)
+        logger.info(f'{container_name} container deleted.')
+
+    def list_blobs(self, container_name, name_starts_with=None):
+        """
+        List all of the names of blobs in a container
+
+        `Args:`
+            container_name: str
+                The name of the container
+            name_starts_with: Optional[str]
+                A prefix to filter blob names
+        `Returns:`
+            list[str]
+                A list of blob names
+        """
+
+        container_client = self.get_container(container_name)
+        blob_names = [
+            blob.name for blob in container_client.list_blobs(name_starts_with=name_starts_with)
+        ]
+        logger.info(f'Found {len(blob_names)} blobs in {container_name} container.')
+        return blob_names
+
+    def blob_exists(self, container_name, blob_name):
+        """
+        Verify that a blob exists in the specified container
+
+        `Args:`
+            container_name: str
+                The container name
+            blob_name: str
+                The blob name
+        `Returns:`
+            bool
+        """
+
+        blob_client = self.get_blob(container_name, blob_name)
+        try:
+            blob_client.get_blob_properties()
+            logger.info(f'{blob_name} exists in {container_name} container.')
+            return True
+        except ResourceNotFoundError:
+            logger.info(f'{blob_name} does not exist in {container_name} container.')
+            return False
+
+    def get_blob(self, container_name, blob_name):
+        """
+        Get a blob object
+
+        `Args:`
+            container_name: str
+                The container name
+            blob_name: str
+                The blob name
+        `Returns:`
+            `BlobClient`
+        """
+
+        blob_client = self.client.get_blob_client(container_name, blob_name)
+        logger.info(f'Got {blob_name} blob from {container_name} container.')
+        return blob_client
+
+    def get_blob_url(self, container_name, blob_name, account_key=None, permission=None,
+                     expiry=None, start=None):
+        """
+        Get a URL with a shared access signature for a blob
+
+        `Args:`
+            container_name: str
+                The container name
+            blob_name: str
+                The blob name
+            account_key: Optional[str]
+                An account shared access key for the storage account. Will default to the key used
+                on initialization if one was provided as the credential, but required if it was not.
+            permission: Optional[Union[BlobSasPermissions, str]]
+                Permissions associated with the blob URL. Can be either a BlobSasPermissions object
+                or a string where 'r', 'a', 'c', 'w', and 'd' correspond to read, add, create,
+                write, and delete permissions respectively.
+            expiry: Optional[Union[datetime, str]]
+                The datetime when the URL should expire. Defaults to UTC.
+            start: Optional[Union[datetime, str]]
+                The datetime when the URL should become valid. Defaults to UTC. If it is ``None``,
+                the URL becomes active when it is first created.
+        `Returns:`
+            str
+                URL with shared access signature for blob
+        """
+
+        if not account_key:
+            if not self.credential:
+                raise ValueError(
+                    f'An account shared access key must be provided if it was not on initialization'
+                )
+            account_key = self.credential
+
+        sas = generate_blob_sas(
+            self.account_name,
+            container_name,
+            blob_name,
+            account_key=account_key,
+            permission=permission,
+            expiry=expiry,
+            start=start,
+        )
+        return f'{self.account_url}/{container_name}/{blob_name}?sas={sas}'
+
+    def _get_content_settings_from_dict(self, kwargs_dict):
+        """
+        Removes any keys for ``ContentSettings`` from a dict and returns a tuple of the generated
+        settings or ``None`` and a dict with the settings keys removed.
+
+        `Args:`
+            kwargs_dict: dict
+                A dict which should be processed and may have keys for ``ContentSettings``
+        `Returns:`
+            Tuple[Optional[ContentSettings], dict]
+                Any created settings or ``None`` and the dict with settings keys remvoed
+        """
+
+        kwargs_copy = {**kwargs_dict}
+        content_settings = None
+        content_settings_dict = {}
+        content_settings_keys = [
+            'content_type', 'content_encoding', 'content_language', 'content_disposition',
+            'cache_control', 'content_md5'
+        ]
+        kwarg_keys = list(kwargs_copy.keys())
+        for key in kwarg_keys:
+            if key in content_settings_keys:
+                content_settings_dict[key] = kwargs_copy.pop(key)
+        if content_settings_dict:
+            content_settings = ContentSettings(**content_settings_dict)
+
+        return content_settings, kwargs_copy
+
+    def put_blob(self, container_name, blob_name, local_path, **kwargs):
+        """
+        Puts a blob (aka file) in a bucket
+
+        `Args:`
+            container_name: str
+                The name of the container to store the blob
+            blob_name: str
+                The name of the blob to be stored
+            local_path: str
+                The local path of the file to upload
+            kwargs:
+                Additional arguments to be supplied to the Azure Blob Storage API. See `Azure Blob
+                Storage SDK documentation <https://docs.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.blobclient?view=azure-python#upload-blob-data--blob-type--blobtype-blockblob---blockblob----length-none--metadata-none----kwargs->`_
+                for more info. Any keys that belong to the ``ContentSettings`` object will be
+                provided to that class directly.
+        `Returns:`
+            `BlobClient`
+        """  # noqa
+
+        blob_client = self.get_blob(container_name, blob_name)
+
+        # Move all content_settings keys into a ContentSettings object
+        content_settings, kwargs_dict = self._get_content_settings_from_dict(kwargs)
+
+        with open(local_path, 'rb') as f:
+            data = f.read()
+
+        blob_client = blob_client.upload_blob(
+            data,
+            overwrite=True,
+            content_settings=content_settings,
+            **kwargs_dict,
+        )
+        logger.info(f'{blob_name} blob put in {container_name} container')
+
+        # Return refreshed BlobClient object
+        return self.get_blob(container_name, blob_name)
+
+    def download_blob(self, container_name, blob_name, local_path=None):
+        """
+        Downloads a blob from a container into the specified file path or a temporary file path
+
+        `Args:`
+            container_name: str
+                The container name
+            blob_name: str
+                The blob name
+            local_path: Optional[str]
+                The local path where the file will be downloaded. If not specified, a temporary
+                file will be created and returned, and that file will be removed automatically
+                when the script is done running.
+        `Returns:`
+            str
+                The path of the downloaded file
+        """
+
+        if not local_path:
+            local_path = files.create_temp_file_for_path('TEMPFILEAZURE')
+
+        blob_client = self.get_blob(container_name, blob_name)
+
+        logger.info(f'Downloading {blob_name} blob from {container_name} container.')
+        with open(local_path, 'wb') as f:
+            blob_client.download_blob().readinto(f)
+        logger.info(f'{blob_name} blob saved to {local_path}.')
+
+        return local_path
+
+    def delete_blob(self, container_name, blob_name):
+        """
+        Delete a blob in a specified container.
+
+        `Args:`
+            container_name: str
+                The container name
+            blob_name: str
+                The blob name
+        `Returns:`
+            ``None``
+        """
+
+        blob_client = self.get_blob(container_name, blob_name)
+        blob_client.delete_blob()
+        logger.info(f'{blob_name} blob in {container_name} container deleted.')
+
+    def upload_table(self, table, container_name, blob_name, data_type='csv', **kwargs):
+        """
+        Load the data from a Parsons table into a blob.
+
+        `Args:`
+            table: obj
+                A :ref:`parsons-table`
+            container_name: str
+                The container name to upload the data into
+            blob_name: str
+                The blob name to upload the data into
+            data_type: str
+                The file format to use when writing the data. One of: `csv` or `json`
+            kwargs:
+                Additional keyword arguments to supply to ``put_blob``
+        `Returns:`
+            `BlobClient`
+        """
+
+        if data_type == 'csv':
+            local_path = table.to_csv()
+            content_type = 'text/csv'
+        elif data_type == 'json':
+            local_path = table.to_json()
+            content_type = 'application/json'
+        else:
+            raise ValueError(f'Unknown data_type value ({data_type}): must be one of: csv or json')
+
+        return self.put_blob(
+            container_name, blob_name, local_path, content_type=content_type, **kwargs
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ newmode==0.1.6
 mysql-connector-python==8.0.18
 braintree==4.0.0
 python-dateutil==2.8.1
+azure-storage-blob==12.3.2
 
 # Testing Requirements
 requests-mock==1.5.2

--- a/test/test_azure/test_azure_blob_storage.py
+++ b/test/test_azure/test_azure_blob_storage.py
@@ -1,0 +1,165 @@
+import os
+import unittest
+from datetime import datetime
+from urllib.parse import parse_qs, urlparse
+
+from azure.storage.blob import BlobClient, ContainerClient
+
+from parsons.azure import AzureBlobStorage
+from parsons.etl import Table
+from parsons.utilities import files
+
+
+TEST_ACCOUNT_NAME = os.getenv('PARSONS_AZURE_ACCOUNT_NAME')
+TEST_CREDENTIAL = os.getenv('PARSONS_AZURE_CREDENTIAL')
+TEST_CONTAINER_NAME = os.getenv('PARSONS_AZURE_CONTAINER_NAME')
+TEST_FILE_NAME = 'tmp_file_01.txt'
+TEST_FILE_CONTENTS = 'Test'
+
+
+@unittest.skipIf(not os.getenv('LIVE_TEST'), 'Skipping because not running live test')
+class TestAzureBlobStorage(unittest.TestCase):
+    def setUp(self):
+
+        self.azure_blob = AzureBlobStorage(
+            account_name=TEST_ACCOUNT_NAME, credential=TEST_CREDENTIAL
+        )
+
+        # Create the container if it does not exist already
+        if not self.azure_blob.container_exists(TEST_CONTAINER_NAME):
+            self.azure_blob.create_container(TEST_CONTAINER_NAME)
+
+        # Create blob if it doesn't exist already
+        if not self.azure_blob.blob_exists(TEST_CONTAINER_NAME, TEST_FILE_NAME):
+            tmp_file_path = files.string_to_temp_file(TEST_FILE_CONTENTS, suffix='.txt')
+            self.azure_blob.put_blob(TEST_CONTAINER_NAME, TEST_FILE_NAME, tmp_file_path)
+
+    def test_list_containers(self):
+
+        # Make sure container created in setup is in the list
+        container_list = self.azure_blob.list_containers()
+        self.assertIn(TEST_CONTAINER_NAME, container_list)
+
+    def test_container_exists(self):
+
+        # Assert that setup container exists
+        self.assertTrue(self.azure_blob.container_exists(TEST_CONTAINER_NAME))
+
+        # Assert that invalid bucket does not exists
+        self.assertFalse(self.azure_blob.container_exists('fakecontainer'))
+
+    def test_get_container(self):
+
+        # Assert that a ContainerClient object is returned
+        self.assertIsInstance(self.azure_blob.get_container(TEST_CONTAINER_NAME), ContainerClient)
+
+    def test_create_container(self):
+
+        # Assert that container created in setup exists
+        self.assertTrue(self.azure_blob.container_exists(TEST_CONTAINER_NAME))
+
+        # Add current datetime microseconds for randomness to avoid intermittent failures
+        dt_microseconds = datetime.now().isoformat()[-6:]
+        create_container_name = f'{TEST_CONTAINER_NAME}create{dt_microseconds}'
+
+        # Create a new container with metadata, assert that it is included
+        create_container = self.azure_blob.create_container(
+            create_container_name, metadata={'testing': 'parsons'}
+        )
+        create_container_properties = create_container.get_container_properties()
+        self.assertIn('testing', create_container_properties.metadata)
+
+        # Delete the container after the assertion
+        self.azure_blob.delete_container(create_container_name)
+
+    def test_delete_container(self):
+
+        # Add current datetime microseconds for randomness to avoid intermittent failures
+        dt_microseconds = datetime.now().isoformat()[-6:]
+        delete_container_name = f'{TEST_CONTAINER_NAME}delete{dt_microseconds}'
+
+        # Create an additional container, assert that it exists
+        self.azure_blob.create_container(delete_container_name)
+        self.assertTrue(self.azure_blob.container_exists(delete_container_name))
+
+        # Then delete the container and assert it does not exist
+        self.azure_blob.delete_container(delete_container_name)
+        self.assertFalse(self.azure_blob.container_exists(delete_container_name))
+
+    def test_list_blobs(self):
+
+        blob_name_list = self.azure_blob.list_blobs(TEST_CONTAINER_NAME)
+
+        # Assert that file created in setup is in the list
+        self.assertIn(TEST_FILE_NAME, blob_name_list)
+
+    def test_blob_exists(self):
+
+        # Assert that blob created in setup exists
+        self.assertTrue(self.azure_blob.blob_exists(TEST_CONTAINER_NAME, TEST_FILE_NAME))
+
+        # Assert that invalid blob does not exist
+        self.assertFalse(self.azure_blob.blob_exists(TEST_CONTAINER_NAME, 'FAKE_BLOB'))
+
+    def test_get_blob(self):
+
+        # Assert that get_blob returns a BlobClient object for blob created in setup
+        self.assertIsInstance(
+            self.azure_blob.get_blob(TEST_CONTAINER_NAME, TEST_FILE_NAME), BlobClient
+        )
+
+    def test_get_blob_url(self):
+
+        # Assert that get_blob_url returns a URL with a shared access signature
+        blob_url = self.azure_blob.get_blob_url(TEST_CONTAINER_NAME, TEST_FILE_NAME, permission='r')
+        parsed_blob_url = urlparse(blob_url)
+        parsed_blob_query = parse_qs(parsed_blob_url.query)
+        self.assertIn('sas', parsed_blob_query)
+
+    def test_put_blob(self):
+
+        # Assert that put_blob returns a BlobClient object
+        put_blob_name = 'tmp_file_put.txt'
+        tmp_file_path = files.string_to_temp_file('Test', suffix='.txt')
+
+        put_blob_client = self.azure_blob.put_blob(
+            TEST_CONTAINER_NAME, put_blob_name, tmp_file_path
+        )
+        self.assertIsInstance(put_blob_client, BlobClient)
+
+        self.azure_blob.delete_blob(TEST_CONTAINER_NAME, put_blob_name)
+
+    def test_download_blob(self):
+
+        # Download blob and ensure that it has the expected file contents
+        download_blob_path = self.azure_blob.download_blob(TEST_CONTAINER_NAME, TEST_FILE_NAME)
+        with open(download_blob_path, 'r') as f:
+            self.assertEqual(f.read(), TEST_FILE_CONTENTS)
+
+    def test_delete_blob(self):
+
+        delete_blob_name = 'delete_blob.txt'
+
+        # Upload a blob, assert that it exists
+        tmp_file_path = files.string_to_temp_file(TEST_FILE_CONTENTS, suffix='.txt')
+        self.azure_blob.put_blob(TEST_CONTAINER_NAME, delete_blob_name, tmp_file_path)
+        self.assertTrue(self.azure_blob.blob_exists(TEST_CONTAINER_NAME, delete_blob_name))
+
+        # Delete the blob, assert that it no longer exists
+        self.azure_blob.delete_blob(TEST_CONTAINER_NAME, delete_blob_name)
+        self.assertFalse(self.azure_blob.blob_exists(TEST_CONTAINER_NAME, delete_blob_name))
+
+    def test_upload_table(self):
+
+        test_table = Table([{'first': 'Test', 'last': 'Person'}])
+        test_table_blob_name = 'table.csv'
+
+        # Upload a test table as CSV, assert that blob is a CSV
+        table_blob_client = self.azure_blob.upload_table(
+            test_table, TEST_CONTAINER_NAME, test_table_blob_name, data_type='csv'
+        )
+        table_blob_client_properties = table_blob_client.get_blob_properties()
+        self.assertEqual(table_blob_client_properties.content_settings.content_type, 'text/csv')
+
+        # Remove blob after assertion
+        self.azure_blob.delete_blob(TEST_CONTAINER_NAME, test_table_blob_name)


### PR DESCRIPTION
Progress on #73 (might close if it was only intended for Azure storage). Adds a connector for Azure Blob Storage primarily based on the Google Cloud Storage connector, but also pulling a bit from the S3 connector.

Here are a few things in particular I'm interested in feedback on:

- I split out `AZURE_ACCOUNT_NAME` and `AZURE_ACCOUNT_DOMAIN` from `AZURE_ACCOUNT_URL` because the account domain is almost always the same thing, and I haven't seen as strong of conventions for environment variables for Azure storage as I've seen around S3
- The example code uses an access token for authentication, and I broadened that here to support any credential accepted by the `BlobServiceClient`
- As a way of enforcing stricter typing the Azure storage SDK has a lot of wrapper types for things like setting headers when uploading blobs. To make this a little easier to use in `put_blob`, I'm pulling out `kwargs` so that people people can supply `content_type=` as a keyword argument instead of importing the `ContentSettings` type, initializing it with `content_type`, and passing it to `put_blob` in the `content_settings` keyword argument. If that's wrapping the API too much though I can remove it

Feedback is welcome! I also wrote up some notes on the process of writing a connector for the first time that I'll share in the Slack