### PR TITLE
redshift: move distkey/sortkey warning

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -323,9 +323,6 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 See :ref:`parsons-table` for output options.
         """
 
-        # Warn the user if they don't provide a DIST key or a SORT key
-        self._log_key_warning(distkey=distkey, sortkey=sortkey, method='copy_s3')
-
         with self.connection() as connection:
 
             if self._create_table_precheck(connection, table_name, if_exists):
@@ -468,9 +465,6 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             Parsons Table or ``None``
                 See :ref:`parsons-table` for output options.
         """
-
-        # Warn the user if they don't provide a DIST key or a SORT key
-        self._log_key_warning(distkey=distkey, sortkey=sortkey, method='copy')
 
         # Specify the columns for a copy statement.
         if specifycols or (specifycols is None and template_table):
@@ -879,29 +873,6 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         # Return a Redshift table object
 
         return RedshiftTable(self, table_name)
-
-    @staticmethod
-    def _log_key_warning(distkey=None, sortkey=None, method=''):
-        # Log a warning message advising the user about DIST and SORT keys
-
-        if distkey and sortkey:
-            return
-
-        keys = [
-            (distkey, "DIST", "https://aws.amazon.com/about-aws/whats-new/2019/08/amazon-redshift-"
-                              "now-recommends-distribution-keys-for-improved-query-performance/"),
-            (sortkey, "SORT", "https://docs.amazonaws.cn/en_us/redshift/latest/dg/c_best-practices-"
-                              "sort-key.html")
-        ]
-        warning = "".join([
-            "You didn't provide a {} key to method `parsons.redshift.Redshift.{}`.\n"
-            "You can learn about best practices here:\n{}.\n".format(
-                keyname, method, keyinfo
-            ) for key, keyname, keyinfo in keys if not key])
-
-        warning += "You may be able to further optimize your queries."
-
-        logger.warning(warning)
 
 
 class RedshiftTable(BaseTable):

--- a/parsons/databases/redshift/rs_create_table.py
+++ b/parsons/databases/redshift/rs_create_table.py
@@ -35,6 +35,10 @@ class RedshiftCreateTable(object):
 
     def create_statement(self, tbl, table_name, padding=None, distkey=None, sortkey=None,
                          varchar_max=None, varchar_truncate=True, columntypes=None):
+
+        # Warn the user if they don't provide a DIST key or a SORT key
+        self._log_key_warning(distkey=distkey, sortkey=sortkey, method='copy')
+
         # Generate a table create statement
 
         # Validate and rename column names if needed
@@ -254,3 +258,26 @@ class RedshiftCreateTable(object):
             clean_columns.append(c)
 
         return clean_columns
+
+    @staticmethod
+    def _log_key_warning(distkey=None, sortkey=None, method=''):
+        # Log a warning message advising the user about DIST and SORT keys
+
+        if distkey and sortkey:
+            return
+
+        keys = [
+            (distkey, "DIST", "https://aws.amazon.com/about-aws/whats-new/2019/08/amazon-redshift-"
+                              "now-recommends-distribution-keys-for-improved-query-performance/"),
+            (sortkey, "SORT", "https://docs.amazonaws.cn/en_us/redshift/latest/dg/c_best-practices-"
+                              "sort-key.html")
+        ]
+        warning = "".join([
+            "You didn't provide a {} key to method `parsons.redshift.Redshift.{}`.\n"
+            "You can learn about best practices here:\n{}.\n".format(
+                keyname, method, keyinfo
+            ) for key, keyname, keyinfo in keys if not key])
+
+        warning += "You may be able to further optimize your queries."
+
+        logger.warning(warning)


### PR DESCRIPTION
This commit moves the warning for missing distkey / sortkeys when
copying data into Redshift to only fire when a new table is being
created, instead of whenever `copy` (or `upsert`) is called.

cc @tiburona 