### PR TITLE
Clean up docs args

### DIFF
--- a/parsons/bloomerang/bloomerang.py
+++ b/parsons/bloomerang/bloomerang.py
@@ -99,7 +99,7 @@ class Bloomerang(object):
     def create_constituent(self, **kwargs):
         """
         `Args:`
-            **kwargs:`
+            **kwargs:
                 Fields to include, e.g., FirstName = 'Rachel'.
 
                 See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Constituents/post_constituent>`_. # noqa
@@ -111,7 +111,7 @@ class Bloomerang(object):
         `Args:`
             constituent_id: str or int
                 Constituent ID to update
-            **kwargs:`
+            **kwargs:
                 Fields to update, e.g., FirstName = 'RJ'.
 
                 See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Constituents/put_constituent__id_>`_. # noqa
@@ -153,7 +153,7 @@ class Bloomerang(object):
     def create_transaction(self, **kwargs):
         """
         `Args:`
-            **kwargs:`
+            **kwargs:
                 Fields to include, e.g., CreditCardType = 'Visa'.
 
                 See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Transactions/post_transaction>`_. # noqa
@@ -165,7 +165,7 @@ class Bloomerang(object):
         `Args:`
             transaction_id: str or int
                 Transaction ID to update
-            **kwargs:`
+            **kwargs:
                 Fields to update, e.g., CreditCardType = 'Visa'.
 
                 See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Transactions/put_transaction__id_>`_. # noqa
@@ -231,7 +231,7 @@ class Bloomerang(object):
     def create_interaction(self, **kwargs):
         """
         `Args:`
-            **kwargs:`
+            **kwargs:
                 Fields to include, e.g., Channel = "Email".
 
                 See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Interactions/post_interaction>`_. # noqa
@@ -243,7 +243,7 @@ class Bloomerang(object):
         `Args:`
             interaction_id: str or int
                 Interaction ID to update
-            **kwargs:`
+            **kwargs:
                 Fields to update, e.g., EmailAddress = "user@example.com".
 
                 See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Interactions/put_interaction__id_>`_. # noqa

--- a/parsons/twilio/twilio.py
+++ b/parsons/twilio/twilio.py
@@ -138,7 +138,7 @@ class Twilio:
         `Args:`
             to: str
                 Filter to messages only sent to the specified phone number.
-            from_: str
+            from\_: str
                 Filter to messages only sent from the specified phone number.
             date_sent: str
                 Filter to messages only sent on the specified date (ex. ``2019-01-01``).


### PR DESCRIPTION
Minor fixes for #269:

- Bloomerang: rm some extraneous backticks from args in docstrings
- Twilio: escape hyperlink formatting using backslash in the `from_` arg