### PR TITLE
VAN.get_person() - Fix MyVoters Error

### DIFF
--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -363,7 +363,7 @@ class People(object):
         # Removing the fields that are not returned in MyVoters
         NOT_IN_MYVOTERS = ['codes', 'contribution_history', 'organization_roles']
 
-        if self.connection.db == 0:
+        if self.connection.db_code == 0:
             expand_fields = [v for v in expand_fields if v not in NOT_IN_MYVOTERS]
 
         logger.info(f'Getting person with {id_type} of {id} at url {url}')

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -360,6 +360,13 @@ class People(object):
 
         expand_fields = ','.join([json_format.arg_format(f) for f in expand_fields])
 
+        # Removing the fields that are not returned in MyVoters
+        NOT_IN_MYVOTERS = ['codes', 'contribution_history', 'organization_roles']
+        
+        if self.db == 0:
+            expand_fields = [v for v in expand_fields if v not in NOT_IN_MYVOTERS]
+
+
         logger.info(f'Getting person with {id_type} of {id} at url {url}')
         return self.connection.get_request(url, params={'$expand': expand_fields})
 

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -363,7 +363,7 @@ class People(object):
         # Removing the fields that are not returned in MyVoters
         NOT_IN_MYVOTERS = ['codes', 'contribution_history', 'organization_roles']
 
-        if self.db == 0:
+        if self.connection.db == 0:
             expand_fields = [v for v in expand_fields if v not in NOT_IN_MYVOTERS]
 
         logger.info(f'Getting person with {id_type} of {id} at url {url}')

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -362,10 +362,9 @@ class People(object):
 
         # Removing the fields that are not returned in MyVoters
         NOT_IN_MYVOTERS = ['codes', 'contribution_history', 'organization_roles']
-        
+
         if self.db == 0:
             expand_fields = [v for v in expand_fields if v not in NOT_IN_MYVOTERS]
-
 
         logger.info(f'Getting person with {id_type} of {id} at url {url}')
         return self.connection.get_request(url, params={'$expand': expand_fields})


### PR DESCRIPTION
The default fields returned from `VAN.get_person()` are only returned with EveryAction, not MyVoters. This PR removes them when the database is set to MyVoters.

Addresses issue #310.