### PR TITLE
add actionkit update events and signups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# PyCharm project settings
+.idea/*
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -152,6 +152,22 @@ class ActionKit(object):
         resp = self.conn.patch(self._base_endpoint('user', user_id), data=json.dumps(kwargs))
         logger.info(f'{resp.status_code}: {user_id}')
 
+    def update_event(self, event_id, **kwargs):
+        """
+        Update an event.
+
+        `Args:`
+            event_id: int
+                The event id of the event to update
+            event_dict: dict
+                A dictionary of fields to update for the event.
+        `Returns:`
+            ``None``
+        """
+
+        resp = self.conn.patch(self._base_endpoint('event', event_id), data=json.dumps(kwargs))
+        logger.info(f'{resp.status_code}: {event_id}')
+
     def delete_user(self, user_id):
         """
         Delete a user.
@@ -391,6 +407,23 @@ class ActionKit(object):
                                page=f'/rest/v1/page/{page_id}/',
                                thank_you_text=thank_you_text,
                                **kwargs)
+
+    def update_event_signup(self, event_signup_id, **kwargs):
+        """
+        Update an event signup.
+
+        `Args:`
+            event_signup_id: int
+                The id of the event signup to update
+            event_signup_dict: dict
+                A dictionary of fields to update for the event signup.
+        `Returns:`
+            ``None``
+        """
+
+        resp = self.conn.patch(self._base_endpoint('eventsignup', event_signup_id),
+                               data=json.dumps(kwargs))
+        logger.info(f'{resp.status_code}: {event_signup_id}')
 
     def get_page_followup(self, page_followup_id):
         """

--- a/test/test_action_kit.py
+++ b/test/test_action_kit.py
@@ -86,6 +86,19 @@ class TestActionKit(unittest.TestCase):
             data=json.dumps({'last_name': 'new name'})
         )
 
+    def test_update_event(self):
+        # Test update event
+
+        # Mock resp and status code
+        resp_mock = mock.MagicMock()
+        type(resp_mock.patch()).status_code = mock.PropertyMock(return_value=202)
+        self.actionkit.conn = resp_mock
+        self.actionkit.update_event(123, is_approved='test')
+        self.actionkit.conn.patch.assert_called_with(
+            'https://domain.actionkit.com/rest/v1/event/123/',
+            data=json.dumps({'is_approved': 'test'})
+        )
+
     def test_delete_user(self):
         # Test delete user
 
@@ -233,6 +246,19 @@ class TestActionKit(unittest.TestCase):
                 'page': '/rest/v1/page/123/',
                 'thank_you_text': 'thank you'
             })
+        )
+
+    def test_update_event_signup(self):
+        # Test update event signup
+
+        # Mock resp and status code
+        resp_mock = mock.MagicMock()
+        type(resp_mock.patch()).status_code = mock.PropertyMock(return_value=202)
+        self.actionkit.conn = resp_mock
+        self.actionkit.update_event_signup(123, email='test')
+        self.actionkit.conn.patch.assert_called_with(
+            'https://domain.actionkit.com/rest/v1/eventsignup/123/',
+            data=json.dumps({'email': 'test'})
         )
 
     def test_get_page_followup(self):


### PR DESCRIPTION
This PR adds two new methods:

`ActionKit.update_event()`
`ActionKit.update_event_signup()`

I also updated `.gitignore` to prevent tracking of PyCharm project files.

Issue addressed: #233 

All pytest tests passed.