### PR TITLE
table: materialize_to_file return file

### DIFF
--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -197,6 +197,9 @@ class Table(ETL, ToFrom):
             file_path: str
                 The path to the file to materialize the table to; if not specified, a temp file
                 will be created.
+        `Returns:`
+            str
+                Path to the temp file that now contains the table
         """
 
         # Load the data in batches, and "pickle" the rows to a temp file.
@@ -211,6 +214,8 @@ class Table(ETL, ToFrom):
 
         # Load a Table from the file
         self.table = petl.frompickle(file_path)
+
+        return file_path
 
     def is_valid_table(self):
         """

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -82,7 +82,7 @@ class TestParsonsTable(unittest.TestCase):
     def test_materialize_to_file(self):
         # Simple test that materializing doesn't change the table
         tbl_materialized = Table(self.lst_dicts)
-        tbl_materialized.materialize_to_file()
+        _ = tbl_materialized.materialize_to_file()
 
         assert_matching_tables(self.tbl, tbl_materialized)
 


### PR DESCRIPTION
This commit updates the `Table.materialize_to_file` method to
return the path to the temp file that contains the data of the
Parsons `Table`. This allows users to track and clean up the
temp files as needed.