### PR TITLE
Issue #286 sphinx for building docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Parsons documentation is built using the Python Sphinx tool, which uses the `doc
 To create docs internally you need two packages:
 
 ```
-gi
+Sphinx==1.8.3
 sphinx-rtd-theme==0.4.2
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If you would like to contribute to Parsons, please review the issues in the repo
 
 One important way to contribute to the Parsons project is to submit sample code that provides recipes and patterns for how to use the Parsons library.
 
-We have a folder called `sample_code/` in the root of the repository. If you have scripts that incorporate Parsons, we encourage you to create a Pull Request adding them there!
+We have a folder called `useful_resources/` in the root of the repository. If you have scripts that incorporate Parsons, we encourage you to create a Pull Request adding them there!
 
 ### Coding Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,10 @@ sphinx-rtd-theme==0.4.2
 
 Then to generate all of the html locally, do the following:
 
+```
 > cd docs
 > make html
+```
 
 ### Testing your Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,31 +44,6 @@ To set up your development environment:
 
 Now it's time to make your changes. We suggest taking a quick look at our [coding conventions](#coding-conventions) - it'll make the review process easier down the line. In addition to any code changes, make sure to update the documentation and the unit tests if necessary. Not sure if your changes require test or documentation updates? Just ask in Slack or through a comment on the relevant issue.  When you're done, make sure to run the [unit tests](#unit-tests) and the [linter](#linting) again.
 
-### Documentation
-
-Parsons documentation is built using the Python Sphinx tool, which uses the `docs/*.rst` files in the repository to create the documentation. If you are adding a new connector, you will need to add a reference to the connector to one of the .rst files. Please use the existing documentation as an example.
-
-To create docs internally you need additional packages you can install with:
-
-```
-pip install -r docs/requirements.txt
-```
-
-Then to generate all of the html locally, do the following:
-
-```
-> cd docs
-> make html
-```
-
-If required dependencies conflict with packages or modules you need for other projects, you can create and use a [virtual environment](https://docs.python.org/3/library/venv.html).
-
-```
-python -m venv .venv       # Creates a virtual environment in the .venv folder 
-source .venv/bin/activate  # Activate in Unix or MacOS
-.venv/Scripts/activate.bat # Activate in Windows 
-```
-
 #### Installing Dependencies
 
 Before running or testing your code changes, be sure to install all of the required Python libraries that Parsons depends on.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If you would like to contribute to Parsons, please review the issues in the repo
 
 One important way to contribute to the Parsons project is to submit sample code that provides recipes and patterns for how to use the Parsons library.
 
-We have a folder called `useful_resources/` in the root of the repository. If you have scripts that incorporate Parsons, we encourage you to create a Pull Request adding them there!
+We have a folder called `useful_resources/` in the root of the regpository. If you have scripts that incorporate Parsons, we encourage you to create a Pull Request adding them there!
 
 ### Coding Conventions
 
@@ -57,6 +57,16 @@ From the root of the parsons repository, use the run the following command:
 
 ```bash
 > pip install -r requirements.txt
+```
+
+#### Virtual Environments
+
+If required dependencies conflict with packages or modules you need for other projects, you can create and use a [virtual environment](https://docs.python.org/3/library/venv.html).
+
+```
+python -m venv .venv       # Creates a virtual environment in the .venv folder 
+source .venv/bin/activate  # Activate in Unix or MacOS
+.venv/Scripts/activate.bat # Activate in Windows 
 ```
 
 #### Unit Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If you would like to contribute to Parsons, please review the issues in the repo
 
 One important way to contribute to the Parsons project is to submit sample code that provides recipes and patterns for how to use the Parsons library.
 
-We have a folder called `useful_resources/` in the root of the regpository. If you have scripts that incorporate Parsons, we encourage you to create a Pull Request adding them there!
+We have a folder called `useful_resources/` in the root of the repository. If you have scripts that incorporate Parsons, we encourage you to create a Pull Request adding them there!
 
 ### Coding Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ The following is a list of best practices to consider when writing code for the 
 
 * Inline comments explaining complex codes and methods are appreciated.
 
+* Capitalize Parsons
+
 ### Documentation
 
 Parsons documentation is built using the Python Sphinx tool, which uses the `docs/*.rst` files in the repository to create the documentation. If you are adding a new connector, you will need to add a reference to the connector to one of the .rst files. Please use the existing documentation as an example.
@@ -48,7 +50,7 @@ Parsons documentation is built using the Python Sphinx tool, which uses the `doc
 To create docs internally you need two packages:
 
 ```
-Sphinx==1.8.3
+gi
 sphinx-rtd-theme==0.4.2
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,19 @@ The following is a list of best practices to consider when writing code for the 
 
 ### Documentation
 
-Parsons documentation is built using the Python Sphinx tool. Sphinx uses the `docs/*.rst` files in the repository to create the documentation. If you are adding a new connector, you will need to add a reference to the connector to one of the .rst files. Please use the existing documentation as an example.
+Parsons documentation is built using the Python Sphinx tool, which uses the `docs/*.rst` files in the repository to create the documentation. If you are adding a new connector, you will need to add a reference to the connector to one of the .rst files. Please use the existing documentation as an example.
+
+To create docs internally you need two packages:
+
+```
+Sphinx==1.8.3
+sphinx-rtd-theme==0.4.2
+```
+
+Then to generate all of the html locally, do the following:
+
+> cd docs
+> make html
 
 ### Testing your Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,18 +44,14 @@ To set up your development environment:
 
 Now it's time to make your changes. We suggest taking a quick look at our [coding conventions](#coding-conventions) - it'll make the review process easier down the line. In addition to any code changes, make sure to update the documentation and the unit tests if necessary. Not sure if your changes require test or documentation updates? Just ask in Slack or through a comment on the relevant issue.  When you're done, make sure to run the [unit tests](#unit-tests) and the [linter](#linting) again.
 
-<<<<<<< HEAD
-* Capitalize Parsons
-
 ### Documentation
 
 Parsons documentation is built using the Python Sphinx tool, which uses the `docs/*.rst` files in the repository to create the documentation. If you are adding a new connector, you will need to add a reference to the connector to one of the .rst files. Please use the existing documentation as an example.
 
-To create docs internally you need two packages:
+To create docs internally you need additional packages you can install with:
 
 ```
-Sphinx==1.8.3
-sphinx-rtd-theme==0.4.2
+pip install -r docs/requirements.txt
 ```
 
 Then to generate all of the html locally, do the following:
@@ -64,11 +60,6 @@ Then to generate all of the html locally, do the following:
 > cd docs
 > make html
 ```
-=======
-Finally, you'll want to [submit a pull request](#submitting-a-pull-request). And that's it!
-
-#### Virtual Environments
->>>>>>> upstream/master
 
 If required dependencies conflict with packages or modules you need for other projects, you can create and use a [virtual environment](https://docs.python.org/3/library/venv.html).
 
@@ -141,6 +132,8 @@ The following is a list of best practices to consider when writing code for the 
 * You should avoid abbreviations for method names and variable names where possible.
 
 * Inline comments explaining complex codes and methods are appreciated.
+
+* Capitalize Parsons
 
 If you are building a new connector or extending an existing connector, there are more best practices in the [How to Build a Connector](https://move-coop.github.io/parsons/html/build_a_connector.html) documentation. 
 


### PR DESCRIPTION
Added and lightly copyedited this comment to the docs section: https://github.com/move-coop/parsons/pull/313#issuecomment-660397875

Note, I wasn't able to `make html`, even after installing the proper versions of Sphinx & the theme, I believe due to https://github.com/sphinx-doc/sphinx/issues/7420. 

Should we assume readers will know the syntax `pip install -Iv Sphinx==1.8.3` or add to requirements.txt? 