### PR TITLE
Add SurveyGizmo connector to the top-level parson's imports

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,7 +106,7 @@ minimize resource utilization:
   1. Don't import classes from the root Parsons package
   2. Install only the dependencies you need
 
-*** Don't import from the root Parsons package
+*** Don't import from the root Parsons package ***
 
 Throughout the Parsons documentation, users are encouraged to load Parsons classes like so:
 
@@ -128,7 +128,7 @@ If you use the `PARSONS_SKIP_IMPORT_ALL` and import directly from the appropriat
 you will only load the classes that you need and will not consume extra resources. Using this
 method, you may see as much as an 8x decrease in memory usage for Parsons.
 
-*** Install only the dependencies you need
+*** Install only the dependencies you need ***
 
 Since Parsons needs to talk to so many different API's, it has a number of dependencies on other
 Python libraries. It may be preferable to only install those external dependencies that you will

--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -49,6 +49,7 @@ if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
     from parsons.github.github import GitHub
     from parsons.bloomerang.bloomerang import Bloomerang
     from parsons.sisense.sisense import Sisense
+    from parsons.surveygizmo.surveygizmo import SurveyGizmo
 
     __all__ = [
         'VAN',
@@ -91,7 +92,8 @@ if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
         'AzureBlobStorage',
         'GitHub',
         'Bloomerang',
-        'Sisense'
+        'Sisense',
+        'SurveyGizmo'
     ]
 
 # Define the default logging config for Parsons and its submodules. For now the


### PR DESCRIPTION
When building the connector originally, the last step to add it to the parson's top-level import wasn't done.

Based on [this comment](https://github.com/move-coop/parsons/issues/217#issuecomment-698567117)