### PR TITLE
Redshift/Postgres Fix Duplicate Columns Bug

### DIFF
--- a/parsons/databases/postgres/postgres_create_statement.py
+++ b/parsons/databases/postgres/postgres_create_statement.py
@@ -238,6 +238,10 @@ class PostgresCreateStatement(object):
                 logger.info(f'Column {c[:10]}... too long. Truncating column name.')
                 c = c[:120]
 
+            # Check for duplicate column names and add index if a dupe is found.
+            if c in clean_columns:
+                c = f'{c}_{idx}'
+
             clean_columns.append(c)
 
         return clean_columns

--- a/parsons/databases/redshift/rs_create_table.py
+++ b/parsons/databases/redshift/rs_create_table.py
@@ -238,6 +238,10 @@ class RedshiftCreateTable(object):
                 logger.info(f'Column {c[:10]}... too long. Truncating column name.')
                 c = c[:120]
 
+            # Check for duplicate column names and add index if a dupe is found.
+            if c in clean_columns:
+                c = f'{c}_{idx}'
+
             clean_columns.append(c)
 
         return clean_columns

--- a/test/test_databases/test_postgres.py
+++ b/test/test_databases/test_postgres.py
@@ -104,8 +104,8 @@ class TestPostgresCreateStatement(unittest.TestCase):
 
     def test_column_validate(self):
 
-        bad_cols = ['', 'SELECT', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjklasdfjklasjkldfakljsdfjalsdkfjklasjdfklasjdfklasdkljf'] # noqa: E501
-        fixed_cols = ['col_0', 'col_1', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjkl'] # noqa: E501
+        bad_cols = ['a','a','', 'SELECT', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjklasdfjklasjkldfakljsdfjalsdkfjklasjdfklasjdfklasdkljf'] # noqa: E501
+        fixed_cols = ['a','a_1','col_2', 'col_3', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjkl'] # noqa: E501
         self.assertEqual(self.pg.column_name_validate(bad_cols), fixed_cols)
 
     def test_create_statement(self):

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -103,8 +103,8 @@ class TestRedshift(unittest.TestCase):
 
     def test_column_validate(self):
 
-        bad_cols = ['', 'SELECT', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjklasdfjklasjkldfakljsdfjalsdkfjklasjdfklasjdfklasdkljf'] # noqa: E501
-        fixed_cols = ['col_0', 'col_1', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjkl'] # noqa: E501
+        bad_cols = ['a','a','', 'SELECT', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjklasdfjklasjkldfakljsdfjalsdkfjklasjdfklasjdfklasdkljf'] # noqa: E501
+        fixed_cols = ['a','a_1','col_2', 'col_3', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjkl'] # noqa: E501
         self.assertEqual(self.rs.column_name_validate(bad_cols), fixed_cols)
 
     def test_create_statement(self):


### PR DESCRIPTION
When a table is copied and has duplicate columns, the list index of the duplicate column(s) have their list index appended, avoiding Postgres / Redshift errors.

Addresses Issue #204 