### PR TITLE
Lint: add flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+


### PR DESCRIPTION
Currently a [line length of 100 is allowed](https://github.com/move-coop/parsons/blob/master/CONTRIBUTING.md#linting). Therefore, the command to lint the code, as mentioned in the README, is `flake8 --max-line-length=100 parsons`. This change would allow for an easier way to run the command, `flake8 parsons` and allow for additional linting options to easily be added in the future.

This is also helpful for text editors that rely on flake8 to provide linting hints.