### PR TITLE
update civis and joblib for python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.20.0
 petl==1.2.0
 boto3==1.9.25
-civis==1.11.0
+civis==1.14.2
 slackclient==1.3.0
 psycopg2-binary==2.8.5
 xmltodict==0.11.0
@@ -14,7 +14,7 @@ httplib2==0.18.0
 validate-email==1.3
 paramiko==2.7.1
 xmltodict==0.11.0
-joblib==0.13
+joblib==0.14.1
 censusgeocode==0.4.3.post1
 airtable-python-wrapper==0.11.3.post1
 google-cloud-storage==1.17.0


### PR DESCRIPTION
This commit updates the versions of the civis and joblib
dependencies to ensure full support of Python 3.8.