### PR TITLE
redshift: add region parameter to copy from S3

### DIFF
--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -52,16 +52,6 @@ class S3(object):
         self.client = self.s3.meta.client
         """Boto3 API Session client object. Use for more advanced boto3 features."""
 
-    @property
-    def region_name(self):
-        """
-        Get the name of the AWS region for the S3 client.
-
-        `Returns:`
-            str region name
-        """
-        return self.aws.session.region_name
-
     def list_buckets(self):
         """
         List all buckets to which you have access.

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -52,6 +52,16 @@ class S3(object):
         self.client = self.s3.meta.client
         """Boto3 API Session client object. Use for more advanced boto3 features."""
 
+    @property
+    def region_name(self):
+        """
+        Get the name of the AWS region for the S3 client.
+
+        `Returns:`
+            str region name
+        """
+        return self.aws.session.region_name
+
     def list_buckets(self):
         """
         List all buckets to which you have access.

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -232,7 +232,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 dateformat='auto', timeformat='auto', emptyasnull=True,
                 blanksasnull=True, nullas=None, acceptinvchars=True, truncatecolumns=False,
                 columntypes=None, specifycols=None,
-                aws_access_key_id=None, aws_secret_access_key=None):
+                aws_access_key_id=None, aws_secret_access_key=None, aws_region=None):
         """
         Copy a file from s3 to Redshift.
 
@@ -314,10 +314,16 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             aws_secret_access_key:
                 An AWS secret access key granted to the bucket where the file is located. Not
                 required if keys are stored as environmental variables.
+            aws_region:
+                The AWS region where the source S3 bucket lives; if not specified, defaults to
+                the same region as the Redshift cluster. For more information about the region
+                parameter, see the
+                `AWS documentation <https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-source-s3.html#copy-region>`_.
+
         `Returns`
             Parsons Table or ``None``
                 See :ref:`parsons-table` for output options.
-        """
+        """  # noqa: E501
 
         with self.connection() as connection:
 

--- a/parsons/databases/redshift/rs_copy_table.py
+++ b/parsons/databases/redshift/rs_copy_table.py
@@ -24,7 +24,7 @@ class RedshiftCopyTable(object):
                        dateformat='auto', timeformat='auto', emptyasnull=True,
                        blanksasnull=True, nullas=None, acceptinvchars=True, truncatecolumns=False,
                        specifycols=None, aws_access_key_id=None, aws_secret_access_key=None,
-                       compression=None):
+                       compression=None, aws_region=None):
 
         # Source / Destination
         source = f's3://{bucket}/{key}'
@@ -40,6 +40,8 @@ class RedshiftCopyTable(object):
         # Other options
         if manifest:
             sql += "manifest \n"
+        if aws_region:
+            sql += f"region '{aws_region}'\n"
         sql += f"maxerror {max_errors} \n"
         if statupdate:
             sql += "statupdate on\n"

--- a/parsons/databases/redshift/rs_copy_table.py
+++ b/parsons/databases/redshift/rs_copy_table.py
@@ -42,6 +42,7 @@ class RedshiftCopyTable(object):
             sql += "manifest \n"
         if bucket_region:
             sql += f"region '{bucket_region}'\n"
+            logger.info('Copying data from S3 bucket %s in region %s', bucket, bucket_region)
         sql += f"maxerror {max_errors} \n"
         if statupdate:
             sql += "statupdate on\n"

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -160,7 +160,7 @@ class TestRedshift(unittest.TestCase):
         sql = self.rs.copy_statement('test_schema.test', 'buck', 'file.csv',
                                      aws_access_key_id='abc123',
                                      aws_secret_access_key='abc123',
-                                     aws_region='us-east-2')
+                                     bucket_region='us-east-2')
 
         # Scrub the keys
         sql = re.sub(r'id=.+;', '*id=HIDDEN*;', re.sub(r"key=.+'", "key=*HIDDEN*'", sql))

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -117,8 +117,11 @@ class TestRedshift(unittest.TestCase):
 
     def test_column_validate(self):
 
-        bad_cols = ['a', 'a', '', 'SELECT', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjklasdfjklasjkldfakljsdfjalsdkfjklasjdfklasjdfklasdkljf']  # noqa: E501
-        fixed_cols = ['a', 'a_1', 'col_2', 'col_3', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjkl']  # noqa: E501
+        bad_cols = ['a', 'a', '', 'SELECT', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasj'
+                    'dfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjklasdfjklasjkl'
+                    'dfakljsdfjalsdkfjklasjdfklasjdfklasdkljf']
+        fixed_cols = ['a', 'a_1', 'col_2', 'col_3', 'asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaks'
+                      'dfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjkl']
         self.assertEqual(self.rs.column_name_validate(bad_cols), fixed_cols)
 
     def test_create_statement(self):
@@ -152,18 +155,12 @@ class TestRedshift(unittest.TestCase):
         os.environ['AWS_ACCESS_KEY_ID'] = prior_aws_access_key_id
         os.environ['AWS_SECRET_ACCESS_KEY'] = prior_aws_secret_access_key
 
-    def scrub_copy_tokens(self, s):
-
-        s = re.sub('=.+;', '=*HIDDEN*;', s)
-        s = re.sub('aws_secret_access_key=.+\'',
-                   'aws_secret_access_key=*HIDDEN*\'', s)
-        return s
-
     def test_copy_statement(self):
 
-        sql = self.rs.copy_statement(
-            'test_schema.test', 'buck', 'file.csv',
-            aws_access_key_id='abc123', aws_secret_access_key='abc123')
+        sql = self.rs.copy_statement('test_schema.test', 'buck', 'file.csv',
+                                     aws_access_key_id='abc123',
+                                     aws_secret_access_key='abc123',
+                                     aws_region='us-east-2')
 
         # Scrub the keys
         sql = re.sub(r'id=.+;', '*id=HIDDEN*;', re.sub(r"key=.+'", "key=*HIDDEN*'", sql))
@@ -172,10 +169,11 @@ class TestRedshift(unittest.TestCase):
                             "dateformat 'auto'", "timeformat 'auto'", "csv delimiter ','",
                             "copy test_schema.test \nfrom 's3://buck/file.csv'",
                             "'aws_access_key_*id=HIDDEN*;aws_secret_access_key=*HIDDEN*'",
-                            'emptyasnull', 'blanksasnull', 'acceptinvchars']
+                            "region 'us-east-2'", 'emptyasnull', 'blanksasnull',
+                            'acceptinvchars']
 
         # Check that all of the expected options are there:
-        [self.assertNotEqual(sql.find(o), -1) for o in expected_options]
+        [self.assertNotEqual(sql.find(o), -1, o) for o in expected_options]
 
     def test_copy_statement_columns(self):
 
@@ -222,8 +220,10 @@ class TestRedshiftDB(unittest.TestCase):
 
         other_sql = f"""
                     create table {self.temp_schema}.test (id smallint,name varchar(5));
-                    create view {self.temp_schema}.test_view as (select * from {self.temp_schema}.test);
-                    """  # noqa: E501
+                    create view {self.temp_schema}.test_view as (
+                        select * from {self.temp_schema}.test
+                    );
+        """
 
         self.rs.query(setup_sql)
 


### PR DESCRIPTION
This commit adds the `aws_region` parameter to the `copy_s3`
method in the `Redshift` connector class to support loading keys
from an S3 bucket outside the current Redshift cluster's region.
The `aws_region` populates the `region` parameter in the `copy`
statement used to load the S3 data.

cc @elyse-weiss 

Fixes #356 

---
I don't have a good set up to test this. @elyse-weiss would you be able to test this locally for your use case?