### PR TITLE
Redshift: Add dist/sort keys to upsert.

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -690,9 +690,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
     def upsert(self, table_obj, target_table, primary_key, vacuum=True, distinct_check=True,
                cleanup_temp_table=True, **copy_args):
         """
-        Preform an upsert on an existing table. An upsert is a function in which records
-        in a table are updated and inserted at the same time. Unlike other SQL databases,
-        it does not exist natively in Redshift.
+        Preform an upsert on an existing table. An upsert is a function in which rows
+        in a table are updated and inserted at the same time.
 
         `Args:`
             table_obj: obj
@@ -716,7 +715,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         if not self.table_exists(target_table):
             logger.info('Target table does not exist. Copying into newly \
                          created target table.')
-            self.copy(table_obj, target_table)
+            self.copy(table_obj, target_table, distkey=primary_key, sortkey=primary_key)
             return None
 
         # Make target table column widths match incoming table, if necessary
@@ -762,6 +761,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                     copy_args = dict(copy_args, compupdate=False)
                 self.copy(table_obj, staging_tbl,
                           template_table=target_table,
+                          distkey=primary_key,
+                          sortkey=primary_key
                           **copy_args)
 
                 staging_table_name = staging_tbl.split('.')[1]


### PR DESCRIPTION
This PR does the following:

- Adds arguments that allow the user to set the dist/sort keys for an upsert. If the table does not previously exist, this will set the dist/sort keys. If the table exists, it will set the dist/sort keys for the staging table to the provided arguments.

- If the dist/sort key areguments are `None`, then it will set the primary_key as the dist/sort keys for the staging table.

The benefit of all of this should be that upserts should run faster whether the argument is passed or not, since the staging table will have a dist/sort key which will most likely be the same as the destination table.