### PR TITLE
upgrade psycopg2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ petl==1.2.0
 boto3==1.9.25
 civis==1.11.0
 slackclient==1.3.0
-psycopg2-binary==2.7.6.1
+psycopg2-binary==2.8.5
 xmltodict==0.11.0
 gspread==3.3.0
 oauth2client==4.1.3


### PR DESCRIPTION
This commit updates the version of the `psycopg2-binary`
dependency for Parsons. THe update is necessary due to a
limitation in the old version (2.7.6) that caused it to not play
well with Python 3.8.

This fixes issues with installing Parsons on Python 3.8.