### PR TITLE
Redshift Table Utilities: fix get definition methods

### DIFF
--- a/parsons/databases/redshift/queries/asl-license.txt
+++ b/parsons/databases/redshift/queries/asl-license.txt
@@ -1,0 +1,39 @@
+Amazon Software License
+
+1. Definitions
+
+“Licensor” means any person or entity that distributes its Work.
+
+“Software” means the original work of authorship made available under this License.
+
+“Work” means the Software and any additions to or derivative works of the Software that are made available under this License.
+
+The terms “reproduce,” “reproduction,” “derivative works,” and “distribution” have the meaning as provided under U.S. copyright law; provided, however, that for the purposes of this License, derivative works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work.
+
+Works, including the Software, are “made available” under this License by including in or with the Work either (a) a copyright notice referencing the applicability of this License to the Work, or (b) a copy of this License.
+2. License Grants
+
+2.1 Copyright Grant. Subject to the terms and conditions of this License, each Licensor grants to you a perpetual, worldwide, non-exclusive, royalty-free, copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense and distribute its Work and any resulting derivative works in any form.
+
+2.2 Patent Grant. Subject to the terms and conditions of this License, each Licensor grants to you a perpetual, worldwide, non-exclusive, royalty-free patent license to make, have made, use, sell, offer for sale, import, and otherwise transfer its Work, in whole or in part. The foregoing license applies only to the patent claims licensable by Licensor that would be infringed by Licensor’s Work (or portion thereof) individually and excluding any combinations with any other materials or technology.
+3. Limitations
+
+3.1 Redistribution. You may reproduce or distribute the Work only if (a) you do so under this License, (b) you include a complete copy of this License with your distribution, and (c) you retain without modification any copyright, patent, trademark, or attribution notices that are present in the Work.
+
+3.2 Derivative Works. You may specify that additional or different terms apply to the use, reproduction, and distribution of your derivative works of the Work (“Your Terms”) only if (a) Your Terms provide that the use limitation in Section 3.3 applies to your derivative works, and (b) you identify the specific derivative works that are subject to Your Terms. Notwithstanding Your Terms, this License (including the redistribution requirements in Section 3.1) will continue to apply to the Work itself.
+
+3.3 Use Limitation. The Work and any derivative works thereof only may be used or intended for use with the web services, computing platforms or applications provided by Amazon.com, Inc. or its affiliates, including Amazon Web Services, Inc.
+
+3.4 Patent Claims. If you bring or threaten to bring a patent claim against any Licensor (including any claim, cross-claim or counterclaim in a lawsuit) to enforce any patents that you allege are infringed by any Work, then your rights under this License from such Licensor (including the grants in Sections 2.1 and 2.2) will terminate immediately.
+
+3.5 Trademarks. This License does not grant any rights to use any Licensor’s or its affiliates’ names, logos, or trademarks, except as necessary to reproduce the notices described in this License.
+
+3.6 Termination. If you violate any term of this License, then your rights under this License (including the grants in Sections 2.1 and 2.2) will terminate immediately.
+4. Disclaimer of Warranty.
+
+THE WORK IS PROVIDED “AS IS” WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WARRANTIES OR CONDITIONS OF M ERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE OR NON-INFRINGEMENT. YOU BEAR THE RISK OF UNDERTAKING ANY ACTIVITIES UNDER THIS LICENSE. SOME STATES’ CONSUMER LAWS DO NOT ALLOW EXCLUSION OF AN IMPLIED WARRANTY, SO THIS DISCLAIMER MAY NOT APPLY TO YOU.
+5. Limitation of Liability.
+
+EXCEPT AS PROHIBITED BY APPLICABLE LAW, IN NO EVENT AND UNDER NO LEGAL THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE SHALL ANY LICENSOR BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR RELATED TO THIS LICENSE, THE USE OR INABILITY TO USE THE WORK (INCLUDING BUT NOT LIMITED TO LOSS OF GOODWILL, BUSINESS INTERRUPTION, LOST PROFITS OR DATA, COMPUTER FAILURE OR MALFUNCTION, OR ANY OTHER COMM ERCIAL DAMAGES OR LOSSES), EVEN IF THE LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+Effective Date – April 18, 2008 © 2008 Amazon.com, Inc. or its affiliates. All rights reserved.

--- a/parsons/databases/redshift/queries/v_generate_tbl_ddl.sql
+++ b/parsons/databases/redshift/queries/v_generate_tbl_ddl.sql
@@ -1,0 +1,285 @@
+--DROP VIEW admin.v_generate_tbl_ddl;
+/**********************************************************************************************
+Purpose: View to get the DDL for a table.  This will contain the distkey, sortkey, constraints,
+         not null, defaults, etc.
+
+Notes:   Default view ordering causes foreign keys to be created at the end.
+         This is needed due to dependencies of the foreign key constraint and the tables it
+         links.  Due to this one should not manually order the output if you are expecting to
+         be able to replay the SQL directly from the VIEW query result. It is still possible to
+         order if you filter out the FOREIGN KEYS and then apply them later.
+
+         The following filters are useful:
+           where ddl not like 'ALTER TABLE %'  -- do not return FOREIGN KEY CONSTRAINTS
+           where ddl like 'ALTER TABLE %'      -- only get FOREIGN KEY CONSTRAINTS
+           where tablename in ('t1', 't2')     -- only get DDL for specific tables
+           where schemaname in ('s1', 's2')    -- only get DDL for specific schemas
+
+         So for example if you want to order DDL on tablename and only want the tables 't1', 't2'
+         and 't4' you can do so by using a query like:
+           select ddl from (
+             (
+               select
+                 *
+               from admin.v_generate_tbl_ddl
+               where ddl not like 'ALTER TABLE %'
+               order by tablename
+             )
+             UNION ALL
+             (
+               select
+                 *
+               from admin.v_generate_tbl_ddl
+               where ddl like 'ALTER TABLE %'
+               order by tablename
+             )
+           ) where tablename in ('t1', 't2', 't4');
+
+History:
+2014-02-10 jjschmit Created
+2015-05-18 ericfe Added support for Interleaved sortkey
+2015-10-31 ericfe Added cast tp increase size of returning constraint name
+2016-05-24 chriz-bigdata Added support for BACKUP NO tables
+2017-05-03 pvbouwel Change table & schemaname of Foreign key constraints to allow for filters
+2018-01-15 pvbouwel Add QUOTE_IDENT for identifiers (schema,table and column names)
+2018-05-30 adedotua Add table_id column
+2018-05-30 adedotua Added ENCODE RAW keyword for non compressed columns (Issue #308)
+2018-10-12 dmenin Added table ownership to the script (as an alter table statment as the owner of the table is the issuer of the CREATE TABLE command)
+2019-03-24 adedotua added filter for diststyle AUTO distribution style
+**********************************************************************************************/
+CREATE OR REPLACE VIEW admin.v_generate_tbl_ddl
+AS
+SELECT
+ table_id
+ ,REGEXP_REPLACE (schemaname, '^zzzzzzzz', '') AS schemaname
+ ,REGEXP_REPLACE (tablename, '^zzzzzzzz', '') AS tablename
+ ,seq
+ ,ddl
+FROM
+ (
+ SELECT
+  table_id
+  ,schemaname
+  ,tablename
+  ,seq
+  ,ddl
+ FROM
+  (
+  --DROP TABLE
+  SELECT
+   c.oid::bigint as table_id
+   ,n.nspname AS schemaname
+   ,c.relname AS tablename
+   ,0 AS seq
+   ,'--DROP TABLE ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ';' AS ddl
+  FROM pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  WHERE c.relkind = 'r'
+  --CREATE TABLE
+  UNION SELECT
+   c.oid::bigint as table_id
+   ,n.nspname AS schemaname
+   ,c.relname AS tablename
+   ,2 AS seq
+   ,'CREATE TABLE IF NOT EXISTS ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + '' AS ddl
+  FROM pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  WHERE c.relkind = 'r'
+  --OPEN PAREN COLUMN LIST
+  UNION SELECT c.oid::bigint as table_id,n.nspname AS schemaname, c.relname AS tablename, 5 AS seq, '(' AS ddl
+  FROM pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  WHERE c.relkind = 'r'
+  --COLUMN LIST
+  UNION SELECT
+   table_id
+   ,schemaname
+   ,tablename
+   ,seq
+   ,'\t' + col_delim + col_name + ' ' + col_datatype + ' ' + col_nullable + ' ' + col_default + ' ' + col_encoding AS ddl
+  FROM
+   (
+   SELECT
+    c.oid::bigint as table_id
+   ,n.nspname AS schemaname
+    ,c.relname AS tablename
+    ,100000000 + a.attnum AS seq
+    ,CASE WHEN a.attnum > 1 THEN ',' ELSE '' END AS col_delim
+    ,QUOTE_IDENT(a.attname) AS col_name
+    ,CASE WHEN STRPOS(UPPER(format_type(a.atttypid, a.atttypmod)), 'CHARACTER VARYING') > 0
+      THEN REPLACE(UPPER(format_type(a.atttypid, a.atttypmod)), 'CHARACTER VARYING', 'VARCHAR')
+     WHEN STRPOS(UPPER(format_type(a.atttypid, a.atttypmod)), 'CHARACTER') > 0
+      THEN REPLACE(UPPER(format_type(a.atttypid, a.atttypmod)), 'CHARACTER', 'CHAR')
+     ELSE UPPER(format_type(a.atttypid, a.atttypmod))
+     END AS col_datatype
+    ,CASE WHEN format_encoding((a.attencodingtype)::integer) = 'none'
+     THEN 'ENCODE RAW'
+     ELSE 'ENCODE ' + format_encoding((a.attencodingtype)::integer)
+     END AS col_encoding
+    ,CASE WHEN a.atthasdef IS TRUE THEN 'DEFAULT ' + adef.adsrc ELSE '' END AS col_default
+    ,CASE WHEN a.attnotnull IS TRUE THEN 'NOT NULL' ELSE '' END AS col_nullable
+   FROM pg_namespace AS n
+   INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+   INNER JOIN pg_attribute AS a ON c.oid = a.attrelid
+   LEFT OUTER JOIN pg_attrdef AS adef ON a.attrelid = adef.adrelid AND a.attnum = adef.adnum
+   WHERE c.relkind = 'r'
+     AND a.attnum > 0
+   ORDER BY a.attnum
+   )
+  --CONSTRAINT LIST
+  UNION (SELECT
+   c.oid::bigint as table_id
+   ,n.nspname AS schemaname
+   ,c.relname AS tablename
+   ,200000000 + CAST(con.oid AS INT) AS seq
+   ,'\t,' + pg_get_constraintdef(con.oid) AS ddl
+  FROM pg_constraint AS con
+  INNER JOIN pg_class AS c ON c.relnamespace = con.connamespace AND c.oid = con.conrelid
+  INNER JOIN pg_namespace AS n ON n.oid = c.relnamespace
+  WHERE c.relkind = 'r' AND pg_get_constraintdef(con.oid) NOT LIKE 'FOREIGN KEY%'
+  ORDER BY seq)
+  --CLOSE PAREN COLUMN LIST
+  UNION SELECT c.oid::bigint as table_id,n.nspname AS schemaname, c.relname AS tablename, 299999999 AS seq, ')' AS ddl
+  FROM pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  WHERE c.relkind = 'r'
+  --BACKUP
+  UNION SELECT
+  c.oid::bigint as table_id
+   ,n.nspname AS schemaname
+   ,c.relname AS tablename
+   ,300000000 AS seq
+   ,'BACKUP NO' as ddl
+FROM pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  INNER JOIN (SELECT
+    SPLIT_PART(key,'_',5) id
+    FROM pg_conf
+    WHERE key LIKE 'pg_class_backup_%'
+    AND SPLIT_PART(key,'_',4) = (SELECT
+      oid
+      FROM pg_database
+      WHERE datname = current_database())) t ON t.id=c.oid
+  WHERE c.relkind = 'r'
+  --BACKUP WARNING
+  UNION SELECT
+  c.oid::bigint as table_id
+   ,n.nspname AS schemaname
+   ,c.relname AS tablename
+   ,1 AS seq
+   ,'--WARNING: This DDL inherited the BACKUP NO property from the source table' as ddl
+FROM pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  INNER JOIN (SELECT
+    SPLIT_PART(key,'_',5) id
+    FROM pg_conf
+    WHERE key LIKE 'pg_class_backup_%'
+    AND SPLIT_PART(key,'_',4) = (SELECT
+      oid
+      FROM pg_database
+      WHERE datname = current_database())) t ON t.id=c.oid
+  WHERE c.relkind = 'r'
+  --DISTSTYLE
+  UNION SELECT
+   c.oid::bigint as table_id
+   ,n.nspname AS schemaname
+   ,c.relname AS tablename
+   ,300000001 AS seq
+   ,CASE WHEN c.reldiststyle = 0 THEN 'DISTSTYLE EVEN'
+    WHEN c.reldiststyle = 1 THEN 'DISTSTYLE KEY'
+    WHEN c.reldiststyle = 8 THEN 'DISTSTYLE ALL'
+    WHEN c.reldiststyle = 9 THEN 'DISTSTYLE AUTO'
+    ELSE '<<Error - UNKNOWN DISTSTYLE>>'
+    END AS ddl
+  FROM pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  WHERE c.relkind = 'r'
+  --DISTKEY COLUMNS
+  UNION SELECT
+   c.oid::bigint as table_id
+   ,n.nspname AS schemaname
+   ,c.relname AS tablename
+   ,400000000 + a.attnum AS seq
+   ,' DISTKEY (' + QUOTE_IDENT(a.attname) + ')' AS ddl
+  FROM pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  INNER JOIN pg_attribute AS a ON c.oid = a.attrelid
+  WHERE c.relkind = 'r'
+    AND a.attisdistkey IS TRUE
+    AND a.attnum > 0
+  --SORTKEY COLUMNS
+  UNION select table_id,schemaname, tablename, seq,
+       case when min_sort <0 then 'INTERLEAVED SORTKEY (' else ' SORTKEY (' end as ddl
+from (SELECT
+   c.oid::bigint as table_id
+   ,n.nspname AS schemaname
+   ,c.relname AS tablename
+   ,499999999 AS seq
+   ,min(attsortkeyord) min_sort FROM pg_namespace AS n
+  INNER JOIN  pg_class AS c ON n.oid = c.relnamespace
+  INNER JOIN pg_attribute AS a ON c.oid = a.attrelid
+  WHERE c.relkind = 'r'
+  AND abs(a.attsortkeyord) > 0
+  AND a.attnum > 0
+  group by 1,2,3,4 )
+  UNION (SELECT
+   c.oid::bigint as table_id
+   ,n.nspname AS schemaname
+   ,c.relname AS tablename
+   ,500000000 + abs(a.attsortkeyord) AS seq
+   ,CASE WHEN abs(a.attsortkeyord) = 1
+    THEN '\t' + QUOTE_IDENT(a.attname)
+    ELSE '\t, ' + QUOTE_IDENT(a.attname)
+    END AS ddl
+  FROM  pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  INNER JOIN pg_attribute AS a ON c.oid = a.attrelid
+  WHERE c.relkind = 'r'
+    AND abs(a.attsortkeyord) > 0
+    AND a.attnum > 0
+  ORDER BY abs(a.attsortkeyord))
+  UNION SELECT
+   c.oid::bigint as table_id
+   ,n.nspname AS schemaname
+   ,c.relname AS tablename
+   ,599999999 AS seq
+   ,'\t)' AS ddl
+  FROM pg_namespace AS n
+  INNER JOIN  pg_class AS c ON n.oid = c.relnamespace
+  INNER JOIN  pg_attribute AS a ON c.oid = a.attrelid
+  WHERE c.relkind = 'r'
+    AND abs(a.attsortkeyord) > 0
+    AND a.attnum > 0
+  --END SEMICOLON
+  UNION SELECT c.oid::bigint as table_id ,n.nspname AS schemaname, c.relname AS tablename, 600000000 AS seq, ';' AS ddl
+  FROM  pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  WHERE c.relkind = 'r'
+
+  UNION
+  --TABLE OWNERSHIP AS AN ALTER TABLE STATMENT
+  SELECT c.oid::bigint as table_id ,n.nspname AS schemaname, c.relname AS tablename, 600500000 AS seq,
+  'ALTER TABLE ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ' owner to '+  QUOTE_IDENT(u.usename) +';' AS ddl
+  FROM  pg_namespace AS n
+  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+  INNER JOIN pg_user AS u ON c.relowner = u.usesysid
+  WHERE c.relkind = 'r'
+
+  )
+  UNION (
+    SELECT c.oid::bigint as table_id,'zzzzzzzz' || n.nspname AS schemaname,
+       'zzzzzzzz' || c.relname AS tablename,
+       700000000 + CAST(con.oid AS INT) AS seq,
+       'ALTER TABLE ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ' ADD ' + pg_get_constraintdef(con.oid)::VARCHAR(1024) + ';' AS ddl
+    FROM pg_constraint AS con
+      INNER JOIN pg_class AS c
+             ON c.relnamespace = con.connamespace
+             AND c.oid = con.conrelid
+      INNER JOIN pg_namespace AS n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'r'
+    AND con.contype = 'f'
+    ORDER BY seq
+  )
+ ORDER BY table_id,schemaname, tablename, seq
+ )
+;

--- a/parsons/databases/redshift/queries/v_generate_view_ddl.sql
+++ b/parsons/databases/redshift/queries/v_generate_view_ddl.sql
@@ -1,0 +1,23 @@
+--DROP VIEW admin.v_generate_view_ddl;
+/**********************************************************************************************
+Purpose: View to get the DDL for a view.
+History:
+2014-02-10 jjschmit Created
+2018-01-15 pvbouwel Replace tabs and add QUOTE_IDENT for identifiers (schema and view names)
+2018-08-03 alexlsts Included CASE to check for late binding view
+**********************************************************************************************/
+CREATE OR REPLACE VIEW admin.v_generate_view_ddl
+AS
+SELECT
+    n.nspname AS schemaname
+    ,c.relname AS viewname
+    ,'--DROP VIEW ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ';\n'
+    + CASE
+     	WHEN c.relnatts > 0 then 'CREATE OR REPLACE VIEW ' + QUOTE_IDENT(n.nspname) + '.' + QUOTE_IDENT(c.relname) + ' AS\n' + COALESCE(pg_get_viewdef(c.oid, TRUE), '')
+     	ELSE  COALESCE(pg_get_viewdef(c.oid, TRUE), '') END AS ddl
+FROM
+    pg_catalog.pg_class AS c
+INNER JOIN
+    pg_catalog.pg_namespace AS n
+    ON c.relnamespace = n.oid
+WHERE relkind = 'v';

--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -1,4 +1,5 @@
 import logging
+import pkgutil
 
 logger = logging.getLogger(__name__)
 
@@ -601,9 +602,13 @@ class RedshiftTableUtilities(object):
         conditions_str = ' and '.join(conditions)
         where_clause = f"where {conditions_str}" if conditions_str else ''
 
+        ddl_query = pkgutil.get_data(
+            __name__, "queries/v_generate_tbl_ddl.sql").decode()
         sql_get_ddl = f"""
             select *
-            from admin.v_generate_tbl_ddl
+            from (
+                {ddl_query}
+            )
             {where_clause}
         """
         ddl_table = self.query(sql_get_ddl)
@@ -674,9 +679,13 @@ class RedshiftTableUtilities(object):
         conditions_str = ' and '.join(conditions)
         where_clause = f"where {conditions_str}" if conditions_str else ''
 
+        ddl_query = pkgutil.get_data(
+            __name__, "queries/v_generate_view_ddl.sql").decode()
         sql_get_ddl = f"""
             select schemaname || '.' || viewname as viewname, ddl
-            from admin.v_generate_view_ddl g
+            from (
+                {ddl_query}
+            )
             {where_clause}
         """
         ddl_view = self.query(sql_get_ddl)


### PR DESCRIPTION
The sql for the underlying queries is now included instead of relying on views to exist in the database.

Addresses #301 