### PR TITLE
VAN: Bulk Upload Initial Methods

### DIFF
--- a/docs/ngpvan.rst
+++ b/docs/ngpvan.rst
@@ -67,6 +67,34 @@ documentation for all functions.
 Common Workflows
 ****************
 
+===========
+Bulk Import
+===========
+For some methods, VAN allows you to bulk import multiple records to create or modify them. 
+
+The bulk upload endpoint, requires access to file on the public internet as it runs the upload
+asynchronously. Therefore, in order to bulk import, you must pass in cloud storage credentials
+so that the file can be posted. Currently, only S3 is supported.
+
+**Bulk Apply Activist Codes**
+
+.. code-block:: python
+
+   from parsons import VAN, Table
+
+   van = VAN(db=EveryAction)
+
+   # Load a table containing the VANID, activistcodeid and other options.
+   tbl = Table.from_csv('new_volunteers.csv')
+
+   # Table will be sent to S3 bucket and a POST request will be made to VAN creating
+   # the bulk import job with all of the valid meta information. The method will 
+   # return the job id.
+   job_id = van.bulk_apply_activist_codes(tbl, url_type="S3", bucket='my_bucket')
+
+   # The bulk import job is run asynchronously, so you may poll the status of a job.
+   job_status = van.get_bulk_import_job(job_id)
+
 ============================
 Scores: Loading and Updating
 ============================
@@ -77,7 +105,8 @@ Loading a score is a multi-step process. Once a score is set to approved, loadin
 
 .. code-block:: python
 
-   from parsons import VAN
+   from parsons import VAN, Table
+
    van = VAN(db='MyVoters') # API key stored as an environmental variable
 
    # If you don't know the id, you can run van.get_scores() to list the
@@ -225,6 +254,12 @@ People
 Activist Codes
 ==============
 .. autoclass:: parsons.ngpvan.van.ActivistCodes
+   :inherited-members:
+
+===========
+Bulk Import
+===========
+.. autoclass:: parsons.ngpvan.van.BulkImport
    :inherited-members:
 
 =================

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -4,6 +4,7 @@ from parsons.utilities import cloud_storage
 
 import logging
 import uuid
+import csv
 
 logger = logging.getLogger(__name__)
 
@@ -79,8 +80,13 @@ class BulkImport(object):
 
         # Move to cloud storage
         file_name = str(uuid.uuid1())
-        url = cloud_storage.post_file(tbl, url_type, file_path=file_name + '.zip', **url_kwargs)
+        url = cloud_storage.post_file(tbl,
+                                      url_type,
+                                      file_path=file_name + '.zip',
+                                      quoting=csv.QUOTE_ALL,
+                                      **url_kwargs)
         logger.info(f'Table uploaded to {url_type}.')
+        print (url)
 
         # Generate request json
         json = {"description": description,
@@ -89,7 +95,7 @@ class BulkImport(object):
                     "columns": [{'name': c} for c in tbl.columns],
                     "fileName": file_name + '.csv',
                     "hasHeader": "True",
-                    "hasQuotes": "False",
+                    "hasQuotes": "True",
                     "sourceUrl": url},
                 "actions": [{"resultFileSizeKbLimit": 5000,
                              "resourceType": resource_type,

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -75,8 +75,7 @@ class BulkImport(object):
 
     def post_bulk_import(self, tbl, url_type, resource_type, mapping_types,
                          description, **url_kwargs):
-        # Internal method to post bulk imports. Specific types of imports call this
-        # internal method.
+        # Internal method to post bulk imports.
 
         # Move to cloud storage
         file_name = str(uuid.uuid1())
@@ -104,7 +103,30 @@ class BulkImport(object):
 
     def bulk_apply_activist_codes(self, tbl, url_type, **url_kwargs):
         """
-        Apply activist codes
+        Bulk apply activist codes.
+
+        The table may include the following columns. The first column
+        must be ``vanid``.
+
+        .. list-table::
+            :widths: 25 25 50
+            :header-rows: 1
+
+            * - Column Name
+              - Required
+              - Description
+            * - ``vanid``
+              - Yes
+              - A valid VANID primary key
+            * - ``activistcodeid``
+              - Yes
+              - A valid activist code id
+            * - ``datecanvassed``
+              - No
+              - An ISO formatted date
+            * - ``contacttypeid``
+              - No
+              - The method of contact.
 
         `Args:`
             table: Parsons table
@@ -120,17 +142,9 @@ class BulkImport(object):
                 The bulk import job id
         """
 
-        self.validate_first_column(tbl, "vanid")
         return self.post_bulk_import(tbl,
                                      url_type,
                                      'ContactsActivistCodes',
                                      [{"name": "ActivistCode"}],
                                      'Activist Code Upload',
                                      **url_kwargs)
-
-    def validate_first_column(self, tbl, required_column):
-        # The first column of a file is restricted based on the ResourceType and MappingType
-        # and must match or be mapped to a specific column name. This method validates it.
-
-        if tbl.columns[0].lower() != required_column:
-            raise ValueError(f"First column name must be {required_column}")

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -33,6 +33,10 @@ class BulkImport(object):
         """
         Get a bulk import job status.
 
+        .. note::
+            The job status may not be immediately avaliable for polling job 
+            once the job is posted.
+
         `Args:`
             job_id : int
                 The bulk import job id.

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -86,7 +86,6 @@ class BulkImport(object):
                                       quoting=csv.QUOTE_ALL,
                                       **url_kwargs)
         logger.info(f'Table uploaded to {url_type}.')
-        print (url)
 
         # Generate request json
         json = {"description": description,

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -34,7 +34,7 @@ class BulkImport(object):
         Get a bulk import job status.
 
         .. note::
-            The job status may not be immediately avaliable for polling job 
+            The job status may not be immediately avaliable for polling job
             once the job is posted.
 
         `Args:`

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -33,10 +33,6 @@ class BulkImport(object):
         """
         Get a bulk import job status.
 
-        .. note::
-            The job status may not be immediately avaliable for polling job
-            once the job is posted.
-
         `Args:`
             job_id : int
                 The bulk import job id.

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -1,6 +1,10 @@
 """NGPVAN Bulk Import Endpoints"""
+from parsons.etl.table import Table
+from parsons.utilities import cloud_storage
 
 import logging
+import uuid
+
 logger = logging.getLogger(__name__)
 
 
@@ -24,3 +28,109 @@ class BulkImport(object):
         r = self.connection.get_request(f'bulkImportJobs/resources')
         logger.info(f'Found {len(r)} bulk import resources.')
         return r
+
+    def get_bulk_import_job(self, job_id):
+        """
+        Get a bulk import job status.
+
+        `Args:`
+            job_id : int
+                The bulk import job id.
+        `Returns:`
+            dict
+                The bulk import job
+        """
+
+        r = self.connection.get_request(f'bulkImportJobs/{job_id}')
+        logger.info(f'Found bulk import job {job_id}.')
+        return r
+
+    def get_bulk_import_mapping_types(self):
+        """
+        Get bulk import mapping types.
+
+        `Returns:`
+            Parsons Table
+                See :ref:`parsons-table` for output options.
+        """
+
+        tbl = Table(self.connection.get_request('bulkImportMappingTypes'))
+        logger.info(f'Found {tbl.num_rows} bulk import mapping types.')
+        return tbl
+
+    def get_bulk_import_mapping_type(self, type_name):
+        """
+        Get a single bulk import mapping type.
+
+        `Args:`
+            type_name: str
+        `Returns`:
+            dict
+                A mapping type json
+        """
+
+        r = self.connection.get_request(f'bulkImportMappingTypes/{type_name}')
+        logger.info(f'Found {type_name} bulk import mapping type.')
+        return r
+
+    def post_bulk_import(self, tbl, url_type, resource_type, mapping_types,
+                         description, **url_kwargs):
+        # Internal method to post bulk imports. Specific types of imports call this
+        # internal method.
+
+        # Move to cloud storage
+        file_name = str(uuid.uuid1())
+        url = cloud_storage.post_file(tbl, url_type, file_path=file_name + '.zip', **url_kwargs)
+        logger.info(f'Table uploaded to {url_type}.')
+
+        # Generate request json
+        json = {"description": description,
+                "file": {
+                    "columnDelimiter": 'csv',
+                    "columns": [{'name': c} for c in tbl.columns],
+                    "fileName": file_name + '.csv',
+                    "hasHeader": "True",
+                    "hasQuotes": "False",
+                    "sourceUrl": url},
+                "actions": [{"resultFileSizeKbLimit": 5000,
+                             "resourceType": resource_type,
+                             "actionType": "loadMappedFile",
+                             "mappingTypes": mapping_types}]
+                }
+
+        r = self.connection.post_request('bulkImportJobs', json=json)
+        logger.info(f"Bulk upload {r['jobId']} created.")
+        return r['jobId']
+
+    def bulk_apply_activist_codes(self, tbl, url_type, **url_kwargs):
+        """
+        Apply activist codes
+
+        `Args:`
+            table: Parsons table
+                A Parsons table.
+            url_type: str
+                The cloud file storage to use to post the file. Currently only ``S3``.
+            **url_kwargs: kwargs
+                Arguments to configure your cloud storage url type.
+                    * S3 requires ``bucket`` argument and, if not stored as env variables
+                      ``aws_access_key`` and ``aws_secret_access_key``.
+        `Returns:`
+            int
+                The bulk import job id
+        """
+
+        self.validate_first_column(tbl, "vanid")
+        return self.post_bulk_import(tbl,
+                                     url_type,
+                                     'ContactsActivistCodes',
+                                     [{"name": "ActivistCode"}],
+                                     'Activist Code Upload',
+                                     **url_kwargs)
+
+    def validate_first_column(self, tbl, required_column):
+        # The first column of a file is restricted based on the ResourceType and MappingType
+        # and must match or be mapped to a specific column name. This method validates it.
+
+        if tbl.columns[0].lower() != required_column:
+            raise ValueError(f"First column name must be {required_column}")

--- a/parsons/utilities/cloud_storage.py
+++ b/parsons/utilities/cloud_storage.py
@@ -1,3 +1,5 @@
+import csv
+
 """
 This utility method is a generalizable method for moving files to an
 online file storage class. It is used by methods that require access
@@ -6,7 +8,7 @@ in the future, might include SFTP, and Google Cloud Storage.
 """
 
 
-def post_file(tbl, type, file_path=None, **file_storage_args):
+def post_file(tbl, type, file_path=None, quoting=csv.QUOTE_MINIMAL, **file_storage_args):
     """
     This utility method is a generalizable method for moving files to an
     online file storage class. It is used by methods that require access
@@ -22,6 +24,8 @@ def post_file(tbl, type, file_path=None, **file_storage_args):
         file_path: str
             The file path to store the file. Not required if provided with
             the **file_storage_args.
+        quoting: attr
+            The type of quoting to use for the csv.
         **kwargs: kwargs
                 Optional arguments specific to the file storage.
     `Returns:`
@@ -34,7 +38,7 @@ def post_file(tbl, type, file_path=None, **file_storage_args):
         if 'key' in file_storage_args:
             file_storage_args['key'] = file_path
 
-        return tbl.to_s3_csv(public_url=True, key=file_path, **file_storage_args)
+        return tbl.to_s3_csv(public_url=True, key=file_path, quoting=quoting, **file_storage_args)
 
     # To Do: Add in SFTP, GoogleCloud Storage
 

--- a/test/test_van/test_bulkimport.py
+++ b/test/test_van/test_bulkimport.py
@@ -2,6 +2,8 @@ import unittest
 import os
 import requests_mock
 from parsons.ngpvan.van import VAN
+from parsons.etl.table import Table
+from test.utils import assert_matching_tables
 
 os.environ['VAN_API_KEY'] = 'SOME_KEY'
 
@@ -10,7 +12,8 @@ class TestBulkImport(unittest.TestCase):
 
     def setUp(self):
 
-        self.van = VAN(os.environ['VAN_API_KEY'], db="MyVoters", raise_for_status=False)
+        self.van = VAN(os.environ['VAN_API_KEY'],
+                       db="MyVoters", raise_for_status=False)
 
     def tearDown(self):
 
@@ -19,8 +22,74 @@ class TestBulkImport(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_bulk_import_resources(self, m):
 
-        json = ['Contacts', 'Contributions', 'ActivistCodes', 'ContactsActivistCodes']
+        json = ['Contacts', 'Contributions',
+                'ActivistCodes', 'ContactsActivistCodes']
 
         m.get(self.van.connection.uri + 'bulkImportJobs/resources', json=json)
 
         self.assertEqual(self.van.get_bulk_import_resources(), json)
+
+    @requests_mock.Mocker()
+    def test_get_bulk_import_job(self, m):
+
+        json = {'id': 59,
+                'status': 'InProgress',
+                'resourceType': 'ContactsActivistCodes',
+                'webhookUrl': None,
+                'resultFileSizeLimitKb': 5000,
+                'errors': [],
+                'resultFiles': []}
+
+        m.get(self.van.connection.uri + 'bulkImportJobs/53407', json=json)
+
+        self.assertEqual(self.van.get_bulk_import_job(53407), json)
+
+    @requests_mock.Mocker()
+    def test_get_bulk_import_mapping_types(self, m):
+
+        json = {'name': 'ActivistCode',
+                'displayName': 'Apply Activist Code',
+                'allowMultipleMode': 'Multiple',
+                'resourceTypes': ['Contacts', 'ContactsActivistCodes'],
+                'fields': [{
+                    'name': 'ActivistCodeID',
+                    'description': 'Activist Code ID',
+                    'hasPredefinedValues': True,
+                    'isRequired': True,
+                    'canBeMappedToColumn': True,
+                    'canBeMappedByName': True,
+                    'parents': None},
+                    {'name': 'CanvassedBy',
+                     'description': 'Recruited By, Must be a Valid User ID',
+                     'hasPredefinedValues': False,
+                     'isRequired': False,
+                     'canBeMappedToColumn': True,
+                     'canBeMappedByName': True,
+                     'parents': None},
+                    {'name': 'DateCanvassed',
+                     'description': 'Contacted When',
+                     'hasPredefinedValues': False,
+                     'isRequired': False,
+                     'canBeMappedToColumn': True,
+                     'canBeMappedByName': True,
+                     'parents': [{
+                         'parentFieldName': 'CanvassedBy',
+                         'limitedToParentValues': None
+                     }]
+                     }, {
+                    'name': 'ContactTypeID',
+                    'description': 'Contacted How',
+                    'hasPredefinedValues': True,
+                    'isRequired': False,
+                    'canBeMappedToColumn': True,
+                    'canBeMappedByName': True,
+                    'parents': [{
+                        'parentFieldName': 'CanvassedBy',
+                        'limitedToParentValues': None
+                    }]
+                }]
+                }
+
+        m.get(self.van.connection.uri + 'bulkImportMappingTypes', json=json)
+
+        assert_matching_tables(self.van.get_bulk_import_mapping_types(), Table(json))

--- a/test/test_van/test_bulkimport.py
+++ b/test/test_van/test_bulkimport.py
@@ -53,11 +53,11 @@ class TestBulkImport(unittest.TestCase):
         assert_matching_tables(self.van.get_bulk_import_mapping_types(), Table(mapping_type))
 
     @requests_mock.Mocker()
-    def get_bulk_import_mapping_type(self, m):
+    def test_get_bulk_import_mapping_type(self, m):
 
         m.get(self.van.connection.uri + 'bulkImportMappingTypes/ActivistCode', json=mapping_type)
 
-        self.assertEqual(self.van.get_bulk_import_mapping_type('ActivistCode'), json)
+        self.assertEqual(self.van.get_bulk_import_mapping_type('ActivistCode'), mapping_type)
 
     @requests_mock.Mocker()
     def test_post_bulk_import(self, m):


### PR DESCRIPTION
This PR contains the initial commits for the Bulk Upload functionality. The Bulk Import endpoint is pretty powerful and allow you to update contacts and contributions. For this initial functionality, I focused on a more basic type, activist codes.

**Public Methods**
- `get_bulk_import_job()`
- `get_bulk_import_mapping_types()`
- `get_bulk_import_mapping_type()`
- `bulk_apply_activist_codes()`

For future PRs:

- `bulk_create_update_person` - The ability to update contact data on a person level.
- Better validation prior to sending the request (checking that required columns are in the table.
- Convenience method to download the results of a bulk import job as a Parsons Table.

Additional Needs:
- Better documentation and additional options for cloud storage. Outlined in Issue #347.
