### PR TITLE
redshift: upsert(from_s3:bool) and s3_copy(template_table:str)

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -800,7 +800,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 if from_s3:
                     if table_obj is not None:
                         raise ValueError(
-                            'upsert() using from_s3= requires the first argument (table_obj)'
+                            'upsert(... from_s3=True) requires the first argument (table_obj)'
                             ' to be None. from_s3 and table_obj are mutually exclusive.'
                         )
                     self.copy_s3(staging_tbl,

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -236,7 +236,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 blanksasnull=True, nullas=None, acceptinvchars=True, truncatecolumns=False,
                 columntypes=None, specifycols=None,
                 aws_access_key_id=None, aws_secret_access_key=None, bucket_region=None,
-                strict_length=True):
+                strict_length=True, template_table=None):
         """
         Copy a file from s3 to Redshift.
 
@@ -327,6 +327,10 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 or if their size will be rounded up to account for future values being larger
                 then the current dataset. defaults to ``True``; this argument is ignored if
                 ``padding`` is specified
+            template_table: str
+                Instead of specifying columns, columntypes, and/or inference, if there
+                is a pre-existing table that has the same columns/types, then use the template_table
+                table name as the schema for the new table.
 
         `Returns`
             Parsons Table or ``None``
@@ -336,24 +340,26 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         with self.connection() as connection:
 
             if self._create_table_precheck(connection, table_name, if_exists):
-                # Grab the object from s3
-                from parsons.aws.s3 import S3
-                s3 = S3(aws_access_key_id=aws_access_key_id,
-                        aws_secret_access_key=aws_secret_access_key)
-
-                local_path = s3.get_file(bucket, key)
-
-                if data_type == 'csv':
-                    tbl = Table.from_csv(local_path, delimiter=csv_delimiter)
+                if template_table:
+                    sql = f'CREATE TABLE {table_name} (LIKE {template_table})'
                 else:
-                    raise TypeError("Invalid data type provided")
+                    # Grab the object from s3
+                    from parsons.aws.s3 import S3
+                    s3 = S3(aws_access_key_id=aws_access_key_id,
+                            aws_secret_access_key=aws_secret_access_key)
 
-                # Create the table
-                sql = self.create_statement(tbl, table_name, padding=padding,
-                                            distkey=distkey, sortkey=sortkey,
-                                            varchar_max=varchar_max,
-                                            columntypes=columntypes,
-                                            strict_length=strict_length)
+                    local_path = s3.get_file(bucket, key)
+                    if data_type == 'csv':
+                        tbl = Table.from_csv(local_path, delimiter=csv_delimiter)
+                    else:
+                        raise TypeError("Invalid data type provided")
+
+                    # Create the table
+                    sql = self.create_statement(tbl, table_name, padding=padding,
+                                                distkey=distkey, sortkey=sortkey,
+                                                varchar_max=varchar_max,
+                                                columntypes=columntypes,
+                                                strict_length=strict_length)
 
                 self.query_with_connection(sql, connection, commit=False)
                 logger.info(f'{table_name} created.')
@@ -712,7 +718,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         return manifest
 
     def upsert(self, table_obj, target_table, primary_key, vacuum=True, distinct_check=True,
-               cleanup_temp_table=True, alter_table=True, **copy_args):
+               cleanup_temp_table=True, alter_table=True, from_s3=False, **copy_args):
         """
         Preform an upsert on an existing table. An upsert is a function in which records
         in a table are updated and inserted at the same time. Unlike other SQL databases,
@@ -733,6 +739,12 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 Check if the primary key column is distinct. Raise error if not.
             cleanup_temp_table: boolean
                 A temp table is dropped by default on cleanup. You can set to False for debugging.
+            alter_table: boolean
+                Set to False to avoid automatic varchar column resizing to accomodate new data
+            from_s3: boolean
+                Instead of specifying a table_obj (set the first argument to None),
+                set this to True and include :func:`~parsons.databases.Redshift.copy_s3` arguments
+                to upsert a pre-existing s3 file into the target_table
             \**copy_args: kwargs
                 See :func:`~parsons.databases.Redshift.copy` for options.
         """  # noqa: W605
@@ -743,7 +755,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             self.copy(table_obj, target_table)
             return None
 
-        if alter_table:
+        if alter_table and table_obj:
             # Make target table column widths match incoming table, if necessary
             self.alter_varchar_column_widths(table_obj, target_table)
 
@@ -785,10 +797,20 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                     # column is not impactful barely impactful
                     # https://docs.aws.amazon.com/redshift/latest/dg/c_Loading_tables_auto_compress.html
                     copy_args = dict(copy_args, compupdate=False)
-                self.copy(table_obj, staging_tbl,
-                          template_table=target_table,
-                          alter_table=False,  # We just did our own alter table above
-                          **copy_args)
+                if from_s3:
+                    if table_obj is not None:
+                        raise ValueError(
+                            'upsert() using from_s3= requires the first argument (table_obj)'
+                            ' to be None. from_s3 and table_obj are mutually exclusive.'
+                        )
+                    self.copy_s3(staging_tbl,
+                                 template_table=target_table,
+                                 **copy_args)
+                else:
+                    self.copy(table_obj, staging_tbl,
+                              template_table=target_table,
+                              alter_table=False,  # We just did our own alter table above
+                              **copy_args)
 
                 staging_table_name = staging_tbl.split('.')[1]
                 target_table_name = target_table.split('.')[1]


### PR DESCRIPTION
Instead of using a local table, this allows using the upsert command to upload an existing S3 file.

cc: @crayolakat 