### PR TITLE
Add pandas to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ python-dateutil==2.8.1
 azure-storage-blob==12.3.2
 PyGitHub==1.51
 surveygizmo==1.2.3
+pandas==1.1.4
 
 # Testing Requirements
 requests-mock==1.5.2


### PR DESCRIPTION
When using the `movementcooperative/parsons` docker image and running `CivisClient.table_import()`, I get a `ModuleNotFoundError: No module named 'pandas'` error. 

Extended stack trace:
```
File "/src/parsons/civis/civisclient.py", line 111, in table_import
    fut = civis.io.dataframe_to_civis(table_obj.to_dataframe(), database=self.db,
File "/src/parsons/etl/tofrom.py", line 33, in to_dataframe
    columns=columns, coerce_float=coerce_float)
File "/usr/local/lib/python3.7/site-packages/petl/io/pandas.py", line 30, in todataframe
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
```