### PR TITLE
Docs: Update Zoom

### DIFF
--- a/docs/zoom.rst
+++ b/docs/zoom.rst
@@ -5,24 +5,40 @@ Zoom
 Overview
 ********
 
-`Zoom <https://zoom.us>`_ is a video conferencing platform.
+`Zoom <https://zoom.us>`_ is a video conferencing platform. This connector supports
+fetching users, fetching meetings, fetching metadata for past meetings, and fetching
+participants of past meetings via the `Zoom API <https://marketplace.zoom.us/docs/api-reference/zoom-api/>`_.
+
+.. note::
+  Authentication
+    The ``Zoom`` class supports `JSON Web Token Authentication <https://marketplace.zoom.us/docs/guides/auth/jwt>`_.
+    You must `Create a JWT App <https://marketplace.zoom.us/docs/guides/build/jwt-app>`_ to obtain
+    an API Key and API Secret for authentication.
 
 ***********
 Quick Start
 ***********
 
-**Get Meeting Participants**
+To instantiate the ``Zoom`` class, you can either store your Zoom API
+key and secret as environmental variables (``ZOOM_API_KEY`` and ``ZOOM_API_SECRET``,
+respectively) or pass them in as arguments:
 
 .. code-block:: python
 
   from parsons import Zoom
+
+  # If environmental variables ZOOM_API_KEY and ZOOM_API_SECRET
+  # are set, no need for arguments
   zoom = Zoom()
 
-  # Get a table of host's meetings via their email or user id.
-  mtgs_tbl = zoom.get_meetings(bob@bob.com) 
+  # If providing authentication credentials via arguments
+  zoom = Zoom(api_key='my_api_key', api_secret='my_api_secret')
+
+  # Get a table of host's meetings via their email or user id
+  meetings_tbl = zoom.get_meetings('my_name@mail.com')
 
   # Get the list of participants in a past meeting
-  par_tbl = zoom.get_past_meeting_participants('asdf123ads')
+  participants_tbl = zoom.get_past_meeting_participants('my_meeting_id')
 
 ***
 API

--- a/parsons/zoom/zoom.py
+++ b/parsons/zoom/zoom.py
@@ -38,9 +38,7 @@ class Zoom:
         self.client.headers = {'authorization': f"Bearer {token}",
                                'content-type': "application/json"}
 
-    def get_request(self, endpoint, data_key, params=None, **kwargs):
-        # Internal GET request method.
-
+    def _get_request(self, endpoint, data_key, params=None, **kwargs):
         # To Do: Consider increasing default page size.
 
         self.refresh_header_token()
@@ -87,7 +85,7 @@ class Zoom:
         params = {'status': status,
                   'role_id': role_id}
 
-        tbl = self.get_request('users', 'users', params=params)
+        tbl = self._get_request('users', 'users', params=params)
         logger.info(f'Retrieved {tbl.num_rows} users.')
         return tbl
 
@@ -120,7 +118,7 @@ class Zoom:
                 See :ref:`parsons-table` for output options.
         """
 
-        tbl = self.get_request(f'users/{user_id}/meetings', 'meetings')
+        tbl = self._get_request(f'users/{user_id}/meetings', 'meetings')
         logger.info(f'Retrieved {tbl.num_rows} meetings.')
         return tbl
 
@@ -132,10 +130,11 @@ class Zoom:
             meeting_id: str
                 The meeting id
         `Returns:`
-            dict
+            Parsons Table
+                See :ref:`parsons-table` for output options.
         """
 
-        tbl = self.get_request(f'past_meetings/{meeting_uuid}', None)
+        tbl = self._get_request(f'past_meetings/{meeting_uuid}', None)
         logger.info(f'Retrieved meeting {meeting_uuid}.')
         return tbl
 
@@ -151,6 +150,6 @@ class Zoom:
                 See :ref:`parsons-table` for output options.
         """
 
-        tbl = self.get_request(f'report/meetings/{meeting_id}/participants', 'participants')
+        tbl = self._get_request(f'report/meetings/{meeting_id}/participants', 'participants')
         logger.info(f'Retrieved {tbl.num_rows} participants.')
         return tbl


### PR DESCRIPTION
This PR adds an Authentication Guide and improves the Overview and Quick Start for the Zoom connector, checking the boxes for Zoom in #269. 

In addition, I made the following changes after reviewing the docstrings and functions in the Zoom class:

- Corrected the return value description in the docstring for `get_past_meeting` from `dict` to `Table`
- Prepended an underscore to the private `get_request` method, following the convention used in most other connectors 