### PR TITLE
SurveyGizmo connector

### DIFF
--- a/parsons/surveygizmo/__init__.py
+++ b/parsons/surveygizmo/__init__.py
@@ -1,4 +1,3 @@
 from parsons.surveygizmo.surveygizmo import SurveyGizmo
 
-__all__ = [
-    'SurveyGizmo' ]
+__all__ = ['SurveyGizmo']

--- a/parsons/surveygizmo/__init__.py
+++ b/parsons/surveygizmo/__init__.py
@@ -1,0 +1,4 @@
+from parsons.surveygizmo.surveygizmo import SurveyGizmo
+
+__all__ = [
+    'SurveyGizmo' ]

--- a/parsons/surveygizmo/surveygizmo.py
+++ b/parsons/surveygizmo/surveygizmo.py
@@ -1,8 +1,10 @@
 import logging
 import surveygizmo
+from parsons.etl import Table
 from parsons.utilities import check_env
 
 logger = logging.getLogger(__name__)
+
 
 class SurveyGizmo(object):
     """
@@ -22,10 +24,14 @@ class SurveyGizmo(object):
     """
 
     def __init__(self, api_token, api_token_secret):
-        self.api_token=check_env('SURVEYGIZMO_API_TOKEN', api_token)
-        self.api_token_secret=check_env('SURVEYGIZMO_API_TOKEN_SECRET', api_token_secret)
+        self.api_token = check_env('SURVEYGIZMO_API_TOKEN', api_token)
+        self.api_token_secret = check_env('SURVEYGIZMO_API_TOKEN_SECRET', api_token_secret)
 
-        self.client = surveygizmo.SurveyGizmo(api_version='v5', api_token=self.api_token api_token_secret=self.api_token_secret)
+        self.client = surveygizmo.SurveyGizmo(
+                api_version='v5',
+                api_token=self.api_token,
+                api_token_secret=self.api_token_secret
+                )
 
     def get_surveys(self):
         """

--- a/parsons/surveygizmo/surveygizmo.py
+++ b/parsons/surveygizmo/surveygizmo.py
@@ -39,7 +39,7 @@ class SurveyGizmo(object):
                 api_token_secret=self.api_token_secret
                 )
 
-    def get_surveys(self):
+    def get_surveys(self, page=None):
         """
         Get a table of lists under the account.
 
@@ -50,12 +50,13 @@ class SurveyGizmo(object):
             Table Class
         """
 
-        r = self._client.api.survey.list()
+        r = self._client.api.survey.list(page)
         data = r['data']
 
-        while r['page'] < r['total_pages']:
-            r = self._client.api.survey.list(page=(r['page']+1))
-            data.extend(r['data'])
+        if not page:
+            while r['page'] < r['total_pages']:
+                r = self._client.api.survey.list(page=(r['page']+1))
+                data.extend(r['data'])
 
         tbl = Table(data).remove_column('links')
         tbl.unpack_dict('statistics', prepend=False)
@@ -76,7 +77,7 @@ class SurveyGizmo(object):
             Table Class
         """
 
-        r = self._client.api.surveyresponse.list(survey_id)
+        r = self._client.api.surveyresponse.list(survey_id, page)
         logger.info(f"{survey_id}: {r['total_count']} responses.")
         data = r['data']
 

--- a/parsons/surveygizmo/surveygizmo.py
+++ b/parsons/surveygizmo/surveygizmo.py
@@ -85,8 +85,9 @@ class SurveyGizmo(object):
             while r['page'] < r['total_pages']:
                 r = self._client.api.surveyresponse.list(survey_id, page=(r['page']+1))
                 data.extend(r['data'])
-                logger.info(f"{survey_id}: Retrieving {r['page']} of {r['total_count']}.")
 
         tbl = Table(data).add_column('survey_id', survey_id, index=1)
+
+        logger.info(f"Found #{tbl.num_rows} responses.")
 
         return tbl

--- a/parsons/surveygizmo/surveygizmo.py
+++ b/parsons/surveygizmo/surveygizmo.py
@@ -23,12 +23,13 @@ class SurveyGizmo(object):
         SurveyGizmo Class
     """
 
-    def __init__(self, api_token, api_token_secret):
-        self.api_token = check_env('SURVEYGIZMO_API_TOKEN', api_token)
-        self.api_token_secret = check_env('SURVEYGIZMO_API_TOKEN_SECRET', api_token_secret)
+    def __init__(self, api_token=None, api_token_secret=None, api_version='v5'):
+        self.api_token = check_env.check('SURVEYGIZMO_API_TOKEN', api_token)
+        self.api_token_secret = check_env.check('SURVEYGIZMO_API_TOKEN_SECRET', api_token_secret)
+        self.api_version = check_env.check('SURVEYGIZMO_API_VERSION', api_version)
 
         self.client = surveygizmo.SurveyGizmo(
-                api_version='v5',
+                api_version=self.api_version,
                 api_token=self.api_token,
                 api_token_secret=self.api_token_secret
                 )

--- a/parsons/surveygizmo/surveygizmo.py
+++ b/parsons/surveygizmo/surveygizmo.py
@@ -44,7 +44,9 @@ class SurveyGizmo(object):
         Get a table of lists under the account.
 
         `Args:`
-            None
+            page : int
+                Retrieve a specific page of responses. If not given,
+                then all pages are retrieved.
 
         `Returns:`
             Table Class
@@ -72,6 +74,10 @@ class SurveyGizmo(object):
         `Args:`
             survey_id: string
                 The id of survey for which to retrieve the responses.
+
+            page : int
+                Retrieve a specific page of responses. If not given,
+                then all pages are retrieved.
 
         `Returns:`
             Table Class

--- a/parsons/surveygizmo/surveygizmo.py
+++ b/parsons/surveygizmo/surveygizmo.py
@@ -1,0 +1,79 @@
+import logging
+import surveygizmo
+from parsons.utilities import check_env
+
+logger = logging.getLogger(__name__)
+
+class SurveyGizmo(object):
+    """
+    Instantiate SurveyGizmo Class
+
+    `Args:`
+        api_token:
+            The SurveyGizmo-provided application token. Not required if
+            ``SURVEYGIZMO_API_TOKEN`` env variable set.
+
+        api_token:
+            The SurveyGizmo-provided application token. Not required if
+            ``SURVEYGIZMO_API_TOKEN_SECRET`` env variable set.
+
+    `Returns:`
+        SurveyGizmo Class
+    """
+
+    def __init__(self, api_token, api_token_secret):
+        self.api_token=check_env('SURVEYGIZMO_API_TOKEN', api_token)
+        self.api_token_secret=check_env('SURVEYGIZMO_API_TOKEN_SECRET', api_token_secret)
+
+        self.client = surveygizmo.SurveyGizmo(api_version='v5', api_token=self.api_token api_token_secret=self.api_token_secret)
+
+    def get_surveys(self):
+        """
+        Get a table of lists under the account.
+
+        `Args:`
+            None
+
+        `Returns:`
+            Table Class
+        """
+
+        r = self.client.api.survey.list()
+        data = r['data']
+
+        while r['page'] < r['total_pages']:
+            r = self.client.api.survey.list(page=(r['page']+1))
+            data.extend(r['data'])
+
+        tbl = Table(data).remove_column('links')
+        tbl.unpack_dict('statistics', prepend=False)
+
+        logger.info(f"Found {tbl.num_rows} surveys.")
+
+        return tbl
+
+    def get_survey_responses(self, survey_id, page=None):
+        """
+        Get the responses for a given survey.
+
+        `Args:`
+            survey_id: string
+                The id of survey for which to retrieve the responses.
+
+        `Returns:`
+            Table Class
+        """
+
+        r = self.client.api.surveyresponse.list(survey_id)
+        logger.info(f"{survey_id}: {r['total_count']} responses.")
+        data = r['data']
+
+        if not page:
+            while r['page'] < r['total_pages']:
+                r = self.client.api.surveyresponse.list(survey_id, page=(r['page']+1))
+                data.extend(r['data'])
+                logger.info(f"{survey_id}: Retrieving {r['page']} of {r['total_count']}.")
+
+        tbl = Table(data).add_column('survey_id', survey_id, index=1)
+
+        return tbl

--- a/parsons/surveygizmo/surveygizmo.py
+++ b/parsons/surveygizmo/surveygizmo.py
@@ -19,6 +19,11 @@ class SurveyGizmo(object):
             The SurveyGizmo-provided application token. Not required if
             ``SURVEYGIZMO_API_TOKEN_SECRET`` env variable set.
 
+        api_version:
+            The version of the API that you would like to use. Not required if
+            ``SURVEYGIZMO_API_VERSION`` env variable set.
+            Default v5
+
     `Returns:`
         SurveyGizmo Class
     """

--- a/parsons/surveygizmo/surveygizmo.py
+++ b/parsons/surveygizmo/surveygizmo.py
@@ -33,7 +33,7 @@ class SurveyGizmo(object):
         self.api_token_secret = check_env.check('SURVEYGIZMO_API_TOKEN_SECRET', api_token_secret)
         self.api_version = check_env.check('SURVEYGIZMO_API_VERSION', api_version)
 
-        self.client = surveygizmo.SurveyGizmo(
+        self._client = surveygizmo.SurveyGizmo(
                 api_version=self.api_version,
                 api_token=self.api_token,
                 api_token_secret=self.api_token_secret
@@ -50,11 +50,11 @@ class SurveyGizmo(object):
             Table Class
         """
 
-        r = self.client.api.survey.list()
+        r = self._client.api.survey.list()
         data = r['data']
 
         while r['page'] < r['total_pages']:
-            r = self.client.api.survey.list(page=(r['page']+1))
+            r = self._client.api.survey.list(page=(r['page']+1))
             data.extend(r['data'])
 
         tbl = Table(data).remove_column('links')
@@ -76,13 +76,13 @@ class SurveyGizmo(object):
             Table Class
         """
 
-        r = self.client.api.surveyresponse.list(survey_id)
+        r = self._client.api.surveyresponse.list(survey_id)
         logger.info(f"{survey_id}: {r['total_count']} responses.")
         data = r['data']
 
         if not page:
             while r['page'] < r['total_pages']:
-                r = self.client.api.surveyresponse.list(survey_id, page=(r['page']+1))
+                r = self._client.api.surveyresponse.list(survey_id, page=(r['page']+1))
                 data.extend(r['data'])
                 logger.info(f"{survey_id}: Retrieving {r['page']} of {r['total_count']}.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ braintree==4.0.0
 python-dateutil==2.8.1
 azure-storage-blob==12.3.2
 PyGitHub==1.51
+surveygizmo==1.2.3
 
 # Testing Requirements
 requests-mock==1.5.2

--- a/test/test_surveygizmo/test_getresponses.py
+++ b/test/test_surveygizmo/test_getresponses.py
@@ -1,0 +1,19 @@
+import os
+import unittest
+import unittest.mock as mock
+from parsons.surveygizmo.surveygizmo import SurveyGizmo, Table
+import logging
+
+logger = logging.getLogger(__name__)
+
+class TestSurveyGizmoGetResponses(unittest.TestCase):
+    def setUp(self):
+        os.environ['SURVEYGIZMO_API_TOKEN'] = 'MYFAKEAPITOKEN'
+        os.environ['SURVEYGIZMO_API_TOKEN_SECRET'] = 'MYFAKETOKENSECRET'
+        os.environ['SURVEYGIZMO_API_VERSION'] = 'MYFAKEVERSION'
+
+        self.surveygizmo = SurveyGizmo()
+        self.surveygizmo._client = mock.MagicMock()
+
+    def test_foo(self):
+        pass

--- a/test/test_surveygizmo/test_getresponses.py
+++ b/test/test_surveygizmo/test_getresponses.py
@@ -15,5 +15,133 @@ class TestSurveyGizmoGetResponses(unittest.TestCase):
         self.surveygizmo = SurveyGizmo()
         self.surveygizmo._client = mock.MagicMock()
 
-    def test_foo(self):
-        pass
+        self.test_survey_id = "1234567"
+
+    def test_adds_survey_id(self):
+        api_return = self._get_responses_return_single_page()
+        self.surveygizmo._client.api.surveyresponse.list.return_value = api_return
+
+        actual_responses = self.surveygizmo.get_survey_responses(self.test_survey_id)
+
+        assert self.test_survey_id, actual_responses["survey_id"]
+
+    def _get_responses_return_single_page(self):
+        return {
+                "result_ok": True,
+                "total_count": 2,
+                "page": 1,
+                "total_pages": 1,
+                "results_per_page": 50,
+                "data": [
+                    {
+                        "id": "1",
+                        "contact_id": "",
+                        "status": "Complete",
+                        "is_test_data": "0",
+                        "date_submitted": "2018-09-27 10:42:26 EDT",
+                        "session_id": "1538059336_5bacec4869caa2.27680217",
+                        "language": "English",
+                        "date_started": "2018-09-27 10:42:16 EDT",
+                        "link_id": "7473882",
+                        "url_variables": [],
+                        "ip_address": "50.232.185.226",
+                        "referer": "https://app.surveygizmo.com/distribute/share/id/4599075",
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+                        "response_time": 10,
+                        "data_quality": [],
+                        "longitude": "-105.20369720459",
+                        "latitude": "40.050701141357",
+                        "country": "United States",
+                        "city": "Boulder",
+                        "region": "CO",
+                        "postal": "80301",
+                        "dma": "751",
+                        "survey_data": {
+                            "2": {
+                                "id": 2,
+                                "type": "RADIO",
+                                "question": "Will you attend the event?",
+                                "section_id": 1,
+                                "original_answer": "Yes",
+                                "answer": "1",
+                                "answer_id": 10001,
+                                "shown": True
+                                },
+                            "3": {
+                                "id": 3,
+                                "type": "TEXTBOX",
+                                "question": "How many guests will you bring?",
+                                "section_id": 1,
+                                "answer": "3",
+                                "shown": True
+                                },
+                            "4": {
+                                "id": 4,
+                                "type": "TEXTBOX",
+                                "question": "How many guests are under the age of 18?",
+                                "section_id": 1,
+                                "answer": "2",
+                                "shown": True
+                                }
+                            }
+                        },
+                    {
+                            "id": "2",
+                            "contact_id": "",
+                            "status": "Complete",
+                            "is_test_data": "0",
+                            "date_submitted": "2018-09-27 10:43:11 EDT",
+                            "session_id": "1538059381_5bacec751e41f4.51482165",
+                            "language": "English",
+                            "date_started": "2018-09-27 10:43:01 EDT",
+                            "link_id": "7473882",
+                            "url_variables": {
+                                "__dbget": {
+                                    "key": "__dbget",
+                                    "value": "True",
+                                    "type": "url"
+                                    }
+                                },
+                            "ip_address": "50.232.185.226",
+                            "referer": "",
+                            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+                            "response_time": 10,
+                            "data_quality": [],
+                            "longitude": "-105.20369720459",
+                            "latitude": "40.050701141357",
+                            "country": "United States",
+                            "city": "Boulder",
+                            "region": "CO",
+                            "postal": "80301",
+                            "dma": "751",
+                            "survey_data": {
+                                "2": {
+                                    "id": 2,
+                                    "type": "RADIO",
+                                    "question": "Will you attend the event?",
+                                    "section_id": 1,
+                                    "original_answer": "1",
+                                    "answer": "1",
+                                    "answer_id": 10001,
+                                    "shown": True
+                                    },
+                                "3": {
+                                    "id": 3,
+                                    "type": "TEXTBOX",
+                                    "question": "How many guests will you bring?",
+                                    "section_id": 1,
+                                    "answer": "2",
+                                    "shown": True
+                                    },
+                                "4": {
+                                    "id": 4,
+                                    "type": "TEXTBOX",
+                                    "question": "How many guests are under the age of 18?",
+                                    "section_id": 1,
+                                    "answer": "0",
+                                    "shown": True
+                                    }
+                                }
+                            }
+                  ]
+                }

--- a/test/test_surveygizmo/test_getresponses.py
+++ b/test/test_surveygizmo/test_getresponses.py
@@ -25,6 +25,16 @@ class TestSurveyGizmoGetResponses(unittest.TestCase):
 
         assert self.test_survey_id, actual_responses["survey_id"]
 
+    def test_get_responses_single_page(self):
+        api_return = self._get_responses_return_single_page()
+        self.surveygizmo._client.api.surveyresponse.list.return_value = api_return
+
+        actual_responses = self.surveygizmo.get_survey_responses(self.test_survey_id)
+
+        self.assertEqual(2, actual_responses.num_rows)
+        for i in range(0, 1):
+            self.assertEqual(api_return["data"][i]["session_id"], actual_responses[i]["session_id"])
+
     def _get_responses_return_single_page(self):
         return {
                 "result_ok": True,

--- a/test/test_surveygizmo/test_getsurveys.py
+++ b/test/test_surveygizmo/test_getsurveys.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 # Relevant links
 # V5 API Documentation https://apihelp.surveygizmo.com/help/version-5
 
-class TestSurveyGizmo(unittest.TestCase):
+class TestSurveyGizmoGetSurveys(unittest.TestCase):
     def setUp(self):
         os.environ['SURVEYGIZMO_API_TOKEN'] = 'MYFAKEAPITOKEN'
         os.environ['SURVEYGIZMO_API_TOKEN_SECRET'] = 'MYFAKETOKENSECRET'

--- a/test/test_surveygizmo/test_getsurveys.py
+++ b/test/test_surveygizmo/test_getsurveys.py
@@ -26,7 +26,7 @@ class TestSurveyGizmoGetSurveys(unittest.TestCase):
 
         self.assertEqual(2, actual_surveys.num_rows)
         for i in range(0, 1):
-            self.assertEqual(api_return["data"][i]["title"], actual_surveys[0]["title"])
+            self.assertEqual(api_return["data"][i]["title"], actual_surveys[i]["title"])
 
     def test_removes_links_field(self):
         api_return = self._get_surveys_return_single_page()

--- a/test/test_surveygizmo/test_surveygizmo.py
+++ b/test/test_surveygizmo/test_surveygizmo.py
@@ -26,6 +26,14 @@ class TestSurveyGizmo(unittest.TestCase):
         for i in range(0, 1):
             self.assertEqual(api_return["data"][i]["title"], actual_surveys[0]["title"])
 
+    def test_removes_links_field(self):
+        api_return = self._get_surveys_return_single_page()
+        self.surveygizmo._client.api.survey.list.return_value = api_return
+
+        actual_surveys = self.surveygizmo.get_surveys()
+
+        assert not "links" in actual_surveys.columns
+
 
     def _get_surveys_return_single_page(self):
         return {

--- a/test/test_surveygizmo/test_surveygizmo.py
+++ b/test/test_surveygizmo/test_surveygizmo.py
@@ -17,11 +17,14 @@ class TestSurveyGizmo(unittest.TestCase):
         self.surveygizmo._client = mock.MagicMock()
 
     def test_get_surveys_single_page(self):
-        self.surveygizmo._client.api.survey.list.return_value = self._get_surveys_return_single_page()
+        api_return = self._get_surveys_return_single_page()
+        self.surveygizmo._client.api.survey.list.return_value = api_return
 
         actual_surveys = self.surveygizmo.get_surveys()
 
         self.assertEqual(2, actual_surveys.num_rows)
+        for i in range(0, 1):
+            self.assertEqual(api_return["data"][i]["title"], actual_surveys[0]["title"])
 
 
     def _get_surveys_return_single_page(self):

--- a/test/test_surveygizmo/test_surveygizmo.py
+++ b/test/test_surveygizmo/test_surveygizmo.py
@@ -6,8 +6,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-class TestSurveyGizmo(unittest.TestCase):
+# Relevant links
+# V5 API Documentation https://apihelp.surveygizmo.com/help/version-5
 
+class TestSurveyGizmo(unittest.TestCase):
     def setUp(self):
         os.environ['SURVEYGIZMO_API_TOKEN'] = 'MYFAKEAPITOKEN'
         os.environ['SURVEYGIZMO_API_TOKEN_SECRET'] = 'MYFAKETOKENSECRET'

--- a/test/test_surveygizmo/test_surveygizmo.py
+++ b/test/test_surveygizmo/test_surveygizmo.py
@@ -1,0 +1,71 @@
+import os
+import unittest
+import unittest.mock as mock
+from parsons.surveygizmo.surveygizmo import SurveyGizmo, Table
+import logging
+
+logger = logging.getLogger(__name__)
+
+class TestSurveyGizmo(unittest.TestCase):
+
+    def setUp(self):
+        os.environ['SURVEYGIZMO_API_TOKEN'] = 'MYFAKEAPITOKEN'
+        os.environ['SURVEYGIZMO_API_TOKEN_SECRET'] = 'MYFAKETOKENSECRET'
+        os.environ['SURVEYGIZMO_API_VERSION'] = 'MYFAKEVERSION'
+
+        self.surveygizmo = SurveyGizmo()
+        self.surveygizmo._client = mock.MagicMock()
+
+    def test_get_surveys_single_page(self):
+        self.surveygizmo._client.api.survey.list.return_value = self._get_surveys_return_single_page()
+
+        actual_surveys = self.surveygizmo.get_surveys()
+
+        self.assertEqual(2, actual_surveys.num_rows)
+
+
+    def _get_surveys_return_single_page(self):
+        return {
+                "result_ok": True,
+                "total_count": "1461",
+                "page": 1,
+                "total_pages": 1,
+                "results_per_page": 50,
+                "data": [
+                    {
+                        "id": "1234567",
+                        "team": "433737",
+                        "type": "Standard Survey",
+                        "status": "Launched",
+                        "created_on": "2017-04-24 10:44:23",
+                        "modified_on": "2017-04-24 10:58:20",
+                        "title": "Survey",
+                        "statistics": {
+                            "Partial": 4,
+                            "Complete": 2
+                            },
+                        "links": {
+                            "edit": "[Link to Build Tab]",
+                            "publish": "[Link to Share Tab]",
+                            "default": "[Default Share Link]"
+                            }
+                        },
+                    {
+                        "id": "1234568",
+                        "team": "433737",
+                        "type": "Standard Survey",
+                        "status": "Launched",
+                        "created_on": "2017-04-24 09:53:01",
+                        "modified_on": "2017-04-24 09:53:55",
+                        "title": "Survey",
+                        "statistics": {
+                            "Partial": 1
+                            },
+                        "links": {
+                            "edit": "[Link to Build Tab]",
+                            "publish": "[Link to Share Tab]",
+                            "default": "[Default Share Link]"
+                            }
+                        }
+                    ]
+                }


### PR DESCRIPTION
Initial creation of SurveyGizmo connector based on the code in the issue https://github.com/move-coop/parsons/issues/297

[gist](https://gist.github.com/elyse-weiss/101d251eeed2e4f2fb25e8754ca493bd)


Have done manual testing
```python
>>> sg = SurveyGizmo(api_token=api_token, api_token_secret=api_token_secret)
>>> sg.get_surveys()
surveygizmo INFO Found 1 surveys.
{'id': '5820711', 'team': '1018675', 'type': 'Standard Survey', 'status': 'Launched', 'created_on': '2020-09-02 16:45:03', 'modified_on': '2020-09-02 16:46:46', 'title': 'Test Gizmo Connector'}
```

I would like to punt the automated microtests to a follow-up PR, in order to get this into availability for folks.



@elyse-weiss 
There are 3 methods in the provided gist that are not directly API wrappers, instead appearing to be helpers that were written for a specific case. Not sure whether we want to move these over. Or perhaps into a `SurveyGizmo.Helpers` or something.

- _strip_html
- parse_responses
- parse_respondents