### PR TITLE
Google Cloud Storage: Create Presigned URL

### DIFF
--- a/docs/table.rst
+++ b/docs/table.rst
@@ -27,6 +27,9 @@ From Parsons Table
     * - :py:meth:`~parsons.etl.tofrom.ToFrom.to_s3_csv`
       - AWS s3 Bucket
       - Write a table to a csv stored in S3
+    * - :py:meth:`~parsons.etl.tofrom.ToFrom.to_gcs_csv`
+      - Google Cloud Storage Bucket
+      - Write a table to a csv stored in Google Cloud Storage
     * - :py:meth:`~parsons.etl.tofrom.ToFrom.to_sftp_csv`
       - SFTP Server
       - Write a table to a csv stored on an SFTP server

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -394,6 +394,67 @@ class ToFrom(object):
         else:
             return None
 
+
+    def to_gcs_csv(self, bucket_name, blob_name, app_creds=None, project=None, compression=None,
+                   encoding=None, errors='strict', write_header=True, public_url=False,
+                   public_url_expires=60, **csvargs):
+        """
+        Writes the table to a Google Cloud Storage blob as a CSV.
+
+        `Args:`
+            bucket_name: str
+                The bucket to upload to
+            blob_name: str
+                The blob to name the file. If it ends in '.gz' or '.zip', the file will be
+                compressed.
+            app_creds: str
+                A credentials json string or a path to a json file. Not required
+                if ``GOOGLE_APPLICATION_CREDENTIALS`` env variable set.
+            project: str
+                The project which the client is acting on behalf of. If not passed
+                then will use the default inferred environment.
+            compression: str
+                The compression type for the csv. Currently "None", "zip" and "gzip" are
+                supported. If specified, will override the key suffix.
+            encoding: str
+                The CSV encoding type for `csv.writer()
+                <https://docs.python.org/2/library/csv.html#csv.writer/>`_
+            errors: str
+                Raise an Error if encountered
+            write_header: boolean
+                Include header in output
+            public_url: boolean
+                Create a public link to the file
+            public_url_expire: 60
+                The time, in minutes, until the url expires if ``public_url`` set to ``True``.
+            \**csvargs: kwargs
+                ``csv_writer`` optional arguments
+        `Returns:`
+            Public url if specified. If not ``None``.
+        """  # noqa: W605
+
+        compression = compression or files.compression_type_for_path(blob_name)
+
+        csv_name = files.extract_file_name(blob_name, include_suffix=False) + '.csv'
+
+        # Save the CSV as a temp file
+        local_path = self.to_csv(temp_file_compression=compression,
+                                 encoding=encoding,
+                                 errors=errors,
+                                 write_header=write_header,
+                                 csv_name=csv_name,
+                                 **csvargs)
+
+        from parsons.google.google_cloud_storage import GoogleCloudStorage
+        gcs = GoogleCloudStorage(app_creds=app_creds, project=project)
+        gcs.put_blob(bucket_name, blob_name, local_path)
+
+        if public_url:
+            return gcs.get_url(bucket_name, blob_name, expires_in=public_url_expires)
+        else:
+            return None
+
+
     def to_redshift(self, table_name, username=None, password=None, host=None,
                     db=None, port=None, **copy_args):
         """

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -394,7 +394,6 @@ class ToFrom(object):
         else:
             return None
 
-
     def to_gcs_csv(self, bucket_name, blob_name, app_creds=None, project=None, compression=None,
                    encoding=None, errors='strict', write_header=True, public_url=False,
                    public_url_expires=60, **csvargs):
@@ -453,7 +452,6 @@ class ToFrom(object):
             return gcs.get_url(bucket_name, blob_name, expires_in=public_url_expires)
         else:
             return None
-
 
     def to_redshift(self, table_name, username=None, password=None, host=None,
                     db=None, port=None, **copy_args):

--- a/parsons/google/google_cloud_storage.py
+++ b/parsons/google/google_cloud_storage.py
@@ -2,6 +2,7 @@ import google
 from google.cloud import storage
 from parsons.google.utitities import setup_google_application_credentials
 from parsons.utilities import files
+import datetime
 import logging
 
 logger = logging.getLogger(__name__)
@@ -292,3 +293,26 @@ class GoogleCloudStorage(object):
             files.close_temp_file(local_file)
 
         return f'gs://{bucket_name}/{blob_name}'
+
+    def get_url(self, bucket_name, blob_name, expires_in=60):
+        """
+        Generates a presigned url for a blob
+
+        `Args:`
+            bucket_name: str
+                The name of the bucket
+            blob_name: str
+                The name of the blob
+            expires_in: int
+                Minutes until the url expires
+        `Returns:`
+            url:
+                A link to download the object
+        """
+
+        bucket = self.client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+        url = blob.generate_signed_url(version="v4",
+                                       expiration=datetime.timedelta(minutes=expires_in),
+                                       method="GET")
+        return url

--- a/test/test_google/test_google_cloud_storage.py
+++ b/test/test_google/test_google_cloud_storage.py
@@ -1,5 +1,7 @@
 import unittest
 from parsons.google.google_cloud_storage import GoogleCloudStorage
+from parsons.etl import Table
+from test.utils import assert_matching_tables
 from parsons.utilities import files
 from google.cloud import storage
 import os
@@ -106,3 +108,12 @@ class TestGoogleStorageBuckets(unittest.TestCase):
         # Check that it was deleted.
         self.cloud.delete_blob(TEMP_BUCKET_NAME, file_name)
         self.assertFalse(self.cloud.blob_exists(TEMP_BUCKET_NAME, file_name))
+
+    def test_get_url(self):
+
+        file_name = 'delete_me.csv'
+        input_tbl = Table([['a'], ['1']])
+        self.cloud.upload_table(input_tbl, TEMP_BUCKET_NAME, file_name)
+        url = self.cloud.get_url(TEMP_BUCKET_NAME, file_name)
+        download_tbl = Table.from_csv(url)
+        assert_matching_tables(input_tbl, download_tbl)


### PR DESCRIPTION
This add two methods that mirror existing methods in the S3 class.

`GoogleCloudStorage.get_url()` - Generates a presigned expiring url for the file.

`Table.to_gcs_csv()` - Convenience method to pass a table to GCS.