### PR TITLE
Create infrastructure for sample code

### DIFF
--- a/useful_resources/sample_code/README.md
+++ b/useful_resources/sample_code/README.md
@@ -1,0 +1,20 @@
+# Sample Scripts
+
+The scripts in this folder perform data operations, typically moving data between one connector and another. To perform the same operation, all you should need to do is change the configuration variables in the `Configuration Variables` section of each script. You can also use these scripts as a jumping off point to create new scripts doing similar opeations.
+
+If you can't find the script you want here, you can create an issue in the tracker with the label [sample script request](). Please put in as much detail as possible what you would like the script to do.
+
+If you have a script you'd like to add, you have two options. You can create an issue in the tracker with the contents of your script, and add the label [sample script to add](). Or you can add the script yourself.
+
+If you wish to add the script yourself, please use the `template_script.py` file so that your contribution's structure is consistent with all the other scripts.  Please keep most comments as these are directed at the eventual user of your script, but delete any comments labeled "//To Script Writer//" once you understand their advice.
+
+Please also add your new script to the table below.
+
+# Existing Scripts
+
+| File Name   | Brief Description |  Connectors Used   |
+| ----------- | ----------- |  ----------- |
+| apply_activist_code.py  | Gets activist codes stored in Redshift and applies to users in Van | Redshift, VAN|
+| s3_to_redshift.py  |  Moves files from S3 to Redshift| Redshift, S3|
+| s3_to_s3.py | Get files from vendor s3 bucket and moves to own S3 bucket | S3 |
+| update_user_in_actionkit.py | Adds a voterbase_id (the Targetsmart ID) to users in ActionKit |Redshift, ActionKit |

--- a/useful_resources/sample_code/README.md
+++ b/useful_resources/sample_code/README.md
@@ -2,9 +2,9 @@
 
 The scripts in this folder perform data operations, typically moving data between one connector and another. To perform the same operation, all you should need to do is change the configuration variables in the `Configuration Variables` section of each script. You can also use these scripts as a jumping off point to create new scripts doing similar opeations.
 
-If you can't find the script you want here, you can create an issue in the tracker with the label [sample script request](). Please put in as much detail as possible what you would like the script to do.
+If you can't find the script you want here, you can create an issue in the tracker with the label [script request](https://github.com/move-coop/parsons/labels/script%20request). Please put in as much detail as possible what you would like the script to do.
 
-If you have a script you'd like to add, you have two options. You can create an issue in the tracker with the contents of your script, and add the label [sample script to add](). Or you can add the script yourself.
+If you have a script you'd like to add, you have two options. You can create an issue in the tracker with the contents of your script, and add the label [sample script to add](https://github.com/move-coop/parsons/labels/script%20to%20add). Or you can add the script yourself.
 
 If you wish to add the script yourself, please use the `template_script.py` file so that your contribution's structure is consistent with all the other scripts.  Please keep most comments as these are directed at the eventual user of your script, but delete any comments labeled "//To Script Writer//" once you understand their advice.
 
@@ -12,9 +12,10 @@ Please also add your new script to the table below.
 
 # Existing Scripts
 
-| File Name   | Brief Description |  Connectors Used   |
-| ----------- | ----------- |  ----------- |
-| apply_activist_code.py  | Gets activist codes stored in Redshift and applies to users in Van | Redshift, VAN|
-| s3_to_redshift.py  |  Moves files from S3 to Redshift| Redshift, S3|
-| s3_to_s3.py | Get files from vendor s3 bucket and moves to own S3 bucket | S3 |
-| update_user_in_actionkit.py | Adds a voterbase_id (the Targetsmart ID) to users in ActionKit |Redshift, ActionKit |
+| File Name   | Brief Description |  Connectors Used   | Written For Parsons Version |
+| ----------- | ----------- |  ----------- | ----------- |
+| apply_activist_code.py  | Gets activist codes stored in Redshift and applies to users in Van | Redshift, VAN| unknown |
+| s3_to_redshift.py  |  Moves files from S3 to Redshift| Redshift, S3| unknown |
+| s3_to_s3.py | Get files from vendor s3 bucket and moves to own S3 bucket | S3 |  unknown  |
+| update_user_in_actionkit.py | Adds a voterbase_id (the Targetsmart ID) to users in ActionKit |Redshift, ActionKit |  unknown  |
+

--- a/useful_resources/sample_code/apply_activist_code.py
+++ b/useful_resources/sample_code/apply_activist_code.py
@@ -2,6 +2,7 @@
 
 # Connectors: Redshift, VAN
 # Description: Gets activist codes stored in redshift and applies to users in Van
+# Parsons Version: unknown
 
 
 ### CONFIGURATION
@@ -10,22 +11,22 @@
 # with empty strings.  We recommend using environmental variables if possible.
 
 config_vars = {
-    # Redshift  (note: this assumes a Civis Platform parameter called "REDSHIFT")
+    # Redshift
     "REDSHIFT_PORT": "",
     "REDSHIFT_DB": "",
     "REDSHIFT_HOST": "",
     "REDSHIFT_CREDENTIAL_USERNAME": "",
     "REDSHIFT_CREDENTIAL_PASSWORD": "",
-    # Van  (note: below, we'll be dynamically reading API keys from multiline Civis credential)
+    # Van  
     "VAN_PASSWORD": "",
-    "VAN_DB_NAME": ""   #  FIXME: script had 'MyVoters' - is this a universal default?
+    "VAN_DB_NAME": ""
 }
 
 
 ### CODE
 
 from parsons import Table, Redshift, VAN
-import logging
+from parsons import logger
 import os
 
 # Setup
@@ -35,15 +36,6 @@ for name, value in config_vars.items():    # sets variables if provided in this 
         os.environ[name] = value
 
 rs = Redshift()   # just create Redshift() - VAN connector is created dynamically below
-
-# Logging
-
-logger = logging.getLogger(__name__)
-_handler = logging.StreamHandler()
-_formatter = logging.Formatter('%(levelname)s %(message)s')
-_handler.setFormatter(_formatter)
-logger.addHandler(_handler)
-logger.setLevel('INFO')
 
 # Create dictionary of VAN states and API keys from multiline Civis credential
 

--- a/useful_resources/sample_code/s3_to_redshift.py
+++ b/useful_resources/sample_code/s3_to_redshift.py
@@ -1,21 +1,41 @@
-import os
-import logging
+### METADATA
+
+# Connectors: Redshift, S3
+# Description: Moves files from S3 to Reshift
+
+
+### CONFIGURATION
+
+# Set the configuration variables below or set environmental variables of the same name and leave these
+# with empty strings.  We recommend using environmental variables if possible.
+
+config_vars = {
+    # Redshift  (note: this assumes a Civis Platform parameter called "REDSHIFT")
+    "REDSHIFT_PORT": "",
+    "REDSHIFT_DB": "",
+    "REDSHIFT_HOST": "",
+    "REDSHIFT_CREDENTIAL_USERNAME": "",
+    "REDSHIFT_CREDENTIAL_PASSWORD": "",
+    # S3  (note: this assumes a Civis Platform parameter called "AWS")
+    "S3_TEMP_BUCKET": "",
+    "AWS_ACCESS_KEY_ID": "",
+    "AWS_SECRET_ACCESS_KEY": "",
+    "BUCKET": ""    # FIXME: how does this differ from S3_TEMP_BUCKET?
+}
+
+
+### CODE
+
+import os, logging
 from parsons import Redshift, S3, utilities
 
-# Redshift setup - this assumes a Civis Platform parameter called "REDSHIFT"
+# Setup
 
-set_env_var(os.environ['REDSHIFT_PORT'])
-set_env_var(os.environ['REDSHIFT_DB'])
-set_env_var(os.environ['REDSHIFT_HOST'])
-set_env_var(os.environ['REDSHIFT_CREDENTIAL_USERNAME'])
-set_env_var(os.environ['REDSHIFT_CREDENTIAL_PASSWORD'])
+for name, value in config_vars.items():    # sets variables if provided in this script
+    if value.strip() != "":
+        os.environ[name] = value
+
 rs = Redshift()
-
-# AWS setup - this assumes a Civis Platform parameter called "AWS"
-
-set_env_var('S3_TEMP_BUCKET', 'parsons-tmc')
-set_env_var('AWS_ACCESS_KEY_ID', os.environ['AWS_ACCESS_KEY_ID'])
-set_env_var('AWS_SECRET_ACCESS_KEY', os.environ['AWS_SECRET_ACCESS_KEY'])
 s3 = S3()
 
 # Logging
@@ -27,10 +47,9 @@ _handler.setFormatter(_formatter)
 logger.addHandler(_handler)
 logger.setLevel('INFO')
 
+# Code
 
 bucket = os.environ['BUCKET']
-schema = os.environ['SCHEMA']
-
 keys = s3.list_keys(bucket)
 files = keys.keys()
 

--- a/useful_resources/sample_code/s3_to_redshift.py
+++ b/useful_resources/sample_code/s3_to_redshift.py
@@ -2,6 +2,7 @@
 
 # Connectors: Redshift, S3
 # Description: Moves files from S3 to Reshift
+# Parsons Version: unknown
 
 
 ### CONFIGURATION
@@ -10,24 +11,24 @@
 # with empty strings.  We recommend using environmental variables if possible.
 
 config_vars = {
-    # Redshift  (note: this assumes a Civis Platform parameter called "REDSHIFT")
+    # S3 
+    "AWS_ACCESS_KEY_ID": "",
+    "AWS_SECRET_ACCESS_KEY": "",
+    "BUCKET": "",
+    # Redshift
     "REDSHIFT_PORT": "",
     "REDSHIFT_DB": "",
     "REDSHIFT_HOST": "",
     "REDSHIFT_CREDENTIAL_USERNAME": "",
     "REDSHIFT_CREDENTIAL_PASSWORD": "",
-    # S3  (note: this assumes a Civis Platform parameter called "AWS")
     "S3_TEMP_BUCKET": "",
-    "AWS_ACCESS_KEY_ID": "",
-    "AWS_SECRET_ACCESS_KEY": "",
-    "BUCKET": ""    # FIXME: how does this differ from S3_TEMP_BUCKET?
 }
 
 
 ### CODE
 
-import os, logging
-from parsons import Redshift, S3, utilities
+import os
+from parsons import Redshift, S3, utilities, logger
 
 # Setup
 
@@ -35,17 +36,8 @@ for name, value in config_vars.items():    # sets variables if provided in this 
     if value.strip() != "":
         os.environ[name] = value
 
-rs = Redshift()
 s3 = S3()
-
-# Logging
-
-logger = logging.getLogger(__name__)
-_handler = logging.StreamHandler()
-_formatter = logging.Formatter('%(levelname)s %(message)s')
-_handler.setFormatter(_formatter)
-logger.addHandler(_handler)
-logger.setLevel('INFO')
+rs = Redshift()
 
 # Code
 

--- a/useful_resources/sample_code/s3_to_s3.py
+++ b/useful_resources/sample_code/s3_to_s3.py
@@ -1,7 +1,8 @@
 ### METADATA
 
 # Connectors: S3
-# Description: Gets files from vendor s3 bucket and moves to own S3 bucket
+# Description: Gets files from source s3 bucket and moves to destination S3 bucket
+# Parsons Version: unknown
 
 
 ### CONFIGURATION
@@ -10,13 +11,12 @@
 # with empty strings.  We recommend using environmental variables if possible.
 
 config_vars = {
-        # S3 (source) (note: this assumes a Civis Platform parameter called "AWS")
-        "S3_TEMP_BUCKET": "",
-        "AWS_ACCESS_KEY_ID": "",
-        "AWS_SECRET_ACCESS_KEY": "",
-        # S3 (vendor) (note: this assumes a Civis Platform parameter called "AWS_VENDOR")
-        'AWS_VENDOR_SECRET_ACCESS_KEY': "",
-        'AWS_VENDOR_ACCESS_KEY_ID': ""
+        # S3 (source) 
+        "AWS_SOURCE_ACCESS_KEY_ID": "",
+        "AWS_SOURCE_SECRET_ACCESS_KEY": "",
+        # S3 (destination)
+        'AWS_DESTINATION_SECRET_ACCESS_KEY': "",
+        'AWS_DESTINATION_ACCESS_KEY_ID': ""
 }
 
 DESTINATION_BUCKET = None    
@@ -25,8 +25,7 @@ DESTINATION_BUCKET = None
 ### CODE
 
 import os
-import logging
-from parsons import Redshift, S3, utilities
+from parsons import Redshift, S3, utilities, logger
 
 # Setup 
 
@@ -34,32 +33,22 @@ for name, value in config_vars.items():    # sets variables if provided in this 
     if value.strip() != "":
         os.environ[name] = value
 
-s3 = S3()
-s3_vendor = S3(os.environ['AWS_VENDOR_ACCESS_KEY_ID'], os.environ['AWS_VENDOR_SECRET_ACCESS_KEY'])
-
-# Logging
-
-logger = logging.getLogger(__name__)
-_handler = logging.StreamHandler()
-_formatter = logging.Formatter('%(levelname)s %(message)s')
-_handler.setFormatter(_formatter)
-logger.addHandler(_handler)
-logger.setLevel('INFO')
+s3_source = S3(os.environ['AWS_SOURCE_ACCESS_KEY_ID'], os.environ['AWS_SOURCE_SECRET_ACCESS_KEY'])
+s3_destination = S3(os.environ['AWS_DESTINATION_ACCESS_KEY_ID'], os.environ['AWS_DESTINATION_SECRET_ACCESS_KEY'])
 
 # Let's write some code!
 
-# Get Vendor Bucket Information
-bucket_guide = s3_vendor.list_buckets()
+# Get Source Bucket Information
+bucket_guide = s3_source.list_buckets()
 logger.info(f"We will be getting data from {len(bucket_guide)} buckets...")
 
-# Moving Files from Vendor s3 Bucket to Destination s3 Bucket
+# Moving Files from Source s3 Bucket to Destination s3 Bucket
 for bucket in bucket_guide:
 
     logger.info(f"Working on files for {bucket}...")
-    keys = s3_vendor.list_keys(bucket)
+    keys = s3_source.list_keys(bucket)
     logger.info(f"Found {len(keys)}.")
     for key in keys:
-        temp_file = s3_vendor.get_file(bucket, key)
-        tmc_key = f"vendor_exports/{bucket}/{key}"
-        s3.put_file(DESTINATION_BUCKET, tmc_key, temp_file)
+        temp_file = s3_source.get_file(bucket, key)
+        s3_destination.put_file(DESTINATION_BUCKET, key, temp_file)
         utilities.files.close_temp_file(temp_file)

--- a/useful_resources/sample_code/s3_to_s3.py
+++ b/useful_resources/sample_code/s3_to_s3.py
@@ -1,26 +1,41 @@
+### METADATA
+
+# Connectors: S3
+# Description: Gets files from vendor s3 bucket and moves to own S3 bucket
+
+
+### CONFIGURATION
+
+# Set the configuration variables below or set environmental variables of the same name and leave these
+# with empty strings.  We recommend using environmental variables if possible.
+
+config_vars = {
+        # S3 (source) (note: this assumes a Civis Platform parameter called "AWS")
+        "S3_TEMP_BUCKET": "",
+        "AWS_ACCESS_KEY_ID": "",
+        "AWS_SECRET_ACCESS_KEY": "",
+        # S3 (vendor) (note: this assumes a Civis Platform parameter called "AWS_VENDOR")
+        'AWS_VENDOR_SECRET_ACCESS_KEY': "",
+        'AWS_VENDOR_ACCESS_KEY_ID': ""
+}
+
+DESTINATION_BUCKET = None    
+
+
+### CODE
+
 import os
 import logging
 from parsons import Redshift, S3, utilities
 
-# Redshift setup - this assumes a Civis Platform parameter called "REDSHIFT"
+# Setup 
 
-set_env_var(os.environ['REDSHIFT_PORT'])
-set_env_var(os.environ['REDSHIFT_DB'])
-set_env_var(os.environ['REDSHIFT_HOST'])
-set_env_var(os.environ['REDSHIFT_CREDENTIAL_USERNAME'])
-set_env_var(os.environ['REDSHIFT_CREDENTIAL_PASSWORD'])
-rs = Redshift()
+for name, value in config_vars.items():    # sets variables if provided in this script
+    if value.strip() != "":
+        os.environ[name] = value
 
-# AWS setup - this assumes a Civis Platform parameter called "AWS"
-
-set_env_var('S3_TEMP_BUCKET', 'parsons-tmc')
-set_env_var('AWS_ACCESS_KEY_ID', os.environ['AWS_USERNAME'])
-set_env_var('AWS_SECRET_ACCESS_KEY', os.environ['AWS_PASSWORD'])
 s3 = S3()
-
-# 2nd AWS setup - this assumes a Civis Platform parameter called "AWS_VENDOR"
-s3_vendor = S3(os.environ['AWS_VENDOR_ACCESS_KEY_ID'],
-            os.environ['AWS_VENDOR_SECRET_ACCESS_KEY'])
+s3_vendor = S3(os.environ['AWS_VENDOR_ACCESS_KEY_ID'], os.environ['AWS_VENDOR_SECRET_ACCESS_KEY'])
 
 # Logging
 
@@ -37,9 +52,6 @@ logger.setLevel('INFO')
 bucket_guide = s3_vendor.list_buckets()
 logger.info(f"We will be getting data from {len(bucket_guide)} buckets...")
 
-# Define Destination Bucket
-dest_bucket = 'tmc-data'
-
 # Moving Files from Vendor s3 Bucket to Destination s3 Bucket
 for bucket in bucket_guide:
 
@@ -49,5 +61,5 @@ for bucket in bucket_guide:
     for key in keys:
         temp_file = s3_vendor.get_file(bucket, key)
         tmc_key = f"vendor_exports/{bucket}/{key}"
-        s3.put_file(dest_bucket, tmc_key, temp_file)
+        s3.put_file(DESTINATION_BUCKET, tmc_key, temp_file)
         utilities.files.close_temp_file(temp_file)

--- a/useful_resources/sample_code/template_script.py
+++ b/useful_resources/sample_code/template_script.py
@@ -21,8 +21,8 @@ config_vars = {
 
 ### CODE
 
-import os, logging                 # //To Script Writer//: import any other packages your script uses
-from parsons import utilities      # //To Script Writer//: import any connectors your script uses
+import os                                # //To Script Writer//: import any other packages your script uses
+from parsons import utilities, logger    # //To Script Writer//: import any connectors your script uses
 
 # Setup
 
@@ -32,14 +32,4 @@ for name, value in config_vars.items():    # if variables specified above, sets 
 
 # //To Script Writer// : instantiate connectors here, eg: rs = Redshift().
 
-# Logging
-
-logger = logging.getLogger(__name__)
-_handler = logging.StreamHandler()
-_formatter = logging.Formatter('%(levelname)s %(message)s')
-_handler.setFormatter(_formatter)
-logger.addHandler(_handler)
-logger.setLevel('INFO')
-
 # Code
-

--- a/useful_resources/sample_code/template_script.py
+++ b/useful_resources/sample_code/template_script.py
@@ -1,0 +1,45 @@
+### METADATA
+
+# Connectors: 
+# Description:
+
+### CONFIGURATION
+
+# Set the configuration variables below or set environmental variables of the same name and leave these
+# with empty strings.  We recommend using environmental variables if possible.
+
+# //To Script Writer// : add the environmental variable name but not the value
+# //To Script Writer// : separate environmental variables by connector
+
+config_vars = {
+    # Connector 1:
+    "EXAMPLE_VARIABLE_NAME": "",
+    # Connector 2:
+    "ANOTHER_EXAMPLE_VARIABLE_NAME": ""
+}
+
+
+### CODE
+
+import os, logging                 # //To Script Writer//: import any other packages your script uses
+from parsons import utilities      # //To Script Writer//: import any connectors your script uses
+
+# Setup
+
+for name, value in config_vars.items():    # if variables specified above, sets them as environmental variables
+    if value.strip() != "":
+        os.environ[name] = value
+
+# //To Script Writer// : instantiate connectors here, eg: rs = Redshift().
+
+# Logging
+
+logger = logging.getLogger(__name__)
+_handler = logging.StreamHandler()
+_formatter = logging.Formatter('%(levelname)s %(message)s')
+_handler.setFormatter(_formatter)
+logger.addHandler(_handler)
+logger.setLevel('INFO')
+
+# Code
+

--- a/useful_resources/sample_code/update_user_in_actionkit.py
+++ b/useful_resources/sample_code/update_user_in_actionkit.py
@@ -1,31 +1,42 @@
+### METADATA
+
+# Connectors: Redshift, ActionKit
+# Description: Adds a voterbase_id (the Targetsmart ID) to users in ActionKit
+
+
+### CONFIGURATION
+
+# Set the configuration variables below or set environmental variables of the same name and leave these
+# with empty strings.  We recommend using environmental variables if possible.
+
+config_vars = {
+    # Redshift  (note: this assumes a Civis Platform parameter called "REDSHIFT")
+    "REDSHIFT_PORT": "",
+    "REDSHIFT_DB": "",
+    "REDSHIFT_HOST": "",
+    "REDSHIFT_CREDENTIAL_USERNAME": "",
+    "REDSHIFT_CREDENTIAL_PASSWORD": "",
+    # ActionKit  (note: this assumes a Civis Platform Customo Credential parameter called "AK")
+    "AK_USERNAME": "",
+    "AK_PASSWORD": "",
+    "AK_DOMAIN": ""
+}
+
+### CODE
+
 # Civis Container Link: https://platform.civisanalytics.com/spa/#/scripts/containers/33553735
-import sys
-import os
-import datetime
-import logging
+
+import sys, os, datetime, logging
 from parsons import Redshift, Table, ActionKit
 
-# Redshift setup - this assumes a Civis Platform parameter called "REDSHIFT"
+# Setup
 
-set_env_var(os.environ['REDSHIFT_PORT'])
-set_env_var(os.environ['REDSHIFT_DB'])
-set_env_var(os.environ['REDSHIFT_HOST'])
-set_env_var(os.environ['REDSHIFT_CREDENTIAL_USERNAME'])
-set_env_var(os.environ['REDSHIFT_CREDENTIAL_PASSWORD'])
+for name, value in config_vars.items():    # sets variables if provided in this script
+    if value.strip() != "":
+        os.environ[name] = value
+
 rs = Redshift()
-
-# AWS setup - this assumes a Civis Platform parameter called "AWS"
-
-set_env_var('S3_TEMP_BUCKET', 'parsons-tmc')
-set_env_var('AWS_ACCESS_KEY_ID', os.environ['AWS_ACCESS_KEY_ID'])
-set_env_var('AWS_SECRET_ACCESS_KEY', os.environ['AWS_SECRET_ACCESS_KEY'])
-s3 = S3()
-
-# ActionKit Setup - this assumes a Civis Platform Customo Credential parameter called "AK"
-username = os.environ['AK_USERNAME']
-password = os.environ['AK_PASSWORD']
-domain = os.environ['AK_DOMAIN']
-ak = ActionKit(domain=domain, username=username, password=password)
+ak = ActionKit()
 
 # Logging
 
@@ -38,8 +49,8 @@ logger.setLevel('INFO')
 
 # This example involves adding a voterbase_id (the Targetsmart ID) to a user in ActionKit
 
-timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") #timestamp to be used for log table
-loaded = [['id','voterbase_id','date_updated']] #column names for log table
+timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") # timestamp to be used for log table
+loaded = [['id','voterbase_id','date_updated']] # column names for log table
 
 source_table = 'schema.table' # this is the table with the information I'm pushing to ActionKit
 log_table = 'schema.table' # this is where we will log every user id that gets marked with a voterbase_id

--- a/useful_resources/sample_code/update_user_in_actionkit.py
+++ b/useful_resources/sample_code/update_user_in_actionkit.py
@@ -2,6 +2,7 @@
 
 # Connectors: Redshift, ActionKit
 # Description: Adds a voterbase_id (the Targetsmart ID) to users in ActionKit
+# Parsons Version: unknown
 
 
 ### CONFIGURATION
@@ -10,13 +11,13 @@
 # with empty strings.  We recommend using environmental variables if possible.
 
 config_vars = {
-    # Redshift  (note: this assumes a Civis Platform parameter called "REDSHIFT")
+    # Redshift
     "REDSHIFT_PORT": "",
     "REDSHIFT_DB": "",
     "REDSHIFT_HOST": "",
     "REDSHIFT_CREDENTIAL_USERNAME": "",
     "REDSHIFT_CREDENTIAL_PASSWORD": "",
-    # ActionKit  (note: this assumes a Civis Platform Customo Credential parameter called "AK")
+    # ActionKit 
     "AK_USERNAME": "",
     "AK_PASSWORD": "",
     "AK_DOMAIN": ""
@@ -24,10 +25,8 @@ config_vars = {
 
 ### CODE
 
-# Civis Container Link: https://platform.civisanalytics.com/spa/#/scripts/containers/33553735
-
-import sys, os, datetime, logging
-from parsons import Redshift, Table, ActionKit
+import sys, os, datetime
+from parsons import Redshift, Table, ActionKit, logger
 
 # Setup
 
@@ -37,15 +36,6 @@ for name, value in config_vars.items():    # sets variables if provided in this 
 
 rs = Redshift()
 ak = ActionKit()
-
-# Logging
-
-logger = logging.getLogger(__name__)
-_handler = logging.StreamHandler()
-_formatter = logging.Formatter('%(levelname)s %(message)s')
-_handler.setFormatter(_formatter)
-logger.addHandler(_handler)
-logger.setLevel('INFO')
 
 # This example involves adding a voterbase_id (the Targetsmart ID) to a user in ActionKit
 
@@ -76,7 +66,7 @@ if source_data.num_rows > 0:
             loaded.append([row['id'], row['voterbase_id'],timestamp])
 
     logger.info("Done with loop! Loading into log table...")
-    Table(loaded).to_redshift(log_table,if_exists='append')
+    Table(loaded).to_redshift(log_table, if_exists='append')
 
 else:
     logger.info(f"No one to update today...")


### PR DESCRIPTION
This is my first stab at creating a new infrastructure for handling sample code.  I expect it to need significant edits before merging.

This PR:

- adds a README describing our sample script process, and including a table listing existing scripts
- creates a template_script.py file that outlines how we'd like the scripts to be structure
- edits the existing four scripts to be in line with the template

Some particular feedback I'd like:

- do the label names I've chosen work?  once I get the thumbs up, I'll create the labels and update the PR so the label links in the README link to the labels.
- does the structure of the template_script look good?
- does how we're now handling config variables look good?  I want to isolate config variables in their own section at the top so they're easy to use.  Currently these scripts may overwrite environmental variables, which may not be ideal.
- have I correctly described what each of the four sample scripts does?

Also if anyone can actually _test_ the refactored sample scripts that'd be swell.