### PR TITLE
Docs: Update Azure Blob Storage

### DIFF
--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -8,43 +8,50 @@ Blob Storage
 ========
 Overview
 ========
-Azure Blob Storage is a cloud file storage system. It uses storage accounts to organize containers (similar to
-"buckets" for other storage providers) in which to store arbitrary files referred to as blobs.
 
-This connector currently only implements block blobs and not page or append blobs.
+`Azure Blob Storage <https://azure.microsoft.com/en-us/services/storage/blobs/>`_ is a cloud file storage system that
+uses storage accounts to organize containers (similar to "buckets" for other storage providers) in which to store
+arbitrary files referred to as 'blobs'. This Parsons integration currently only implements
+`block blobs, not page or append blobs <https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs>`_.
 
-You'll need credentials for an Azure Blob Storage storage account to use this connector. The ``azure-storage-blob``
-library is used for this connector, and `examples of how to create and use multiple types of credentials
-<https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/storage/azure-storage-blob#types-of-credentials>`_
-are included in the documentation.
+.. note::
+  Authentication
+    This connector requires authentication credentials for an Azure Blob Storage storage account. The
+    ``azure-storage-blob`` library is used for this connector, and examples of how to create and use
+    `multiple types of credentials <https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/storage/azure-storage-blob#types-of-credentials>`_
+    are included in the documentation.
 
 ==========
 Quickstart
 ==========
 
+This class requires a ``credentials`` argument and *either* an ``account_name`` or an ``account_url`` argument that
+includes the account name. You can store these as environmental variables (``AZURE_CREDENTIAL``, ``AZURE_ACCOUNT_NAME``,
+and ``AZURE_ACCOUNT_URL``, respectively) or pass them in as arguments:
+
+**Instantiate class**
+
+.. code-block:: python
+   from parsons import AzureBlobStorage
+
+   # First approach: Use API credentials via environmental variables
+   azure_blob = AzureBlobStorage()
+
+   # Second approach: Pass API credentials as arguments
+   azure_blob = AzureBlobStorage(account_name='my_account_name', credential='1234')
+
 **List containers and blobs**
 
 .. code-block:: python
-
-  from parsons import AzureBlobStorage
-
-  azure_blob = AzureBlobStorage()
-
   # Get all container names for a storage account
   container_names = azure_blob.list_containers()
 
   # Get all blob names for a storage account and container
   blob_names = azure_blob.list_blobs(container_names[0])
 
-
 **Create a blob from a file or ``Table``**
 
 .. code-block:: python
-
-  from parsons import AzureBlobStorage, Table
-
-  azure_blob = AzureBlobStorage()
-
   container_name = 'testcontainer'
 
   # Upload a CSV file from a local file path and set the content type
@@ -53,7 +60,6 @@ Quickstart
   # Create a Table and upload it as a JSON blob
   table = Table([{'first': 'Test', 'last': 'Person'}])
   azure_blob.upload_table(table, container_name, 'test2.json', data_type='json')
-
 
 **Download a blob**
 
@@ -75,5 +81,6 @@ Quickstart
 ===
 API
 ===
+
 .. autoclass:: parsons.AzureBlobStorage
    :inherited-members:

--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -52,30 +52,21 @@ and ``AZURE_ACCOUNT_URL``, respectively) or pass them in as arguments:
 **Create a blob from a file or ``Table``**
 
 .. code-block:: python
-  container_name = 'testcontainer'
-
   # Upload a CSV file from a local file path and set the content type
-  azure_blob.put_blob(container_name, 'test1.csv', './test1.csv', content_type='text/csv')
+  azure_blob.put_blob('blob_name', 'test1.csv', './test1.csv', content_type='text/csv')
 
   # Create a Table and upload it as a JSON blob
   table = Table([{'first': 'Test', 'last': 'Person'}])
-  azure_blob.upload_table(table, container_name, 'test2.json', data_type='json')
+  azure_blob.upload_table(table, 'blob_name', 'test2.json', data_type='json')
 
 **Download a blob**
 
 .. code-block:: python
-
-  from parsons import AzureBlobStorage
-
-  azure_blob = AzureBlobStorage()
-
-  container_name = 'testcontainer'
-
   # Download to a temporary file path
-  temp_file_path = azure_blob.download_blob(container_name, 'test.csv')
+  temp_file_path = azure_blob.download_blob('blob_name', 'test.csv')
 
   # Download to a specific file path
-  azure_blob.download_blob(container_name, 'test.csv', local_path='/tmp/test.csv')
+  azure_blob.download_blob('blob_name', 'test.csv', local_path='/tmp/test.csv')
 
 
 ===


### PR DESCRIPTION
- add Authentication Guide, improve Overview, and improve Quick Start 
- should check the boxes for Azure: Blob Storage in #269

**Question about the class:** 

@eliotst 

I believe the `account_domain` argument / env variable is unnecessary in `AzureBlogStorage` since it will always be `blob.core.windows.net` (this is why I don't mention it in the Authentication Guide or Quickstart). The argument currently defaults to  `blob.core.windows.net` and it doesn't cause any issues AFAIK; it just looks like clutter in the `__init__`. 

I haven't changed the class yet since I'm not 100% sure there isn't a good reason for keeping the argument, but if someone can confirm that `account_domain` should be a constant in the class, I'm happy to make the change in this PR. 