### PR TITLE
Docs general cleanup

### DIFF
--- a/docs/airtable.rst
+++ b/docs/airtable.rst
@@ -38,11 +38,11 @@ You can then call various endpoints:
 
 .. code-block:: python
 
-	# Get records from a base
-	at.get_records(fields=['id', 'fn', 'ln'])
+    # Get records from a base
+    at.get_records(fields=['id', 'fn', 'ln'])
 
-	# Get a single record from a base
-	at.get_record(1233)
+    # Get a single record from a base
+    at.get_record(1233)
 
     # Insert records
     tbl.from_csv('my_new_records')

--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -1,13 +1,9 @@
-Azure
-=====
+Azure: Blob Storage
+===================
 
-************
-Blob Storage
-************
-
-========
+********
 Overview
-========
+********
 
 `Azure Blob Storage <https://azure.microsoft.com/en-us/services/storage/blobs/>`_ is a cloud file storage system that
 uses storage accounts to organize containers (similar to "buckets" for other storage providers) in which to store
@@ -21,9 +17,9 @@ arbitrary files referred to as 'blobs'. This Parsons integration currently only 
     `multiple types of credentials <https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/storage/azure-storage-blob#types-of-credentials>`_
     are included in the documentation.
 
-==========
+**********
 Quickstart
-==========
+**********
 
 This class requires a ``credentials`` argument and *either* an ``account_name`` or an ``account_url`` argument that
 includes the account name. You can store these as environmental variables (``AZURE_CREDENTIAL``, ``AZURE_ACCOUNT_NAME``,
@@ -32,6 +28,7 @@ and ``AZURE_ACCOUNT_URL``, respectively) or pass them in as arguments:
 **Instantiate class**
 
 .. code-block:: python
+
    from parsons import AzureBlobStorage
 
    # First approach: Use API credentials via environmental variables
@@ -43,15 +40,17 @@ and ``AZURE_ACCOUNT_URL``, respectively) or pass them in as arguments:
 **List containers and blobs**
 
 .. code-block:: python
+
   # Get all container names for a storage account
   container_names = azure_blob.list_containers()
 
   # Get all blob names for a storage account and container
   blob_names = azure_blob.list_blobs(container_names[0])
 
-**Create a blob from a file or ``Table``**
+**Create a blob from a file or Table**
 
 .. code-block:: python
+
   # Upload a CSV file from a local file path and set the content type
   azure_blob.put_blob('blob_name', 'test1.csv', './test1.csv', content_type='text/csv')
 
@@ -62,6 +61,7 @@ and ``AZURE_ACCOUNT_URL``, respectively) or pass them in as arguments:
 **Download a blob**
 
 .. code-block:: python
+
   # Download to a temporary file path
   temp_file_path = azure_blob.download_blob('blob_name', 'test.csv')
 
@@ -69,9 +69,9 @@ and ``AZURE_ACCOUNT_URL``, respectively) or pass them in as arguments:
   azure_blob.download_blob('blob_name', 'test.csv', local_path='/tmp/test.csv')
 
 
-===
+***
 API
-===
+***
 
 .. autoclass:: parsons.AzureBlobStorage
    :inherited-members:

--- a/docs/bill_com.rst
+++ b/docs/bill_com.rst
@@ -1,6 +1,10 @@
 Bill.com
 ==========
 
+********
+Overview
+********
+
 `Bill.com <https://www.bill.com>`_ is an online billing and invoicing tool. This class contains methods to:
 
 - Get lists of customers, users, and invoices

--- a/docs/bloomerang.rst
+++ b/docs/bloomerang.rst
@@ -5,8 +5,8 @@ Bloomerang
 Overview
 ********
 
-`Bloomerang <https://bloomerang.co/>`_ is a donor management platform for non-profits.
-The private `Bloomerang REST API <https://bloomerang.co/features/integrations/api/rest-api>`_
+`Bloomerang <https://bloomerang.co/>`_ is a donor management platform for non-profits. This Parsons integration with
+the private `Bloomerang REST API <https://bloomerang.co/features/integrations/api/rest-api>`_
 supports fetching, creating, and updating records of constituents, donations, and interactions.
 
 .. note::

--- a/docs/braintree.rst
+++ b/docs/braintree.rst
@@ -7,7 +7,7 @@ platforms things like credit card disputes and disbursement (to your bank accoun
 available directly through Braintree.
 
 While much of the `Braintree API <https://developers.braintreepayments.com/>`_ is about processing payments,
-this Parsons integration focuses on the record searching aspects. Specifically, the ``Braintree` class provides
+this Parsons integration focuses on the record searching aspects. Specifically, the ``Braintree`` class provides
 methods for fetching disputes and transactions.
 
 .. note::
@@ -20,7 +20,7 @@ methods for fetching disputes and transactions.
     2. **Public API Key:** Click 'API' and scroll to 'API Keys'. If there are none, click 'Generate New API Key'.
     3. **Private API Key:** Click 'API', scroll to 'API Keys', and click the 'view' link in the private column.
 
-    For more information, see the <`API documentation <https://articles.braintreepayments.com/control-panel/important-gateway-credentials>`_.
+    For more information, see the `API documentation <https://articles.braintreepayments.com/control-panel/important-gateway-credentials>`_.
 
 ***********
 Quick Start
@@ -33,7 +33,7 @@ as arguments:
 
 .. code-block:: python
 
-	from parsons import Braintree
+    from parsons import Braintree
 
     # First approach: Use API credentials via environmental variables
     brains = Braintree()
@@ -41,13 +41,12 @@ as arguments:
     # Second approach: Pass API credentials as arguments
     brains = Braintree(merchant_id='my_merchant_id', public_key='my_public_key', private_key='my_private_key')
 
-	# Get disputes from a single day
+    # Get disputes from a single day
     disputes = brains.get_disputes('2020-01-01', '2020-01-02')
 
-	# Get disbursements from a single day
-    disbursements = brains.get_transactions(
-        disbursement_start_date='2020-01-01',
-        disbursement_end_date='2020-01-02')
+    # Get disbursements from a single day
+    disbursements = brains.get_transactions(disbursement_start_date='2020-01-01',
+                                            disbursement_end_date='2020-01-02')
 
 ***
 API

--- a/docs/braintree.rst
+++ b/docs/braintree.rst
@@ -1,6 +1,10 @@
 Braintree
 =========
 
+********
+Overview
+********
+
 `Braintree <https://www.braintreepayments.com>`_ is an online payment processor often integrated in other
 third-party donation platforms like ActionKit, etc.  Even if much data is accessible through those other
 platforms things like credit card disputes and disbursement (to your bank account!) timing may only be

--- a/docs/copper.rst
+++ b/docs/copper.rst
@@ -5,8 +5,8 @@ Copper
 Overview
 ********
 
-`Copper <https://copper.com>`_ is CRM to track individuals, companies and activity data. The class provides
-methods for extracting people, companies and actions.
+`Copper <https://copper.com>`_ is a customer relationship management (CRM) platform to track individuals, companies
+and activity data. This Parsons class provides methods for extracting people, companies and actions.
 
 .. note::
 	Getting Your API Key

--- a/docs/facebook_ads.rst
+++ b/docs/facebook_ads.rst
@@ -8,7 +8,7 @@ Overview
 The ``FacebookAds`` class allows you to interact with parts of the Facebook Business API.
 Currently the connector provides methods for creating and deleting custom audiences, and for adding users to audiences.
 
-The ``FacebookAds`` connector is a thin wrapper around the `FB Business SDK <https://github.com/facebook/facebook-python-business-sdk>_,
+The ``FacebookAds`` connector is a thin wrapper around the `FB Business SDK <https://github.com/facebook/facebook-python-business-sdk>`_,
 so some of that SDK is exposed, e.g., you may see exceptions like ``FacebookRequestError``.
 
 Facebook's advertising and Pages systems are massive. Check out the overviews for more information:
@@ -19,9 +19,7 @@ Facebook's advertising and Pages systems are massive. Check out the overviews fo
 
 .. note::
   Authentication
-
     Before using ``FacebookAds``, you'll need the following:
-
     * A FB application, specifically the app ID and secret. See `<https://developers.facebook.com>`_ to find your app details or create a new app. Note that a Facebook app isn't necessarily visible to anyone but you: it's just needed to interact with the Facebook API.
     * A FB ad account. See `<https://business.facebook.com>`_ to find your ad accounts or create a new one.
     * A FB access token representing a user that has access to the relevant ad account. You can generate an access token from your app, either via the Facebook API itself, or via console at `<https://developers.facebook.com>`_.
@@ -34,6 +32,7 @@ To instantiate the FacebookAds class, you can either store your authentication c
 (``FB_APP_ID``, ``FB_APP_SECRET``, ``FB_ACCESS_TOKEN``, and ``FB_AD_ACCOUNT_ID``) or pass them in as arguments:
 
 .. code-block:: python
+
    from parsons import FacebookAds
 
    # First approach: Use environmental variables
@@ -48,6 +47,7 @@ To instantiate the FacebookAds class, you can either store your authentication c
 You can then use various methods:
 
 .. code-block:: python
+
    # Create audience
    fb.create_custom_audience(name='audience_name', data_source='USER_PROVIDED_ONLY')
 

--- a/docs/freshdesk.rst
+++ b/docs/freshdesk.rst
@@ -42,6 +42,7 @@ or pass them in as keyword arguments:
 You can then call various endpoints:
 
 .. code-block:: python
+
     # Fetch all tickets requested a individual based on their email
     freshdesk.get_tickets(requester_email='user@email.com')
 

--- a/docs/github.rst
+++ b/docs/github.rst
@@ -1,6 +1,10 @@
 GitHub
 ======
 
+********
+Overview
+********
+
 `GitHub <https://github.com>`_ is an online tool for software collaboration.
 
 This ``GitHub`` class uses the `PyGitHub library <https://pygithub.readthedocs.io/en/latest/introduction.html>`_
@@ -51,8 +55,8 @@ With the class instantiated, you can now call various endpoints.
   # Download Parsons README.md to local "/tmp/README.md"
   parsons_readme_path = github.download_file("move-coop/parsons", "README.md", local_path="/tmp/README.md")
 
-===
+***
 API
-===
+***
 .. autoclass:: parsons.GitHub
    :inherited-members:

--- a/docs/hustle.rst
+++ b/docs/hustle.rst
@@ -5,7 +5,7 @@ Hustle
 Overview
 ********
 
-Hustle is a peer to peer texting communication platform. This Parsons integration with the
+`Hustle <https://www.hustle.com/>`_ is a peer to peer texting communication platform. This Parsons integration with the
 the `Hustle v1 API <https://api.hustle.com/docs/>`_ provides methods for fetching agents,
 organizations, groups, leads, and tags, as well as creating and updating agents and leads.
 
@@ -25,23 +25,30 @@ organizations, groups, leads, and tags, as well as creating and updating agents 
 Quick Start
 ***********
 
+To instantiate the ``Hustle`` class, you can either store your Hustle client ID and secret as environmental variables
+(``HUSTLE_CLIENT_ID`` and ``HUSTLE_CLIENT_SECRET``, respectively) or pass them in as keyword arguments:
+
 .. code-block:: python
 
     from parsons import Hustle
 
+    # First approach: Use API credentials via environmental variables
+    hustle = Hustle()
+
+    # Second approach: Pass API credentials as arguments
     hustle = Hustle(client_id='MYID', client_secret='MYSECRET')
 
-	# Export your groups to a csv
-	tbl = hustle.get_groups(organization_id='ORGID')
-	tbl.to_csv('my_hustle_groups.csv')
+    # Export your groups to a csv
+    tbl = hustle.get_groups(organization_id='ORGID')
+    tbl.to_csv('my_hustle_groups.csv')
 
-	# Export organizations to Redshift
-	tbl.get_organizations().to_redshift('hustleschema.hustle_organizations')
+    # Export organizations to Redshift
+    tbl.get_organizations().to_redshift('hustleschema.hustle_organizations')
 
-	# Import leads from a csv
-	leads = Table.from_csv('my_leads.csv')
-	group_id = 'MYGROUP'
-	hustle.create_leads(leads, group_id)
+    # Import leads from a csv
+    leads = Table.from_csv('my_leads.csv')
+    group_id = 'MYGROUP'
+    hustle.create_leads(leads, group_id)
 
 ***
 API

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -193,8 +193,8 @@ Indices and tables
    salesforce
    sftp
    targetsmart
-   twilio
    turbovote
+   twilio
    zoom
 
 .. toctree::

--- a/docs/mailchimp.rst
+++ b/docs/mailchimp.rst
@@ -1,6 +1,10 @@
 Mailchimp
 =========
 
+********
+Overview
+********
+
 `Mailchimp <https://www.mailchimp.com>`_ is a platform used for creating and sending mass emails.
 `The Mailchimp API <https://developers.braintreepayments.com/>`_ allows users to interact with data from existing
 email campaigns under their account and to configure further campaigns.
@@ -26,7 +30,7 @@ as an environmental variable (``MAILCHIMP_API_KEY``) or pass it as an argument.
     from parsons import Mailchimp
 
     # First approach: API key is stored as an environmental variable
-	mc = Mailchimp()
+    mc = Mailchimp()
 
     # Second approach: Pass API key as argument
     mc = Mailchimp(api_key='my_api_key')

--- a/docs/newmode.rst
+++ b/docs/newmode.rst
@@ -1,18 +1,18 @@
 New/Mode
 ==========
 
+********
+Overview
+********
+
 `New/Mode <https://www.newmode.net/>`_ is a multi-channel advocacy and civic engagement platform
-for organizations and campaigns.
-
-The class includes methods for fetching tools, actions, targets, campaigns, organizations, services,
-and outreaches. There are also methods for looking up targets and running actions given a ``tool_id``.
-
-Most methods in this class return either individual items as dictionaries or lists of items as
-Parsons ``Table`` objects.
+for organizations and campaigns. This Parsons class includes methods for fetching tools, actions, targets, campaigns,
+organizations, services, and outreaches. There are also methods for looking up targets and running actions given a
+``tool_id``. Most methods return either individual items as dictionaries or lists of items as Parsons ``Table`` objects.
 
 .. note::
   Authentication
-    To use the class, you need only provide a New/Mode username and password. For more information,
+    To use the class, you need to provide a New/Mode username and password. For more information,
     see `The New/Mode API is Here <https://blog.newmode.net/new-modes-api-is-here-4c4b70c6fce6>`_.
 
 ***********
@@ -42,5 +42,6 @@ respectively) or pass in your username and password as arguments:
 ***
 API
 ***
+
 .. autoclass :: parsons.Newmode
-:inherited-members:
+    :inherited-members:

--- a/docs/p2a.rst
+++ b/docs/p2a.rst
@@ -1,6 +1,10 @@
 Phone2Action
 ============
 
+********
+Overview
+********
+
 `Phone2Action <https://phone2action.com/>`_ is a digital advocacy tool used by progressive organizations. This class
 allows you to interact with the tool by leveraging their `API <http://docs.phone2action.com/#overview>`_.
 
@@ -12,7 +16,8 @@ allows you to interact with the tool by leveraging their `API <http://docs.phone
 Quick Start
 ***********
 
-To instantiate a class, you can either pass in the app ID and app key as arguments or set the ``PHONE2ACTION_APP_ID`` and ``PHONE2ACTION_APP_KEY`` environmental variables.
+To instantiate the ``Phone2Action`` class, you can either pass in the app ID and app key as arguments or set the
+``PHONE2ACTION_APP_ID`` and ``PHONE2ACTION_APP_KEY`` environmental variables.
 
 .. code-block:: python
 
@@ -37,6 +42,9 @@ To instantiate a class, you can either pass in the app ID and app key as argumen
        if phone['subscribed']:
         p2a.update_advocate(phone['advocate_id'], phone=phone_number, sms_opt_in=True)
 
+***
+API
+***
 
 .. autoclass :: parsons.Phone2Action
    :inherited-members:

--- a/docs/p2a.rst
+++ b/docs/p2a.rst
@@ -40,7 +40,7 @@ To instantiate the ``Phone2Action`` class, you can either pass in the app ID and
        phone_number = phone['phones_address']
        # Only update phone numbers that aren't already subscribed
        if phone['subscribed']:
-        p2a.update_advocate(phone['advocate_id'], phone=phone_number, sms_opt_in=True)
+           p2a.update_advocate(phone['advocate_id'], phone=phone_number, sms_opt_in=True)
 
 ***
 API

--- a/docs/rockthevote.rst
+++ b/docs/rockthevote.rst
@@ -5,27 +5,30 @@ Rock the Vote
 Overview
 ********
 
-`Rock the Vote <https://www.rockthevote.org/>`_ is an online registration tool.
+`Rock the Vote <https://www.rockthevote.org/>`_ is an online registration tool. This Parsons connector makes use of
+Rock the Vote's `Rocky API <https://rock-the-vote.github.io/Voter-Registration-Tool-API-Docs/>`_.
 
-The Parsons Connector makes use of Rock the Vote's Rocky API. In order to authenticate with the
-API, users will need to specify the ID and the API key of the RTV partner organization for the
-data.
+.. note::
+  Authentication
+    In order to authenticate with the API, users must specify the ID and API key of the RTV partner organization for the data.
 
 **********
 QuickStart
 **********
 
-To use the RockTheVote class you can either store the partner ID and API key as an
-environmental variable (RTV_PARTNER_ID and RTV_PARTNER_API_KEY, respectively), or you can
+To use the ``RockTheVote`` class you can either store the partner ID and API key as an
+environmental variable (``RTV_PARTNER_ID`` and ``RTV_PARTNER_API_KEY``, respectively), or you can
 pass them in as arguments to the class.
 
 .. code-block:: python
 
    from parsons import RockTheVote
 
-   rtv = RockTheVote()  # If specified as environment variables, no need to pass them in
+   # If credentials are specified as environment variables, no need to pass them in
+   rtv = RockTheVote()
 
-   rtv = RockTheVote(partner_id='123', partner_api_key='supersecretkey') # Pass credentials directly
+   # Pass credentials directly
+   rtv = RockTheVote(partner_id='123', partner_api_key='supersecretkey')
 
 To fetch a list of registrations submitted for the partner ID, use the `run_registration_report`
 method. It is possible to filter the results by providing a parameter to specify a start date
@@ -33,10 +36,7 @@ for the registrations.
 
 .. code-block:: python
 
-   from parsons import RockTheVote
-
-   rtv = RockTheVote()
-
+   # Get list of registrations
    registrants = rtv.run_registration_report(since='2020-01-01')
 
 The `run_registration_report` will block as the report is being generated and downloaded from the
@@ -46,14 +46,10 @@ data.
 
 .. code-block:: python
 
-   from parsons import RockTheVote
-
-   rtv = RockTheVote()
-
+   # Create report and get the ID
    report_id = rtv.create_registration_report(since='2020-01-01')
 
-   # Do some other stuff here
-
+   # Get registration report
    registrants = rtv.get_registration_report(report_id)
 
 ***

--- a/docs/salesforce.rst
+++ b/docs/salesforce.rst
@@ -1,6 +1,10 @@
 Salesforce
 ==========
 
+********
+Overview
+********
+
 `Salesforce <https://www.salesforce.com>`_ is a cloud-based CRM (customer relationship management) tool
 with a huge share of the for-profit and apolitical non-profit markets. This Parsons integration with the
 `Salesforce REST API <https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_what_is_rest_api.htm>`_
@@ -26,6 +30,7 @@ and security token as environmental variables (``SALESFORCE_USERNAME``, ``SALESF
 and ``SALESFORCE_SECURITY_TOKEN``, respectively) or pass them in as arguments:
 
 .. code-block:: python
+
     from parsons import Salesforce, Table
 
     # First approach: Pass API credentials as environmental variables
@@ -37,6 +42,7 @@ and ``SALESFORCE_SECURITY_TOKEN``, respectively) or pass them in as arguments:
 You can then call different endpoints:
 
 .. code-block:: python
+
     # Get IDs and names for all Contacts
     all_contacts = sf.query("SELECT Id, firstname, lastname FROM Contact")
 

--- a/docs/targetsmart.rst
+++ b/docs/targetsmart.rst
@@ -4,10 +4,8 @@ TargetSmart
 `TargetSmart <https://targetsmart.com/>`_ provides access to voter and consumer data for the progressive community. Currently,
 there are two TargetSmart services that are supported by two Parsons classes, each requiring separate credentials:
 
-1. ``TargetSmartAPI``: `Single record lookup with HTTPS <https://docs.targetsmart.com/developers/tsapis/index.html>`_.
-This class provides methods to support searching for individual people, voters, and district information for a geographic location.
-2. ``TargetSmartAutomation``: `Bulk record matching with SFTP <https://docs.targetsmart.com/developers/automation/index.html>`_.
-This class provides general methods for processing files instead of individual records.
+1. ``TargetSmartAPI``: `Single record lookup with HTTPS <https://docs.targetsmart.com/developers/tsapis/index.html>`_. This class provides methods to support searching for individual people, voters, and district information for a geographic location.
+2. ``TargetSmartAutomation``: `Bulk record matching with SFTP <https://docs.targetsmart.com/developers/automation/index.html>`_. This class provides general methods for processing files instead of individual records.
 
 .. note::
   Authentication
@@ -44,6 +42,7 @@ To instantiate ``TargetSmartAPI``, you can either store your API Key as the envi
 You can then call various endpoints:
 
 .. code-block:: python
+
    # Search for a person record using an email address
    ts_api.data_enhance(search_id='test@email.com', search_id_type='email')
 
@@ -74,6 +73,7 @@ keyword arguments:
 You can then call various endpoints:
 
 .. code-block:: python
+
    # Check the status of a match job
    ts_auto.match_status(job_name='my_job_name')
 

--- a/docs/targetsmart.rst
+++ b/docs/targetsmart.rst
@@ -1,6 +1,10 @@
 TargetSmart
 ============
 
+********
+Overview
+********
+
 `TargetSmart <https://targetsmart.com/>`_ provides access to voter and consumer data for the progressive community. Currently,
 there are two TargetSmart services that are supported by two Parsons classes, each requiring separate credentials:
 
@@ -22,9 +26,13 @@ there are two TargetSmart services that are supported by two Parsons classes, ea
     Access to endpoints is individually provisioned. If you encounter errors accessing an endpoint, please contact
     your TargetSmart account representative to verify that your API key has been provisioned access.
 
-***
-API
-***
+***********
+TargetSmart
+***********
+
+==========
+Quickstart
+==========
 
 To instantiate ``TargetSmartAPI``, you can either store your API Key as the environmental variable
 ``TS_API_KEY``, or pass it in as an argument:
@@ -49,12 +57,20 @@ You can then call various endpoints:
    # Search for district information using an address
    ts_api.district(search_type='address', address='123 test st, Durham NC 27708')
 
+===
+API
+===
+
 .. autoclass :: parsons.TargetSmartAPI
    :inherited-members:
 
 **********
 Automation
 **********
+
+==========
+Quickstart
+==========
 
 To instantiate ``TargetSmartAutomation``, you can either store your SFTP username and password
 as the environmental variables ``TS_SFTP_USERNAME`` and ``TS_SFTP_PASSWORD``, or pass them in as
@@ -79,6 +95,10 @@ You can then call various endpoints:
 
    # Remove all files for the match job
    ts_auto.remove_files(job_name='my_job_name')
+
+===
+API
+===
 
 .. autoclass :: parsons.TargetSmartAutomation
    :inherited-members:

--- a/docs/turbovote.rst
+++ b/docs/turbovote.rst
@@ -8,13 +8,13 @@ tool. This class contains a single method which allows you to export your users
 .. note::
   Authentication
     TurboVote requires `HTTP Basic Auth <https://en.wikipedia.org/wiki/Basic_access_authentication>`_.
-    Clients with a TurboVote account must pass their subdomain, username, and password.
+    Clients with a TurboVote account must pass their username, password, and subdomain.
 
 **********
 QuickStart
 **********
 
-To instantiate the TurboVote class, you can either store your TurboVote API
+To instantiate the ``TurboVote`` class, you can either store your TurboVote API
 username, password, subdomain as environmental variables (``TURBOVOTE_USERNAME``,
 ``TURBOVOTE_PASSWORD``, and ``TURBOVOTE_SUBDOMAIN``, respectively) or pass them 
 in as arguments:

--- a/docs/turbovote.rst
+++ b/docs/turbovote.rst
@@ -1,6 +1,10 @@
 TurboVote
 =========
 
+********
+Overview
+********
+
 `TurboVote <https://turbovote.org/>`_ is an online voter registration and vote by mail
 tool. This class contains a single method which allows you to export your users
 (aka signups).
@@ -36,6 +40,9 @@ You can then call the method:
 	# Get users
 	tv.get_users()
 
+***
+API
+***
 
 .. autoclass :: parsons.TurboVote
    :inherited-members:

--- a/docs/twilio.rst
+++ b/docs/twilio.rst
@@ -20,7 +20,7 @@ Quick Start
 Get Account Usage
 =================================
 
-To instantiate the Twilio class, you can either store your Twilio account SID
+To instantiate the ``Twilio`` class, you can either store your Twilio account SID
 and authorization token as environmental variables (``TWILIO_ACCOUNT_SID`` and
 ``TWILIO_AUTH_TOKEN``, respectively) or pass them in as arguments:
 
@@ -42,16 +42,6 @@ and authorization token as environmental variables (``TWILIO_ACCOUNT_SID`` and
 
    # Get usage for a specific resource
    twilio.get_account_usage(category='sms-inbound')
-
-=================================
-Get Inbound and Outbound Messages
-=================================
-
-.. code-block:: python
-	
-	from parsons import Twilio
-
-	twilio = Twilio()
 
 	# Get messages from a specific day
 	twilio.get_messages(date_sent='10-01-2019')

--- a/docs/twilio.rst
+++ b/docs/twilio.rst
@@ -1,6 +1,10 @@
 Twilio
 ======
 
+********
+Overview
+********
+
 `Twilio <https://twilio.com>`_ is a messaging platform that allows you to programmatically
 send and receive SMS messages, send and receive voice calls, and perform other communication
 functions. This Parsons integration provides methods for fetching messages, accounts, and

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -14,7 +14,6 @@ class ActionNetwork(object):
     `Args:`
         api_token: str
             The OSDI API token
-        api_url:
     """
     def __init__(self, api_token=None):
         self.api_token = check_env.check('AN_API_TOKEN', api_token)

--- a/parsons/bloomerang/bloomerang.py
+++ b/parsons/bloomerang/bloomerang.py
@@ -109,7 +109,7 @@ class Bloomerang(object):
     def update_constituent(self, constituent_id, **kwargs):
         """
         `Args:`
-            constituent_id:
+            constituent_id: str or int
                 Constituent ID to update
             **kwargs:`
                 Fields to update, e.g., FirstName = 'RJ'.
@@ -121,7 +121,7 @@ class Bloomerang(object):
     def get_constituent(self, constituent_id):
         """
         `Args:`
-            constituent_id:
+            constituent_id: str or int
                 Constituent ID to get fields for
         `Returns:`
             A  JSON of the entry or an error.
@@ -131,7 +131,7 @@ class Bloomerang(object):
     def delete_constituent(self, constituent_id):
         """
         `Args:`
-            constituent_id:
+            constituent_id: str or int
                 Constituent ID to delete
         """
         return self._base_delete('constituent', entity_id=constituent_id)
@@ -139,9 +139,9 @@ class Bloomerang(object):
     def get_constituents(self, page_number=1, page_size=50):
         """
         `Args:`
-            page_number:
+            page_number: int
                 Number of the page to fetch
-            page_size:
+            page_size: int
                 Number of records per page (maximum allowed is 50)
         `Returns:`
             A Table of the entries.
@@ -163,7 +163,7 @@ class Bloomerang(object):
     def update_transaction(self, transaction_id, **kwargs):
         """
         `Args:`
-            transaction_id:
+            transaction_id: str or int
                 Transaction ID to update
             **kwargs:`
                 Fields to update, e.g., CreditCardType = 'Visa'.
@@ -175,7 +175,7 @@ class Bloomerang(object):
     def get_transaction(self, transaction_id):
         """
         `Args:`
-            transaction_id:
+            transaction_id: str or int
                 Transaction ID to get fields for
         `Returns:`
             A  JSON of the entry or an error.
@@ -185,7 +185,7 @@ class Bloomerang(object):
     def delete_transaction(self, transaction_id):
         """
         `Args:`
-            transaction_id:
+            transaction_id: str or int
                 Transaction ID to delete
         """
         return self._base_delete('transaction', entity_id=transaction_id)
@@ -193,9 +193,9 @@ class Bloomerang(object):
     def get_transactions(self, page_number=1, page_size=50):
         """
         `Args:`
-            page_number:
+            page_number: int
                 Number of the page to fetch
-            page_size:
+            page_size: int
                 Number of records per page (maximum allowed is 50)
         `Returns:`
             A  JSON of the entry or an error.
@@ -207,7 +207,7 @@ class Bloomerang(object):
     def get_transaction_designation(self, designation_id):
         """
         `Args:`
-            designation_id:
+            designation_id: str or int
                 Transaction Designation ID to get fields for
         `Returns:`
             A  JSON of the entry or an error.
@@ -217,9 +217,9 @@ class Bloomerang(object):
     def get_transaction_designations(self, page_number=1, page_size=50):
         """
         `Args:`
-            page_number:
+            page_number: int
                 Number of the page to fetch
-            page_size:
+            page_size: int
                 Number of records per page (maximum allowed is 50)
         `Returns:`
             A  JSON of the entry or an error.
@@ -241,7 +241,7 @@ class Bloomerang(object):
     def update_interaction(self, interaction_id, **kwargs):
         """
         `Args:`
-            interaction_id:
+            interaction_id: str or int
                 Interaction ID to update
             **kwargs:`
                 Fields to update, e.g., EmailAddress = "user@example.com".
@@ -253,7 +253,7 @@ class Bloomerang(object):
     def get_interaction(self, interaction_id):
         """
         `Args:`
-            interaction_id:
+            interaction_id: str or int
                 Interaction ID to get fields for
         `Returns:`
             A  JSON of the entry or an error.
@@ -263,7 +263,7 @@ class Bloomerang(object):
     def delete_interaction(self, interaction_id):
         """
         `Args:`
-            interaction_id:
+            interaction_id: str or int
                 Interaction ID to delete
         """
         return self._base_delete('interaction', entity_id=interaction_id)
@@ -271,9 +271,9 @@ class Bloomerang(object):
     def get_interactions(self, page_number=1, page_size=50):
         """
         `Args:`
-            page_number:
+            page_number: int
                 Number of the page to fetch
-            page_size:
+            page_size: int
                 Number of records per page (maximum allowed is 50)
         `Returns:`
             A  JSON of the entry or an error.

--- a/parsons/freshdesk/freshdesk.py
+++ b/parsons/freshdesk/freshdesk.py
@@ -66,7 +66,7 @@ class Freshdesk:
         """
         List tickets.
 
-        See the `API Docs <https://developers.freshdesk.com/api/#list_all_tickets>_`
+        See the `API Docs <https://developers.freshdesk.com/api/#list_all_tickets>`_
         for more information.
 
         .. warning::
@@ -112,7 +112,7 @@ class Freshdesk:
         """
         Get contacts.
 
-        See the `API Docs <https://developers.freshdesk.com/api/#list_all_contacts>_`
+        See the `API Docs <https://developers.freshdesk.com/api/#list_all_contacts>`_
         for more information.
 
         `Args:`
@@ -150,7 +150,7 @@ class Freshdesk:
         """
         List companies.
 
-        See the `API Docs <https://developers.freshdesk.com/api/#list_all_companies>_`
+        See the `API Docs <https://developers.freshdesk.com/api/#list_all_companies>`_
         for more information.
 
         `Args:`
@@ -169,7 +169,7 @@ class Freshdesk:
         """
         List agents.
 
-        See the `API Docs <https://developers.freshdesk.com/api/#list_all_agents>_`
+        See the `API Docs <https://developers.freshdesk.com/api/#list_all_agents>`_
         for more information.
 
         `Args:`

--- a/parsons/freshdesk/freshdesk.py
+++ b/parsons/freshdesk/freshdesk.py
@@ -14,10 +14,10 @@ class Freshdesk:
     Instantiate Freshdesk class
 
     `Args:`
-        domain:
+        domain: str
             The subdomain of the Freshdesk account. Not required if ``FRESHDESK_DOMAIN``
             env variable set.
-        api_key:
+        api_key: str
             The Freshdesk provided application key. Not required if ``FRESHDESK_API_KEY``
             env variable set.
     `Returns:`
@@ -88,7 +88,7 @@ class Freshdesk:
                 Filter by requester email.
             company_id: int
                 Filter by company_id.
-            updated_since:
+            updated_since: str
                 Earliest date to include in results.
             expand_custom_fields: boolean
                 Expand nested custom fields to their own columns.

--- a/parsons/pdi/pdi.py
+++ b/parsons/pdi/pdi.py
@@ -21,7 +21,8 @@ class PDI(FlagIDs, Universes, Questions, AcquisitionTypes, Flags):
 
     def __init__(self, username=None, password=None, api_token=None,
                  qa_url=False):
-        """A class to access the PDI API.
+        """
+        Instantiate the PDI class
 
         `Args:`
             username: str

--- a/parsons/rockthevote/rtv.py
+++ b/parsons/rockthevote/rtv.py
@@ -41,6 +41,8 @@ class RTVFailure(Exception):
 
 class RockTheVote:
     """
+    Instantiate the RockTheVote class
+
     `Args:`
         partner_id: str
             The RockTheVote partner ID for the RTV account

--- a/parsons/rockthevote/rtv.py
+++ b/parsons/rockthevote/rtv.py
@@ -45,9 +45,11 @@ class RockTheVote:
 
     `Args:`
         partner_id: str
-            The RockTheVote partner ID for the RTV account
+            The RockTheVote partner ID for the RTV account.
+            Not required if the ``RTV_PARTNER_ID`` environmental variable is set.
         partner_api_key: str
-            The API Key for the partner
+            The API Key for the partner.
+            Not required if the ``RTV_PARTNER_API_KEY`` environmental variable is set.
         testing: bool
             Whether or not to use the staging instance. Defaults to False.
     `Returns`:

--- a/parsons/turbovote/turbovote.py
+++ b/parsons/turbovote/turbovote.py
@@ -10,17 +10,17 @@ TURBOVOTE_URI = 'https://turbovote-admin-http-api.prod.democracy.works/'
 
 class TurboVote(object):
     """
-    Initialize Turbovote class
+    Instantiate the TurboVote class
 
     `Args:`
         username: str
-            A valid turbovote username. Not required if ``TURBOVOTE_USERNAME``
+            A valid TurboVote username. Not required if ``TURBOVOTE_USERNAME``
             env variable set.
         password: str
-            A valid turbovote password. Not required if ``TURBOVOTE_PASSWORD``
+            A valid TurboVote password. Not required if ``TURBOVOTE_PASSWORD``
             env variable set.
         subdomain: str
-            Your turbovote subdomain (i.e. ``https://MYORG.turbovote.org``). Not
+            Your TurboVote subdomain (i.e. ``https://MYORG.turbovote.org``). Not
             required if ``TURBOVOTE_SUBDOMAIN`` env variable set.
     `Returns:`
         class

--- a/parsons/twilio/twilio.py
+++ b/parsons/twilio/twilio.py
@@ -9,6 +9,8 @@ logger = logging.getLogger(__name__)
 
 class Twilio:
     """
+    Instantiate the Twilio class
+
     `Args:`
         account_sid: str
             The Twilio account sid. Not required if ``TWILIO_ACCOUNT_SID`` env variable is
@@ -128,7 +130,7 @@ class Twilio:
 
         return tbl
 
-    def get_messages(self, to=None, from_=None, date_sent=None, date_sent_before=None,
+    def get_messages(self, to=None, sent_from=None, date_sent=None, date_sent_before=None,
                      date_sent_after=None):
         """
         Get Twilio messages.
@@ -136,7 +138,7 @@ class Twilio:
         `Args:`
             to: str
                 Filter to messages only sent to the specified phone number.
-            from_: str
+            sent_from: str
                 Filter to messages only sent from the specified phone number.
             date_sent: str
                 Filter to messages only sent on the specified date (ex. ``2019-01-01``).
@@ -149,7 +151,7 @@ class Twilio:
                 See :ref:`parsons-table` for output options.
         """
 
-        r = self.client.messages.list(to=to, from_=from_, date_sent=date_sent,
+        r = self.client.messages.list(to=to, sent_from=sent_from, date_sent=date_sent,
                                       date_sent_before=date_sent_before,
                                       date_sent_after=date_sent_after)
 

--- a/parsons/zoom/zoom.py
+++ b/parsons/zoom/zoom.py
@@ -18,7 +18,7 @@ class Zoom:
         api_key: str
             A valid Zoom api key. Not required if ``ZOOM_API_KEY`` env
             variable set.
-        api_secret:
+        api_secret: str
             A valid Zoom api secret. Not required if ``ZOOM_API_SECRET`` env
             variable set.
     """
@@ -143,7 +143,7 @@ class Zoom:
         Get past meeting participants
 
         `Args:`
-            meeting_id:
+            meeting_id: str
                 The meeting id
         `Returns:`
             Parsons Table


### PR DESCRIPTION
This PR is a final(ish) cleanup of the docs for #269 , not including the AWS and Google connectors which are still under review or in progress. I passed over all the connectors at `https://move-coop.github.io/parsons/html/index.html` and identified errors, many of which slipped through my recent PRs because I am not set up to test the docs locally. 

Some common mistakes and omissions corrected in this PR include:

- Many Quickstart code blocks were not appearing at all! This happened wherever I failed to include a blank line after `.. code-block:: python`.
- Many Quickstart code blocks had inconsistent indendantion (some white space issues were propogated to many connectors as i was copy-and-pasting without realizing the issue)
- Many docs were missing section headers (e.g., `Overview`, `API`), making it impossible to jump to the desired section from the sidebar menu.
- Some docstrings were missing type hints or had extra args
- Miscellaneous typos and misformatted text, code, and hyperlinks.

Some isolated bugs:

- NewMode's API 'autoclass' section was not rendering due to a formatting bug.
- Twilio had an argument ending in an underscore, which was appearing in the rendered docs as a hyperlink
- Twilio and Turbovote were out of order in the otherwise alphabetized index 