### PR TITLE
Docs: Update AWS

### DIFF
--- a/docs/aws.rst
+++ b/docs/aws.rst
@@ -3,11 +3,11 @@ Amazon Web Services
 
 Parsons provides utility functions and/or connectors for three different `AWS services <https://aws.amazon.com/>`_.
 
-* :ref:`_aws_lambda`: AWS's `serverless computing platform <https://aws.amazon.com/lambda/>`_
-* :ref:`_aws_s3`: AWS's `object storage service <https://aws.amazon.com/s3/>`_
-* :ref:`_redshift`: AWS's `data warehousing service <https://aws.amazon.com/redshift/>`_, with two additional classes providing utility functions:
-  * :ref:`_redshift_table_and_view_api`: Methods for managing tables and views
-  * :ref:`_redshift_schema_api`: Methods for managing schema
+* :ref:`aws_lambda`: AWS's `serverless computing platform <https://aws.amazon.com/lambda/>`_
+* :ref:`aws_s3`: AWS's `object storage service <https://aws.amazon.com/s3/>`_
+* :ref:`redshift`: AWS's `data warehousing service <https://aws.amazon.com/redshift/>`_, with two additional classes providing utility functions:
+  * :ref:`redshift_table_and_view_api`: Methods for managing tables and views
+  * :ref:`redshift_schema_api`: Methods for managing schema
 
 See the documentation for each service for more details.
 
@@ -155,7 +155,7 @@ The connector utilizes the `psycopg2 <https://pypi.org/project/psycopg2/>`_ Pyth
 focus on input, output and querying of the database.
 
 In addition to the core API integration provided by the ``Redshift`` class, Parsons also includes utility functions for
-managing schemas and tables. See :ref:`_redshift_table_and_view_api` and :ref:`_redshift_schema_api` for more information.
+managing schemas and tables. See :ref:`redshift_table_and_view_api` and :ref:`redshift_schema_api` for more information.
 
 .. note::
    S3 Credentials

--- a/docs/aws.rst
+++ b/docs/aws.rst
@@ -76,6 +76,7 @@ API
 
 .. autofunction:: parsons.aws.event_command
 
+
 ***
 S3
 ***

--- a/docs/aws.rst
+++ b/docs/aws.rst
@@ -1,7 +1,7 @@
 Amazon Web Services
 ===================
 
-Parsons provides utility functions and/or connectors for three different `AWS services<https://aws.amazon.com/>`_:
+Parsons provides utility functions and/or connectors for three different `AWS services <https://aws.amazon.com/>`_.
 
 * :ref:`_aws_lambda`: AWS's `serverless computing platform <https://aws.amazon.com/lambda/>`_
 * :ref:`_aws_s3`: AWS's `object storage service <https://aws.amazon.com/s3/>`_
@@ -53,7 +53,6 @@ QuickStart
 A minimalistic example Lambda handler might look something like this:
 
 .. code-block:: python
-   :emphasize-lines: 5,6
 
    from parsons.aws import event_command, distribute_task
 
@@ -178,6 +177,7 @@ which can also be passed as environmental variables (``aws_access_key_id`` and `
 or keyword arguments.
 
 .. code-block:: python
+
   from parsons import Redshift
 
   # Pass credentials as environmental variables

--- a/docs/aws.rst
+++ b/docs/aws.rst
@@ -120,19 +120,19 @@ as keyword arguments.
    with open('winning_formula.csv') as w:
        s3.put_file('my_bucket', 'winning.csv, w)
 
-    # Put a Parsons Table as a CSV using convenience method.
-    tbl = Table.from_csv('winning_formula.csv')
-    tbl.to_s3_csv('my_bucket', 'winning.csv')
+   # Put a Parsons Table as a CSV using convenience method.
+   tbl = Table.from_csv('winning_formula.csv')
+   tbl.to_s3_csv('my_bucket', 'winning.csv')
 
-    # Download a csv file and convert to a table
-    f = s3.get_file('my_bucket', 'my_dir/my_file.csv')
-    tbl = Table(f)
+   # Download a csv file and convert to a table
+   f = s3.get_file('my_bucket', 'my_dir/my_file.csv')
+   tbl = Table(f)
 
-    # List buckets that you have access to
-    s3.list_buckets()
+   # List buckets that you have access to
+   s3.list_buckets()
 
-    # List the keys in a bucket
-    s3.list_keys('my_bucket')
+   # List the keys in a bucket
+   s3.list_keys('my_bucket')
 
 ===
 API

--- a/docs/aws.rst
+++ b/docs/aws.rst
@@ -1,9 +1,77 @@
 Amazon Web Services
 ===================
 
+Parsons provides utility functions and/or connectors for three different `AWS services<https://aws.amazon.com/>`_:
+
+* :ref:`_aws_lambda`: AWS's `serverless computing platform <https://aws.amazon.com/lambda/>`_
+* :ref:`_aws_s3`: AWS's `object storage service <https://aws.amazon.com/s3/>`_
+* :ref:`_redshift`: AWS's `data warehousing service <https://aws.amazon.com/redshift/>`_, with two additional classes providing utility functions:
+  * :ref:`_redshift_table_and_view_api`: Methods for managing tables and views
+  * :ref:`_redshift_schema_api`: Methods for managing schema
+
+See the documentation for each service for more details.
+
 ******
 Lambda
 ******
+
+.. _aws_lambda:
+
+========
+Overview
+========
+
+Parsons' ``distribute_task`` function allows you to distribute process rows of a table across multiple
+`AWS Lambda <https://aws.amazon.com/lambda/>`_ invocations.
+
+If you are running the processing of a table inside AWS Lambda, then you are limited by how many rows can be processed
+within the Lambda's time limit (at time-of-writing, maximum 15min).
+
+Based on experience and some napkin math, with the same data that would allow 1000 rows to be processed inside a single
+AWS Lambda instance, this method allows 10 MILLION rows to be processed.
+
+Rather than converting the table to SQS or other options, the fastest way is to upload the table to S3, and then invoke
+multiple Lambda sub-invocations, each of which can be sent a byte-range of the data in the S3 CSV file for which to process.
+
+Using this method requires some setup. You have three tasks:
+
+1. Define the function to process rows, the first argument, must take your table's data (though only a subset of rows
+will be passed) (e.g. `def task_for_distribution(table, **kwargs):`)
+2. Where you would have run `task_for_distribution(my_table, **kwargs)` instead call
+``distribute_task(my_table, task_for_distribution, func_kwargs=kwargs)`` (either setting env var S3_TEMP_BUCKET or
+passing a ``bucket=`` parameter)
+3. Setup your Lambda handler to include :py:meth:`parsons.aws.event_command` (or run and deploy your lambda with
+`Zappa <https://github.com/Miserlou/Zappa>`_)
+
+To test locally, include the argument `storage="local"`, which will test the distribute_task function, but run the task
+sequentially and in local memory.
+
+==========
+QuickStart
+==========
+
+A minimalistic example Lambda handler might look something like this:
+
+.. code-block:: python
+   :emphasize-lines: 5,6
+
+   from parsons.aws import event_command, distribute_task
+
+   def process_table(table, foo, bar=None):
+       for row in table:
+           do_sloooooow_thing(row, foo, bar)
+
+   def handler(event, context):
+       ## ADD THESE TWO LINES TO TOP OF HANDLER:
+       if event_command(event, context):
+           return
+       table = FakeDatasource.load_to_table(username='123', password='abc')
+       # table is so big that running
+       #   process_table(table, foo=789, bar='baz') would timeout
+       # so instead we:
+       distribute_task(table, process_table,
+                       bucket='my-temp-s3-bucket',
+                       func_kwargs={'foo': 789, 'bar': 'baz'})
 
 ===
 API
@@ -16,60 +84,55 @@ API
 S3
 ***
 
+.. _aws_s3:
+
 ========
 Overview
 ========
 
-S3 is Amazon Web Service's object storage service that allows users to store and access data objects. The Parson's class is a high level wrapper of the AWS SDK `boto3 <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_. It allows users to upload and download files from S3 as well as manipulate buckets.
+The ``S3`` class allows interaction with Amazon Web Service's `object storage service <https://aws.amazon.com/s3/>`_
+to store and access data objects. It is a wrapper around the AWS SDK `boto3 <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_.
+It provides methods to upload and download files from S3 as well as manipulate buckets.
 
 .. note::
   Authentication
-    Access to S3 is controlled through AWS Identity and Access Management (IAM) users in the `AWS Managerment Console <https://aws.amazon.com/console/>`_ . Users can be granted granular access to AWS resources, including S3. IAM users are provisioned keys, which are required to access the S3 class. 
+    Access to S3 is controlled through AWS Identity and Access Management (IAM) users in the `AWS Managerment Console <https://aws.amazon.com/console/>`_ .
+    Users can be granted granular access to AWS resources, including S3. IAM users are provisioned keys, which are required to access the S3 class.
 
 ==========
 QuickStart
 ==========
 
-Instantiate class with credentials.
+S3 credentials can either be passed as environmental variables (``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``) or
+as keyword arguments.
 
 .. code-block:: python
 
    from parsons import S3
 
-   # First approach: Use API credentials via environmental variables
+   # First approach: Pass API credentials via environmental variables
    s3 = S3()
 
    # Second approach: Pass API credentials as arguments
    s3 = S3(aws_access_key_id='MY_KEY', aws_secret_access_key='MY_SECRET')
 
-   # Third approach: Use credentials stored in AWS CLI file ~/.aws/credentials
-   s3 = S3()
+   # Put an arbitrary file in an S3 bucket
+   with open('winning_formula.csv') as w:
+       s3.put_file('my_bucket', 'winning.csv, w)
 
-You can then call various endpoints:
+    # Put a Parsons Table as a CSV using convenience method.
+    tbl = Table.from_csv('winning_formula.csv')
+    tbl.to_s3_csv('my_bucket', 'winning.csv')
 
-.. code-block:: python
-  
-  from parsons import S3, Table
+    # Download a csv file and convert to a table
+    f = s3.get_file('my_bucket', 'my_dir/my_file.csv')
+    tbl = Table(f)
 
-  s3 = S3(aws_access_key_id='MY_KEY', aws_secret_access_key='MY_SECRET')
+    # List buckets that you have access to
+    s3.list_buckets()
 
-  # Put an arbitrary file in an S3 bucket
-  with open('winning_formula.csv') as w:
-    s3.put_file('my_bucket', 'winning.csv, w)
-
-  # Put a Parsons Table as a CSV using convenience method.
-  tbl = Table.from_csv('winning_formula.csv')
-  tbl.to_s3_csv('my_bucket', 'winning.csv')
-
-  # Download a csv file and convert to a table
-  f = s3.get_file('my_bucket', 'my_dir/my_file.csv')
-  tbl = Table(f)
-
-  # List buckets that you have access to
-  s3.list_buckets()
-
-  # List the keys in a bucket
-  s3.list_keys('my_bucket')
+    # List the keys in a bucket
+    s3.list_keys('my_bucket')
 
 ===
 API
@@ -77,7 +140,6 @@ API
 
 .. autoclass :: parsons.S3
    :inherited-members:
-   :members:
 
 ********
 Redshift
@@ -89,43 +151,54 @@ Redshift
 Overview
 ========
 
-The Redshift class allows you to interact with an `Amazon Redshift <https://aws.amazon.com/redshift/>`_ relational database. The Redshift Connector utilizes the ``psycopg2`` python package to connect to the database.
+The ``Redshift`` class allows you to interact with an `Amazon Redshift <https://aws.amazon.com/redshift/>`_ relational database.
+The connector utilizes the `psycopg2 <https://pypi.org/project/psycopg2/>`_ Python package under the hood. The core methods
+focus on input, output and querying of the database.
+
+In addition to the core API integration provided by the ``Redshift`` class, Parsons also includes utility functions for
+managing schemas and tables. See :ref:`_redshift_table_and_view_api` and :ref:`_redshift_schema_api` for more information.
 
 .. note::
    S3 Credentials
       Redshift only allows data to be copied to the database via S3. As such, the the :meth:`copy` and :meth:`copy_s3()`
       methods require S3 credentials and write access on an S3 Bucket, which will be used for storing data en route to
-      Redshift.
+      Redshift. See the `API documentation <https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html>`_
+      for more information about AWS Redshift authorization.
    Whitelisting
-	Remember to ensure that the IP address from which you are connecting has been whitelisted.
+      Remember to ensure that the IP address from which you are connecting has been whitelisted.
 
 ==========
 Quickstart
 ==========
 
-**Query the Database**
+Redshift API credentials can either be passed as environmental variables (``REDSHIFT_USERNAME``, ``REDSHIFT_PASSWORD``,
+``REDSHIFT_HOST``, ``REDSHIFT_DB``, and ``REDSHIFT_PORT``) or as keyword arguments. Methods that use COPY require an
+`access key ID and a secret access key <https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html>`_,
+which can also be passed as environmental variables (``aws_access_key_id`` and ``aws_secret_access_key``)
+or keyword arguments.
 
 .. code-block:: python
-
   from parsons import Redshift
+
+  # Pass credentials as environmental variables
   rs = Redshift()
+
+  # Pass credentials as keyword arguments
+  rs = Redshift(username='my_username', password='my_password', host='my_host',
+                db='my_db', port='5439')
+
+  # Query the Database
   table = rs.query('select * from tmc_scratch.test_data')
 
-**Copy a Parsons Table to the Database**
-
-.. code-block:: python
-
-  from parsons import Redshift
-  rs = Redshift()
+  # Copy a Parsons Table to the Database
   table = rs.copy(tbl, 'tmc_scratch.test_table', if_exists='drop')
 
-All of the standard copy options can be passed as kwargs. See the :meth:`copy` method for all
+All of the standard COPY options can be passed as kwargs. See the :meth:`copy` method for all
 options.
 
 ========
-Core API
+CORE API
 ========
-Redshift core methods focus on input, output and querying of the database.
 
 .. autoclass :: parsons.Redshift
 
@@ -147,6 +220,8 @@ Redshift core methods focus on input, output and querying of the database.
 
 .. autofunction:: parsons.Redshift.alter_table_column_type
 
+.. _redshift_table_and_view_api:
+
 ==================
 Table and View API
 ==================
@@ -156,6 +231,8 @@ used SQL queries run against the Redshift database.
 .. autoclass :: parsons.databases.redshift.redshift.RedshiftTableUtilities
    :inherited-members:
 
+.. _redshift_schema_api:
+
 ==========
 Schema API
 ==========
@@ -164,4 +241,3 @@ used SQL queries run against the Redshift database.
 
 .. autoclass :: parsons.databases.redshift.redshift.RedshiftSchema
    :inherited-members:
-

--- a/docs/aws.rst
+++ b/docs/aws.rst
@@ -3,9 +3,10 @@ Amazon Web Services
 
 Parsons provides utility functions and/or connectors for three different `AWS services <https://aws.amazon.com/>`_.
 
-* :ref:`aws_lambda`: AWS's `serverless computing platform <https://aws.amazon.com/lambda/>`_
-* :ref:`aws_s3`: AWS's `object storage service <https://aws.amazon.com/s3/>`_
-* :ref:`redshift`: AWS's `data warehousing service <https://aws.amazon.com/redshift/>`_, with two additional classes providing utility functions:
+* :ref:`Lambda <aws_lambda>`: AWS's `serverless computing platform <https://aws.amazon.com/lambda/>`_
+* :ref:`S3 <aws_s3>`: AWS's `object storage service <https://aws.amazon.com/s3/>`_
+* :ref:`Redshift <redshift>`: AWS's `data warehousing service <https://aws.amazon.com/redshift/>`_, with two additional classes providing utility functions.
+
   * :ref:`redshift_table_and_view_api`: Methods for managing tables and views
   * :ref:`redshift_schema_api`: Methods for managing schema
 
@@ -35,13 +36,9 @@ multiple Lambda sub-invocations, each of which can be sent a byte-range of the d
 
 Using this method requires some setup. You have three tasks:
 
-1. Define the function to process rows, the first argument, must take your table's data (though only a subset of rows
-will be passed) (e.g. `def task_for_distribution(table, **kwargs):`)
-2. Where you would have run `task_for_distribution(my_table, **kwargs)` instead call
-``distribute_task(my_table, task_for_distribution, func_kwargs=kwargs)`` (either setting env var S3_TEMP_BUCKET or
-passing a ``bucket=`` parameter)
-3. Setup your Lambda handler to include :py:meth:`parsons.aws.event_command` (or run and deploy your lambda with
-`Zappa <https://github.com/Miserlou/Zappa>`_)
+#. Define the function to process rows, the first argument, must take your table's data (though only a subset of rows will be passed) (e.g. `def task_for_distribution(table, **kwargs):`)
+#. Where you would have run `task_for_distribution(my_table, **kwargs)` instead call ``distribute_task(my_table, task_for_distribution, func_kwargs=kwargs)`` (either setting env var S3_TEMP_BUCKET or passing a ``bucket=`` parameter)
+#. Setup your Lambda handler to include :py:meth:`parsons.aws.event_command` (or run and deploy your lambda with `Zappa <https://github.com/Miserlou/Zappa>`_)
 
 To test locally, include the argument `storage="local"`, which will test the distribute_task function, but run the task
 sequentially and in local memory.

--- a/docs/aws.rst
+++ b/docs/aws.rst
@@ -103,14 +103,14 @@ It provides methods to upload and download files from S3 as well as manipulate b
 QuickStart
 ==========
 
-S3 credentials can either be passed as environmental variables (``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``) or
-as keyword arguments.
+S3 credentials can be passed as environmental variables (``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``),
+stored in an AWS CLI file ``~/.aws/credentials``, or passed as keyword arguments.
 
 .. code-block:: python
 
    from parsons import S3
 
-   # First approach: Pass API credentials via environmental variables
+   # First approach: Pass API credentials via environmental variables or an AWS CLI file
    s3 = S3()
 
    # Second approach: Pass API credentials as arguments
@@ -197,7 +197,7 @@ All of the standard COPY options can be passed as kwargs. See the :meth:`copy` m
 options.
 
 ========
-CORE API
+Core API
 ========
 
 .. autoclass :: parsons.Redshift

--- a/docs/aws.rst
+++ b/docs/aws.rst
@@ -36,8 +36,8 @@ multiple Lambda sub-invocations, each of which can be sent a byte-range of the d
 
 Using this method requires some setup. You have three tasks:
 
-#. Define the function to process rows, the first argument, must take your table's data (though only a subset of rows will be passed) (e.g. `def task_for_distribution(table, **kwargs):`)
-#. Where you would have run `task_for_distribution(my_table, **kwargs)` instead call ``distribute_task(my_table, task_for_distribution, func_kwargs=kwargs)`` (either setting env var S3_TEMP_BUCKET or passing a ``bucket=`` parameter)
+#. Define the function to process rows, the first argument, must take your table's data (though only a subset of rows will be passed) (e.g. ``def task_for_distribution(table, **kwargs):``)
+#. Where you would have run ``task_for_distribution(my_table, **kwargs)`` instead call ``distribute_task(my_table, task_for_distribution, func_kwargs=kwargs)`` (either setting env var S3_TEMP_BUCKET or passing a ``bucket=`` parameter)
 #. Setup your Lambda handler to include :py:meth:`parsons.aws.event_command` (or run and deploy your lambda with `Zappa <https://github.com/Miserlou/Zappa>`_)
 
 To test locally, include the argument `storage="local"`, which will test the distribute_task function, but run the task

--- a/docs/aws.rst
+++ b/docs/aws.rst
@@ -40,8 +40,7 @@ Using this method requires some setup. You have three tasks:
 #. Where you would have run ``task_for_distribution(my_table, **kwargs)`` instead call ``distribute_task(my_table, task_for_distribution, func_kwargs=kwargs)`` (either setting env var S3_TEMP_BUCKET or passing a ``bucket=`` parameter)
 #. Setup your Lambda handler to include :py:meth:`parsons.aws.event_command` (or run and deploy your lambda with `Zappa <https://github.com/Miserlou/Zappa>`_)
 
-To test locally, include the argument `storage="local"`, which will test the distribute_task function, but run the task
-sequentially and in local memory.
+To test locally, include the argument ``storage="local"``, which will test the ``distribute_task`` function, but run the task sequentially and in local memory.
 
 ==========
 QuickStart
@@ -73,8 +72,9 @@ A minimalistic example Lambda handler might look something like this:
 API
 ===
 
-.. autofunction :: parsons.aws.distribute_task
-.. autofunction :: parsons.aws.event_command
+.. autofunction:: parsons.aws.distribute_task
+
+.. autofunction:: parsons.aws.event_command
 
 ***
 S3
@@ -134,8 +134,9 @@ stored in an AWS CLI file ``~/.aws/credentials``, or passed as keyword arguments
 API
 ===
 
-.. autoclass :: parsons.S3
+.. autoclass:: parsons.S3
    :inherited-members:
+
 
 ********
 Redshift
@@ -197,7 +198,7 @@ options.
 Core API
 ========
 
-.. autoclass :: parsons.Redshift
+.. autoclass:: parsons.Redshift
 
 .. autofunction:: parsons.Redshift.connection
 
@@ -222,10 +223,11 @@ Core API
 ==================
 Table and View API
 ==================
+
 Table and view utilities are a series of helper methods, all built off of commonly
 used SQL queries run against the Redshift database.
 
-.. autoclass :: parsons.databases.redshift.redshift.RedshiftTableUtilities
+.. autoclass:: parsons.databases.redshift.redshift.RedshiftTableUtilities
    :inherited-members:
 
 .. _redshift_schema_api:
@@ -233,8 +235,9 @@ used SQL queries run against the Redshift database.
 ==========
 Schema API
 ==========
+
 Schema utilities are a series of helper methods, all built off of commonly
 used SQL queries run against the Redshift database.
 
-.. autoclass :: parsons.databases.redshift.redshift.RedshiftSchema
+.. autoclass:: parsons.databases.redshift.redshift.RedshiftSchema
    :inherited-members:

--- a/docs/build_a_connector.rst
+++ b/docs/build_a_connector.rst
@@ -250,34 +250,34 @@ Adding automated tests
  * Add one `“Happy Path” <https://en.wikipedia.org/wiki/Happy_path>`_ test per public method of your connector
  * When possible mock out any external integrations, otherwise mark your test using the
 
-```python
-from parsons.yourconnector.yourconnector import YourConnector
-import unittest
-import requests_mock
+.. code-block:: python
+
+    from parsons.yourconnector.yourconnector import YourConnector
+    import unittest
+    import requests_mock
 
 
-class TestYourConnector(unittest.TestCase):
+    class TestYourConnector(unittest.TestCase):
 
-    def setUp(self):
+        def setUp(self):
 
-        # add any setup code here to run before each test
-        pass
+            # add any setup code here to run before each test
+            pass
 
-    def tearDown(self):
+        def tearDown(self):
 
-        # add any teardown code here to run after each test
-        pass
+            # add any teardown code here to run after each test
+            pass
 
-    @requests_mock.Mocker()
-    def test_get_things(self, m):
+        @requests_mock.Mocker()
+        def test_get_things(self, m):
 
-    	# Test that campaigns are returned correctly.
-        m.get(‘http://yourconnector.com/v1/things’, json=[])
-        yc = YourConnector()
-        tbl = yc.get_things()
+            # Test that campaigns are returned correctly.
+            m.get('http://yourconnector.com/v1/things', json=[])
+            yc = YourConnector()
+            tbl = yc.get_things()
 
-        self.assertEqual(tbl.num_rows, 0)
-```
+            self.assertEqual(tbl.num_rows, 0)
 
 ^^^^^^^^^^^^^^^^^^^^
 Adding documentation

--- a/docs/build_a_connector.rst
+++ b/docs/build_a_connector.rst
@@ -36,7 +36,11 @@ You’ll also want to create the Connector class itself:
 .. code-block:: python
 
     class YourConnectorName(object):
-        “””`Args:`”””
+        """
+        Instantiate class.
+
+           `Args:`
+        """
 
         def __init__(self, api_key=None):
             pass
@@ -60,7 +64,11 @@ We like to give users two different options for getting api keys and other authe
 
 
     class YourConnectorName(object):
-        “””`Args:`”””
+        """
+        Instantiate class.
+
+           `Args:`
+        """
 
         def __init__(self, api_key=None):
             self.api_key = check_env.check('YOURCONNECTORNAME_API_KEY', api_key)

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -102,5 +102,5 @@ Quick Start
 Redshift
 ********
 
-See :ref:`redshift` for documentation.
+See :ref:`Redshift <redshift>` for documentation.
 

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -101,5 +101,5 @@ Quick Start
 Redshift
 ********
 
-See :doc:`aws` section for documentation.
+See :ref:`_redshift` for documentation.
 

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -101,5 +101,5 @@ Quick Start
 Redshift
 ********
 
-See :ref:`_redshift` for documentation.
+See :ref:`redshift` for documentation.
 

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -23,7 +23,7 @@ MySQL
 *****
 .. _my-sql:
 
-MySQL is the world's most popular open source database. The Parsons class leverages on the `mysql <https://github.com/farcepest/MySQLdb1>`_ python package.
+MySQL is the world's most popular open source database. The Parsons class leverages on the `MySQLdb1 <https://github.com/farcepest/MySQLdb1>`_ python package.
 
 ===========
 Quick Start
@@ -57,6 +57,7 @@ Quick Start
    :inherited-members:
 
 .. _postgres:
+
 ********
 Postgres
 ********

--- a/docs/sftp.rst
+++ b/docs/sftp.rst
@@ -23,6 +23,7 @@ To instantiate ``SFTP``, pass your host name, user name, and either a password o
 key file as keyword arguments:
 
 .. code-block:: python
+
    from parsons import SFTP
 
    sftp = SFTP(host='my_hostname', username='my_username', password='my_password')
@@ -37,6 +38,7 @@ To batch multiple methods using a single connection, you can create a connection
 it in a ``with`` block:
 
 .. code-block:: python
+
    connection = sftp.create_connection()
 
    with connection as conn:

--- a/docs/sftp.rst
+++ b/docs/sftp.rst
@@ -1,7 +1,7 @@
 SFTP
 ====
 
-The ``SFTP`` class allows you to interact with `SFTP services<https://en.wikipedia.org/wiki/SSH_File_Transfer_Protocol>`_,
+The ``SFTP`` class allows you to interact with `SFTP services <https://en.wikipedia.org/wiki/SSH_File_Transfer_Protocol>`_,
 using the  `Paramiko SFTP library <http://docs.paramiko.org/en/2.7/api/sftp.html>`_ under the hood.
 
 The class provides methods to:

--- a/parsons/aws/aws_async.py
+++ b/parsons/aws/aws_async.py
@@ -25,21 +25,10 @@ except ImportError:
     zappa_run = None
 
 
-def event_command(event, context):
+def event_command(event):
     """
-    Minimal shim to add to the top lambda handler function
-    to enable distributed tasks
-    In your lambda handler:
-
-    .. code-block:: python
-       :emphasize-lines: 5,6
-
-       from parsons.aws import event_command
-
-       def handler(event, context):
-           ## ADD THESE TWO LINES TO TOP OF HANDLER:
-           if event_command(event, context):
-               return
+    Minimal `shim <https://en.wikipedia.org/wiki/Shim_(computing)>`_
+    to add to the top lambda handler function to enable distributed tasks
 
     The rest of this library is compatible with zappa.async library.
     If you have deployed your app with `Zappa <https://github.com/Miserlou/Zappa>`,

--- a/parsons/aws/aws_async.py
+++ b/parsons/aws/aws_async.py
@@ -31,7 +31,7 @@ def event_command(event, context):
     to add to the top lambda handler function to enable distributed tasks
 
     The rest of this library is compatible with zappa.async library.
-    If you have deployed your app with `Zappa <https://github.com/Miserlou/Zappa>`,
+    If you have deployed your app with `Zappa <https://github.com/Miserlou/Zappa>`_,
     then you do NOT need to add this shim.
     """
     if not set(event).intersection({'task_path', 'args', 'kwargs'}):

--- a/parsons/aws/aws_async.py
+++ b/parsons/aws/aws_async.py
@@ -25,7 +25,7 @@ except ImportError:
     zappa_run = None
 
 
-def event_command(event):
+def event_command(event, context):
     """
     Minimal `shim <https://en.wikipedia.org/wiki/Shim_(computing)>`_
     to add to the top lambda handler function to enable distributed tasks

--- a/parsons/aws/lambda_distribute.py
+++ b/parsons/aws/lambda_distribute.py
@@ -129,56 +129,6 @@ def distribute_task(table, func_to_run,
     """
     Distribute processing rows in a table across multiple AWS Lambda invocations.
 
-    If you are running the processing of a table inside AWS Lambda, then you
-    are limited by how many rows can be processed within the Lambda's time limit
-    (at time-of-writing, maximum 15min).
-
-    Based on experience and some napkin math, with
-    the same data that would allow 1000 rows to be processed inside a single
-    AWS Lambda instance, this method allows 10 MILLION rows to be processed.
-
-    Rather than converting the table to SQS
-    or other options, the fastest way is to upload the table to S3, and then
-    invoke multiple Lambda sub-invocations, each of which can be sent a
-    byte-range of the data in the S3 CSV file for which to process.
-
-    Using this method requires some setup. You have three tasks:
-
-    1. Define the function to process rows, the first argument, must take
-       your table's data (though only a subset of rows will be passed)
-       (e.g. `def task_for_distribution(table, **kwargs):`)
-    2. Where you would have run `task_for_distribution(my_table, **kwargs)`
-       instead call `distribute_task(my_table, task_for_distribution, func_kwargs=kwargs)
-       (either setting env var S3_TEMP_BUCKET or passing a bucket= parameter)
-    3. Setup your Lambda handler to include :py:meth:`parsons.aws.event_command`
-       (or run and deploy your lambda with `Zappa <https://github.com/Miserlou/Zappa>`_)
-
-    To test locally, include the argument `storage="local"` which will test
-    the distribute_task function, but run the task sequentially and in local memory.
-
-    A minimalistic example Lambda handler might look something like this:
-
-    .. code-block:: python
-       :emphasize-lines: 5,6
-
-       from parsons.aws import event_command, distribute_task
-
-       def process_table(table, foo, bar=None):
-           for row in table:
-               do_sloooooow_thing(row, foo, bar)
-
-       def handler(event, context):
-           ## ADD THESE TWO LINES TO TOP OF HANDLER:
-           if event_command(event, context):
-               return
-           table = FakeDatasource.load_to_table(username='123', password='abc')
-           # table is so big that running
-           #   process_table(table, foo=789, bar='baz') would timeout
-           # so instead we:
-           distribute_task(table, process_table,
-                           bucket='my-temp-s3-bucket',
-                           func_kwargs={'foo': 789, 'bar': 'baz'})
-
     `Args:`
         table: Parsons Table
            Table of data you wish to distribute processing across Lambda invocations

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -303,7 +303,9 @@ class S3(object):
                         destination_key=None, suffix=None, regex=None,
                         date_modified_before=None, date_modified_after=None,
                         public_read=False, remove_original=False, **kwargs):
-        """Transfer files between s3 buckets
+        """
+        Transfer files between s3 buckets
+
         `Args:`
             origin_bucket: str
                 The origin bucket
@@ -327,12 +329,13 @@ class S3(object):
             remove_original: bool
                 If the original keys should be removed after transfer
             kwargs:
-                Additional arguments for the S3 API call. See `AWS download_file documentation
+                Additional arguments for the S3 API call. See `AWS download_file docs
                 <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.copy>`_
                 for more info.
         `Returns:`
             ``None``
         """
+
         # If prefix, get all files for the prefix
         if origin_key.endswith('/'):
             resp = self.list_keys(

--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -86,7 +86,7 @@ class MySQL(MySQLCreateTable):
 
     def query(self, sql, parameters=None):
         """
-        Execute a query against the database. Will return ``None``if the query returns zero rows.
+        Execute a query against the database. Will return ``None`` if the query returns zero rows.
 
         To include python variables in your query, it is recommended to pass them as parameters,
         following the `mysql style <https://security.openstack.org/guidelines/dg_parameterize-database-queries.html>`_.

--- a/parsons/databases/postgres/postgres_core.py
+++ b/parsons/databases/postgres/postgres_core.py
@@ -59,7 +59,7 @@ class PostgresCore(PostgresCreateStatement):
 
     def query(self, sql, parameters=None):
         """
-        Execute a query against the database. Will return ``None``if the query returns zero rows.
+        Execute a query against the database. Will return ``None`` if the query returns zero rows.
 
         To include python variables in your query, it is recommended to pass them as parameters,
         following the `psycopg style <http://initd.org/psycopg/docs/usage.html#passing-parameters-to-sql-queries>`_.

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -94,7 +94,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         ``with rs.connection() as conn:``
 
         `Returns:`
-            Psycopg2 `connection` object
+            Psycopg2 ``connection`` object
         """
 
         # Create a psycopg2 connection and cursor
@@ -713,7 +713,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             cleanup_temp_table: boolean
                 A temp table is dropped by default on cleanup. You can set to False for debugging.
             \**copy_args: kwargs
-                See :func:`~parsons.databases.Redshift.copy`` for options.
+                See :func:`~parsons.databases.Redshift.copy` for options.
         """  # noqa: W605
 
         if not self.table_exists(target_table):

--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -361,7 +361,17 @@ class RedshiftTableUtilities(object):
         `Returns:`
             A dict mapping column name to a dict with extra info. The keys of the dict are ordered
             just like the columns in the table. The extra info is a dict with format
-            ``{'data_type': str, 'max_length': int or None, 'max_precision': int or None, 'max_scale': int or None, 'is_nullable': bool}`` # noqa
+
+            .. code-block:: python
+
+                {
+                'data_type': str,
+                'max_length': int or None,
+                'max_precision': int or None,
+                'max_scale': int or None,
+                'is_nullable': bool
+                }
+
         """
 
         query = f"""

--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -361,8 +361,7 @@ class RedshiftTableUtilities(object):
         `Returns:`
             A dict mapping column name to a dict with extra info. The keys of the dict are ordered
             just like the columns in the table. The extra info is a dict with format
-            ``{'data_type': str, 'max_length': int or None, 'max_precision': int or None,
-               'max_scale': int or None, 'is_nullable': bool}``
+            ``{'data_type': str, 'max_length': int or None, 'max_precision': int or None, 'max_scale': int or None, 'is_nullable': bool}`` # noqa
         """
 
         query = f"""

--- a/parsons/sftp/sftp.py
+++ b/parsons/sftp/sftp.py
@@ -168,6 +168,7 @@ class SFTP(object):
     def put_file(self, local_path, remote_path, connection=None):
         """
         Put a file on the SFTP server
+
         `Args:`
             local_path: str
                 The local path of the source file


### PR DESCRIPTION
This PR addresses all of the AWS documentation and should check the AWS boxes for #269.

AWS: ALL

- Add global overview with links to different classes and methods at the top of the RST file 

Lambda
- Move description and example code from method docstrings to Overview and Quickstart
- No Authentication Guide because this isn't a typical Parsons class

S3
- Improve Overview and Quickstart

Redshift

- Add `psychopg2` link to Overview
- Consolidate Quickstart

Additional changes in this PR:

- In the `Redshift` section of `databases.rst`, I replaced the link to AWS docs with a more specific reference to the Redshift section of the AWS docs.