### PR TITLE
Redshift: Correctly pass S3 Credentials

### DIFF
--- a/parsons/databases/redshift/rs_copy_table.py
+++ b/parsons/databases/redshift/rs_copy_table.py
@@ -115,6 +115,10 @@ class RedshiftCopyTable(object):
                             "Must be specified as env vars or kwargs"
                             ))
 
+        # Coalesce S3 Key arguments
+        aws_access_key_id = aws_access_key_id or self.aws_access_key_id
+        aws_secret_access_key = aws_secret_access_key or self.aws_secret_access_key
+
         self.s3 = S3(aws_access_key_id=aws_access_key_id,
                      aws_secret_access_key=aws_secret_access_key)
 


### PR DESCRIPTION
Addresses #285 in which S3 credentials that were being passed via the construction of the Redshift class as kwargs were not actually being read.

Now Working:

```
rs = Redshift(..., aws_access_key_id='MyFakeID', aws_secret_access_key='MyFakeSecret')
rs.copy(tbl, 'schema.table')
```