### PR TITLE
fix actionnetwork empty list default value bug

### DIFF
--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -6,6 +6,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+API_URL = 'https://actionnetwork.org/api/v2'
+
 
 class ActionNetwork(object):
     """
@@ -13,15 +15,14 @@ class ActionNetwork(object):
         api_token: str
             The OSDI API token
         api_url:
-            The end point url
     """
-    def __init__(self, api_token=None, api_url=None):
+    def __init__(self, api_token=None):
         self.api_token = check_env.check('AN_API_TOKEN', api_token)
         self.headers = {
             "Content-Type": "application/json",
             "OSDI-API-Token": self.api_token
         }
-        self.api_url = check_env.check('AN_API_URL', api_url)
+        self.api_url = API_URL
         self.api = APIConnector(self.api_url, headers=self.headers)
 
     def _get_page(self, object_name, page, per_page=25):

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -77,9 +77,8 @@ class ActionNetwork(object):
         """
         return self.api.get_request(url=f"people/{person_id}")
 
-    def add_person(self, email_address, given_name=None, family_name=None, tags=[],
-                   languages_spoken=[], postal_addresses=[],
-                   **kwargs):
+    def add_person(self, email_address, given_name=None, family_name=None, tags=None,
+                   languages_spoken=None, postal_addresses=None, **kwargs):
         """
         `Args:`
             email_address:
@@ -126,14 +125,19 @@ class ActionNetwork(object):
         data = {
             "person": {
                 "email_addresses": email_addresses_field,
-                "given_name": given_name,
-                "family_name": family_name,
-                "languages_spoken": languages_spoken,
-                "postal_addresses": postal_addresses,
-                "custom_fields": {**kwargs}
               },
-            "add_tags": tags
         }
+        if given_name is not None:
+            data["person"]["given_name"] = given_name
+        if family_name is not None:
+            data["person"]["family_name"] = family_name
+        if languages_spoken is not None:
+            data["person"]["languages_spoken"] = languages_spoken
+        if postal_addresses is not None:
+            data["person"]["postal_address"] = postal_addresses
+        if tags is not None:
+            data["add_tags"] = tags
+        data["person"]["custom_fields"] = {**kwargs}
         response = self.api.post_request(url=f"{self.api_url}/people", data=json.dumps(data))
         identifiers = response['identifiers']
         person_id = [entry_id.split(':')[1]

--- a/test/test_action_network/test_action_network.py
+++ b/test/test_action_network/test_action_network.py
@@ -10,10 +10,10 @@ class TestActionNetwork(unittest.TestCase):
     @requests_mock.Mocker()
     def setUp(self, m):
 
-        self.api_url = 'http://fakeurl.com'
+        self.api_url = 'https://actionnetwork.org/api/v2'
         self.api_key = "fake_key"
 
-        self.an = ActionNetwork(self.api_key, self.api_url)
+        self.an = ActionNetwork(self.api_key)
 
         self.fake_datetime = '2019-02-29T00:00:00.000+0000'
         self.fake_date = '2019-02-29'


### PR DESCRIPTION
This is an attempt to close issue #281. I followed the suggestion to filter for supplied arguments when creating the data dictionary. Not sure if there is a cleaner way to do this. 

Working on this PR raised several questions for me:

1. Is there an acceptable default value that can be used in place of the empty lists, thereby avoiding all the ugly if statements? 

2. The Action Network API docs say that only `email_address` is required to POST a new person, so why does the `ActionNetwork` class have arguments for these particular non-required fields rather than having all the optional fields passed in as `**kwargs`? https://actionnetwork.org/docs/v2/post-people/

3. Unrelated to the specific bug in this PR, I noticed that the ActionNetwork Quick Start example in the RST fails (line 29 in action_network.rst) because it does not specify an 'api_url' argument. My question is, why does the class require a user-provided 'api_url'? Won't this argument always be 'https://actionnetwork.org/api/v2'? Something needs to be changed, but I'm not sure whether it is the Quick Start example or the class itself. 