### PR TITLE
Issue #269 update actionkit connector docs

### DIFF
--- a/docs/action_kit.rst
+++ b/docs/action_kit.rst
@@ -6,7 +6,7 @@ Overview
 ********
 
 `ActionKit <https://actionkit.com/>`_ is a platform for advocacy, fundraising, and
-get-out-the-vote. This parsons integration with the
+get-out-the-vote. This Parsons integration with the
 `ActionKit REST API <https://roboticdogs.actionkit.com/docs/manual/api/rest/overview.html>`_
 supports fetching, creating, and updating records of campaigns, events, and users.
 Bulk upload of new users and user updates is also supported.
@@ -23,8 +23,8 @@ Quickstart
 **********
 
 To instantiate the ActionKit class, you can either store your ActionKit API
-domain, username, and password as environmental variables (ACTION_KIT_DOMAIN,
-ACTION_KIT_USERNAME, and ACTION_KIT_PASSWORD, respectively) or pass in your
+domain, username, and password as environmental variables (``ACTION_KIT_DOMAIN``,
+``ACTION_KIT_USERNAME``, and ``ACTION_KIT_PASSWORD``, respectively) or pass in your
 domain, username, and password as arguments:
 
 .. code-block:: python

--- a/docs/action_kit.rst
+++ b/docs/action_kit.rst
@@ -32,7 +32,7 @@ domain, username, and password as arguments:
    from parsons import VAN
 
    # First approach: Specify DB type and pass API credentials via environmental variables
-   ak = ActionKit(db='MyVoters')
+   ak = ActionKit()
 
    # Second approach: Pass API credentials as arguments
    ak = ActionKit(domain='myorg.actionkit.com', username='my_name', password='1234')

--- a/docs/action_kit.rst
+++ b/docs/action_kit.rst
@@ -31,7 +31,7 @@ domain, username, and password as arguments:
 
    from parsons import VAN
 
-   # First approach: Specify DB type and pass API credentials via environmental variables
+   # First approach: Use API credentials via environmental variables
    ak = ActionKit()
 
    # Second approach: Pass API credentials as arguments

--- a/docs/action_kit.rst
+++ b/docs/action_kit.rst
@@ -5,19 +5,53 @@ ActionKit
 Overview
 ********
 
-The ActionKit class allows you to interact with an `ActionKit <https://actionkit.com/>`_.
+`ActionKit <https://actionkit.com/>`_ is a platform for advocacy, fundraising, and
+get-out-the-vote. This parsons integration with the
+`ActionKit REST API <https://roboticdogs.actionkit.com/docs/manual/api/rest/overview.html>`_
+supports fetching, creating, and updating records of campaigns, events, and users.
+Bulk upload of new users and user updates is also supported.
+
+.. note::
+  Authentication
+    ActionKit requires `HTTP Basic Auth <https://en.wikipedia.org/wiki/Basic_access_authentication>`_.
+    Clients with an ActionKit account can obtain the domain, username, and password needed
+    to access the ActionKit API. See the `ActionKit REST API Authentication <https://roboticdogs.actionkit.com/docs/manual/api/rest/overview.html#authentication>`_
+    documentation for more information on obtaining ActionKit API credentials.
 
 **********
 Quickstart
 **********
 
-**Retrieve a User**
+To instantiate the ActionKit class, you can either store your ActionKit API
+domain, username, and password as environmental variables (ACTION_KIT_DOMAIN,
+ACTION_KIT_USERNAME, and ACTION_KIT_PASSWORD, respectively) or pass in your
+domain, username, and password as arguments:
 
 .. code-block:: python
 
-  from parsons import ActionKit
-  ak = ActionKit()
-  user_data = ak.get_user(123)
+   from parsons import VAN
+
+   # First approach: Specify DB type and pass API credentials via environmental variables
+   ak = ActionKit(db='MyVoters')
+
+   # Second approach: Pass API credentials as arguments
+   ak = ActionKit(domain='myorg.actionkit.com', username='my_name', password='1234')
+
+You can then call various endpoints:
+
+.. code-block:: python
+
+    # Create a new user
+    ak.create_user(email='john@email', first_name='John', last_name='Smith', city='Boston')
+
+    # Fetch user fields
+    user_fields = ak.get_user(user_id='123')
+
+    # Update user fields
+    ak.update_user(user_id='123', city='New York')
+
+    # Delete uer
+    ak.delete_user(user_id='123')
 
 ***
 API

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class ActionKit(object):
     """
-    Instatiate the ActionKit class
+    Instantiate the ActionKit class
 
     `Args:`
         domain: str
@@ -20,7 +20,7 @@ class ActionKit(object):
             The authorized ActionKit username. Not required if ``ACTION_KIT_USERNAME`` env
             variable set.
         password: str
-            The authorized ActionKit user password. Not required if ``ACTION_KIT_USERNAME``
+            The authorized ActionKit user password. Not required if ``ACTION_KIT_PASSWORD``
             env variable set.
     """
 

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -129,7 +129,8 @@ class ActionKit(object):
                 Email for the user
             **kwargs:
                 Optional arguments and fields that can sent. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             User json object
         """
@@ -146,7 +147,8 @@ class ActionKit(object):
                 The user id of the person to update
             **kwargs:
                 Optional arguments and fields that can sent. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             ``None``
         """
@@ -163,7 +165,8 @@ class ActionKit(object):
                 The event id of the event to update
             **kwargs:
                 Optional arguments and fields that can sent. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             ``None``
         """
@@ -220,7 +223,8 @@ class ActionKit(object):
                 The name of the campaign to create
             **kwargs:
                 Optional arguments and fields that can sent. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
         `Returns`:
             API location of new resource
         """
@@ -267,7 +271,8 @@ class ActionKit(object):
                 The title of the page to create
             **kwargs:
                 Optional arguments and fields that can sent. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
         `Returns`:
             API location of new resource
         """
@@ -316,7 +321,8 @@ class ActionKit(object):
                 Free form thank you text
             **kwargs:
                 Optional arguments and fields that can sent. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             API location of new resource
         """
@@ -366,7 +372,8 @@ class ActionKit(object):
                 The title of the page to create
             **kwargs:
                 Optional arguments and fields that can sent. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
         `Returns`:
             API location of new resource
         """
@@ -415,7 +422,8 @@ class ActionKit(object):
                 Free form thank you text
             **kwargs:
                 Optional arguments and fields that can sent. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             API location of new resource
         """
@@ -437,7 +445,8 @@ class ActionKit(object):
                 A dictionary of fields to update for the event signup.
             **kwargs:
                 Optional arguments and fields that can sent. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             ``None``
         """
@@ -483,7 +492,8 @@ class ActionKit(object):
                 URL of the folloup page
             **kwargs:
                 Optional arguments and fields that can sent. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
         `Returns`:
             API location of new resource
         """
@@ -507,7 +517,8 @@ class ActionKit(object):
                 The action kit id of the record.
             **kwargs:
                 Optional arguments and fields that can sent. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
         `Returns`:
             dict
                 The response json

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -127,8 +127,9 @@ class ActionKit(object):
         `Args:`
             email: str
                 Email for the user
-            user_dict: dict
-                Optional; Additional user fields
+            **kwargs:
+                Optional arguments and fields that can sent. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             User json object
         """
@@ -143,8 +144,9 @@ class ActionKit(object):
         `Args:`
             user_id: int
                 The user id of the person to update
-            user_dict: dict
-                A dictionary of fields to update for the user.
+            **kwargs:
+                Optional arguments and fields that can sent. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             ``None``
         """
@@ -159,8 +161,9 @@ class ActionKit(object):
         `Args:`
             event_id: int
                 The event id of the event to update
-            event_dict: dict
-                A dictionary of fields to update for the event.
+            **kwargs:
+                Optional arguments and fields that can sent. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             ``None``
         """
@@ -215,6 +218,9 @@ class ActionKit(object):
         `Args:`
             name: str
                 The name of the campaign to create
+            **kwargs:
+                Optional arguments and fields that can sent. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
         `Returns`:
             API location of new resource
         """
@@ -259,6 +265,9 @@ class ActionKit(object):
                 The name of the page to create
             title: str
                 The title of the page to create
+            **kwargs:
+                Optional arguments and fields that can sent. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
         `Returns`:
             API location of new resource
         """
@@ -305,6 +314,9 @@ class ActionKit(object):
                 The page to associate the form with
             thank_you_text: str
                 Free form thank you text
+            **kwargs:
+                Optional arguments and fields that can sent. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             API location of new resource
         """
@@ -352,6 +364,9 @@ class ActionKit(object):
                 The name of the page to create
             title: str
                 The title of the page to create
+            **kwargs:
+                Optional arguments and fields that can sent. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
         `Returns`:
             API location of new resource
         """
@@ -398,6 +413,9 @@ class ActionKit(object):
                 The page to associate the form with
             thank_you_text: str
                 Free form thank you text
+            **kwargs:
+                Optional arguments and fields that can sent. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             API location of new resource
         """
@@ -417,6 +435,9 @@ class ActionKit(object):
                 The id of the event signup to update
             event_signup_dict: dict
                 A dictionary of fields to update for the event signup.
+            **kwargs:
+                Optional arguments and fields that can sent. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
         `Returns:`
             ``None``
         """
@@ -460,6 +481,9 @@ class ActionKit(object):
                 The signup page to associate the followup page with
             url: str
                 URL of the folloup page
+            **kwargs:
+                Optional arguments and fields that can sent. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/manual/api/rest/actionprocessing.html>`_.
         `Returns`:
             API location of new resource
         """

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -128,7 +128,7 @@ class ActionKit(object):
             email: str
                 Email for the user
             **kwargs:
-                Optional arguments and fields that can sent. A full list can be found
+                Optional arguments and fields to pass to the client. A full list can be found
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns:`
@@ -146,7 +146,7 @@ class ActionKit(object):
             user_id: int
                 The user id of the person to update
             **kwargs:
-                Optional arguments and fields that can sent. A full list can be found
+                Optional arguments and fields to pass to the client. A full list can be found
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns:`
@@ -164,7 +164,7 @@ class ActionKit(object):
             event_id: int
                 The event id of the event to update
             **kwargs:
-                Optional arguments and fields that can sent. A full list can be found
+                Optional arguments and fields to pass to the client. A full list can be found
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns:`
@@ -222,7 +222,7 @@ class ActionKit(object):
             name: str
                 The name of the campaign to create
             **kwargs:
-                Optional arguments and fields that can sent. A full list can be found
+                Optional arguments and fields to pass to the client. A full list can be found
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns`:
@@ -270,7 +270,7 @@ class ActionKit(object):
             title: str
                 The title of the page to create
             **kwargs:
-                Optional arguments and fields that can sent. A full list can be found
+                Optional arguments and fields to pass to the client. A full list can be found
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns`:
@@ -320,7 +320,7 @@ class ActionKit(object):
             thank_you_text: str
                 Free form thank you text
             **kwargs:
-                Optional arguments and fields that can sent. A full list can be found
+                Optional arguments and fields to pass to the client. A full list can be found
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns:`
@@ -371,7 +371,7 @@ class ActionKit(object):
             title: str
                 The title of the page to create
             **kwargs:
-                Optional arguments and fields that can sent. A full list can be found
+                Optional arguments and fields to pass to the client. A full list can be found
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns`:
@@ -421,7 +421,7 @@ class ActionKit(object):
             thank_you_text: str
                 Free form thank you text
             **kwargs:
-                Optional arguments and fields that can sent. A full list can be found
+                Optional arguments and fields to pass to the client. A full list can be found
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns:`
@@ -444,7 +444,7 @@ class ActionKit(object):
             event_signup_dict: dict
                 A dictionary of fields to update for the event signup.
             **kwargs:
-                Optional arguments and fields that can sent. A full list can be found
+                Optional arguments and fields to pass to the client. A full list can be found
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns:`
@@ -491,7 +491,7 @@ class ActionKit(object):
             url: str
                 URL of the folloup page
             **kwargs:
-                Optional arguments and fields that can sent. A full list can be found
+                Optional arguments and fields to pass to the client. A full list can be found
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns`:
@@ -516,7 +516,7 @@ class ActionKit(object):
             ak_id:
                 The action kit id of the record.
             **kwargs:
-                Optional arguments and fields that can sent. A full list can be found
+                Optional arguments and fields to pass to the client. A full list can be found
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns`:


### PR DESCRIPTION
This PR updates connector documentation for the ActionKit class, per issue #269.

Change summary:

- Updated the overview and quickstart in the `*.rst`, aiming to following the examples provided in the issue description as closely as possible
- Fixed a couple typos in the main docstring for the class
- Cleaned up `**kwargs` documentation, making it consistent and correct across functions

All tests passed 