### PR TITLE
Redshift + S3: Move Some Logging To DEBUG

### DIFF
--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -115,7 +115,7 @@ class S3(object):
         """
 
         keys_dict = dict()
-        logger.info(f'Fetching keys in {bucket} bucket')
+        logger.debug(f'Fetching keys in {bucket} bucket')
 
         continuation_token = None
 
@@ -158,7 +158,7 @@ class S3(object):
             else:
                 break
 
-        logger.info(f'Retrieved {len(keys_dict)} keys')
+        logger.debug(f'Retrieved {len(keys_dict)} keys')
         return keys_dict
 
     def key_exists(self, bucket, key):
@@ -178,10 +178,10 @@ class S3(object):
         key_count = len(self.list_keys(bucket, prefix=key))
 
         if key_count > 0:
-            logger.info(f'Found {key} in {bucket}.')
+            logger.debug(f'Found {key} in {bucket}.')
             return True
         else:
-            logger.info(f'Did not find {key} in {bucket}.')
+            logger.debug(f'Did not find {key} in {bucket}.')
             return False
 
     def create_bucket(self, bucket):

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -765,7 +765,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                        WHERE {where_clause}
                        """
                 self.query_with_connection(sql, connection, commit=False)
-                logger.info(f'Target rows deleted from {target_table}.')
+                logger.debug(f'Target rows deleted from {target_table}.')
 
                 # Insert rows
                 # ALTER TABLE APPEND would be more efficient, but you can't run it in a

--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -49,10 +49,10 @@ class RedshiftTableUtilities(object):
 
         # If in either, return boolean
         if result >= 1:
-            logger.info(f'{table_name[0]}.{table_name[1]} exists.')
+            logger.debug(f'{table_name[0]}.{table_name[1]} exists.')
             return True
         else:
-            logger.info(f'{table_name[0]}.{table_name[1]} does NOT exist.')
+            logger.debug(f'{table_name[0]}.{table_name[1]} does NOT exist.')
             return False
 
     def get_row_count(self, table_name):
@@ -170,7 +170,7 @@ class RedshiftTableUtilities(object):
 
         else:
             if exists and if_exists == 'drop':
-                logger.info(f"Table {table_name} exist, will drop...")
+                logger.debug(f"Table {table_name} exist, will drop...")
                 drop_sql = f"drop table {table_name};\n"
                 self.query_with_connection(drop_sql, connection, commit=False)
 


### PR DESCRIPTION
A first pass a moving a couple of table utility methods from `INFO` to `DEBUG`. This should reduce the size of our logs significantly.

@SorenSpicknall @eliotst - Anything else that we want to add to this PR? Just thread some ideas.