### PR TITLE
surveygizmo: fix test lint errors

### DIFF
--- a/test/test_surveygizmo/test_getresponses.py
+++ b/test/test_surveygizmo/test_getresponses.py
@@ -1,10 +1,11 @@
 import os
 import unittest
 import unittest.mock as mock
-from parsons.surveygizmo.surveygizmo import SurveyGizmo, Table
+from parsons.surveygizmo.surveygizmo import SurveyGizmo
 import logging
 
 logger = logging.getLogger(__name__)
+
 
 class TestSurveyGizmoGetResponses(unittest.TestCase):
     def setUp(self):
@@ -56,7 +57,7 @@ class TestSurveyGizmoGetResponses(unittest.TestCase):
                         "url_variables": [],
                         "ip_address": "50.232.185.226",
                         "referer": "https://app.surveygizmo.com/distribute/share/id/4599075",
-                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",  # noqa
                         "response_time": 10,
                         "data_quality": [],
                         "longitude": "-105.20369720459",
@@ -114,7 +115,7 @@ class TestSurveyGizmoGetResponses(unittest.TestCase):
                                 },
                             "ip_address": "50.232.185.226",
                             "referer": "",
-                            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+                            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",  # noqa
                             "response_time": 10,
                             "data_quality": [],
                             "longitude": "-105.20369720459",

--- a/test/test_surveygizmo/test_getsurveys.py
+++ b/test/test_surveygizmo/test_getsurveys.py
@@ -1,13 +1,14 @@
 import os
 import unittest
 import unittest.mock as mock
-from parsons.surveygizmo.surveygizmo import SurveyGizmo, Table
+from parsons.surveygizmo.surveygizmo import SurveyGizmo
 import logging
 
 logger = logging.getLogger(__name__)
 
 # Relevant links
 # V5 API Documentation https://apihelp.surveygizmo.com/help/version-5
+
 
 class TestSurveyGizmoGetSurveys(unittest.TestCase):
     def setUp(self):
@@ -34,8 +35,7 @@ class TestSurveyGizmoGetSurveys(unittest.TestCase):
 
         actual_surveys = self.surveygizmo.get_surveys()
 
-        assert not "links" in actual_surveys.columns
-
+        assert "links" not in actual_surveys.columns
 
     def _get_surveys_return_single_page(self):
         return {


### PR DESCRIPTION
This commit fixes a few minor lint errors in the tests for the
`SurveyGizmo` Connector.

---

When these changes were put up for PR, the branch didn't have the new linting rules so the branch passed for the pull request. After being merged into master, the new rules were run against the changes on master, and failed.