### PR TITLE
enabled fixes for Airtables missing columns that are sparsely populated

### DIFF
--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -37,7 +37,7 @@ class Airtable(object):
 
         return self.client.get(record_id)
 
-    def get_records(self, fields=None, max_records=None, view=None, formula=None, sort=None):
+    def get_records(self, fields=None, max_records=None, view=None, formula=None, sort=None, sample_size=None):
         """
         `Args:`
             fields: str or lst
@@ -78,6 +78,9 @@ class Airtable(object):
                 Example usage:
                 ``airtable.get_records(sort=['ColumnA', '-ColumnB'])``
 
+            sample_size: int
+                Number of rows to sample before determining columns
+
         `Returns:`
             Parsons Table
                 See :ref:`parsons-table` for output options.
@@ -94,7 +97,11 @@ class Airtable(object):
         if 'fields' not in tbl.columns:
             return Table([[]])
 
-        return tbl.unpack_dict(column='fields', prepend=False)
+        unpack_dicts_kwargs = {'column': 'fields', 'prepend': False}
+        if sample_size:
+            unpack_dicts_kwargs['sample_size'] = sample_size
+
+        return tbl.unpack_dict(**unpack_dicts_kwargs)
 
     def insert_record(self, row):
         """

--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -37,7 +37,8 @@ class Airtable(object):
 
         return self.client.get(record_id)
 
-    def get_records(self, fields=None, max_records=None, view=None, formula=None, sort=None, sample_size=None):
+    def get_records(self, fields=None, max_records=None, view=None,
+                    formula=None, sort=None, sample_size=None):
         """
         `Args:`
             fields: str or lst

--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -97,7 +97,13 @@ class Airtable(object):
         if 'fields' not in tbl.columns:
             return Table([[]])
 
-        unpack_dicts_kwargs = {'column': 'fields', 'prepend': False}
+        unpack_dicts_kwargs = {
+            'column': 'fields',
+            'prepend': False,
+        }
+        if fields:
+            unpack_dicts_kwargs['keys'] = fields
+
         if sample_size:
             unpack_dicts_kwargs['sample_size'] = sample_size
 

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -356,7 +356,7 @@ class ETL(object):
         return self
 
     def unpack_dict(self, column, keys=None, include_original=False,
-                    sample_size=1000, missing=None, prepend=True,
+                    sample_size=5000, missing=None, prepend=True,
                     prepend_value=None):
         """
         Unpack dictionary values from one column into separate columns

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -237,7 +237,7 @@ class ETL(object):
             `Parsons Table` and also updates self
 
         .. code-block:: python
-        
+
             tbl = [{'fn': 'Jane'},
                    {'lastname': 'Doe'},
                    {'dob': '1980-01-01'}]

--- a/test/test_airtable/airtable_responses.py
+++ b/test/test_airtable/airtable_responses.py
@@ -1,4 +1,3 @@
-
 records_response = {"records": [{"id": "recaBMSHTgXREa5ef",
                                  "fields": {"Name": "This is a row!"},
                                  "createdTime": "2019-05-08T19:37:58.000Z"},
@@ -14,10 +13,26 @@ insert_response = {'id': 'recD4aEaEjQKYZABZ',
                    'fields': {'Name': 'Another row!'},
                    'createdTime': '2019-05-13T16:28:18.000Z'}
 
-
 insert_responses = [{'id': 'recIYuf51JgbmHCHo',
                      'fields': {'Name': 'Another!'},
                      'createdTime': '2019-05-13T16:37:03.000Z'},
                     {'id': 'recJMqCfPwFVV5qfc',
                      'fields': {'Name': 'Another row!'},
                      'createdTime': '2019-05-13T16:37:03.000Z'}]
+
+records_response_with_more_columns = {"records": [{"id": "recaBMSHTgXREa5ef",
+                                                   "fields": {"Name": "This is a row!"},
+                                                   "createdTime": "2019-05-08T19:37:58.000Z"},
+                                                  {"id": "recaBMSHTgXvEa5ef",
+                                                   "fields": {"Name": "This is a row!"},
+                                                   "createdTime": "2019-05-08T19:37:58.000Z"},
+                                                  {"id": "recaBMSHTgXREsaef",
+                                                   "fields": {"Name": "This is a row!"},
+                                                   "createdTime": "2019-05-08T19:37:58.000Z"},
+                                                  {"id": "recObtmLUrD5dOnmD",
+                                                   "fields": {"Name": "This is a row!", "SecondColumn": ""},
+                                                   "createdTime": "2019-05-08T19:37:58.000Z"},
+                                                  {"id": "recmeBNnj4cuHPOSI",
+                                                   "fields": {"Name": "This is a row!", "SecondColumn": ""},
+                                                   "createdTime": "2019-05-08T19:37:58.000Z"}
+                                                  ]}

--- a/test/test_airtable/airtable_responses.py
+++ b/test/test_airtable/airtable_responses.py
@@ -20,19 +20,32 @@ insert_responses = [{'id': 'recIYuf51JgbmHCHo',
                      'fields': {'Name': 'Another row!'},
                      'createdTime': '2019-05-13T16:37:03.000Z'}]
 
-records_response_with_more_columns = {"records": [{"id": "recaBMSHTgXREa5ef",
-                                                   "fields": {"Name": "This is a row!"},
-                                                   "createdTime": "2019-05-08T19:37:58.000Z"},
-                                                  {"id": "recaBMSHTgXvEa5ef",
-                                                   "fields": {"Name": "This is a row!"},
-                                                   "createdTime": "2019-05-08T19:37:58.000Z"},
-                                                  {"id": "recaBMSHTgXREsaef",
-                                                   "fields": {"Name": "This is a row!"},
-                                                   "createdTime": "2019-05-08T19:37:58.000Z"},
-                                                  {"id": "recObtmLUrD5dOnmD",
-                                                   "fields": {"Name": "This is a row!", "SecondColumn": ""},
-                                                   "createdTime": "2019-05-08T19:37:58.000Z"},
-                                                  {"id": "recmeBNnj4cuHPOSI",
-                                                   "fields": {"Name": "This is a row!", "SecondColumn": ""},
-                                                   "createdTime": "2019-05-08T19:37:58.000Z"}
-                                                  ]}
+records_response_with_more_columns = {
+    "records": [
+        {
+            "id": "recaBMSHTgXREa5ef",
+            "fields": {"Name": "This is a row!"},
+            "createdTime": "2019-05-08T19:37:58.000Z"
+        },
+        {
+            "id": "recaBMSHTgXvEa5ef",
+            "fields": {"Name": "This is a row!"},
+            "createdTime": "2019-05-08T19:37:58.000Z"
+        },
+        {
+            "id": "recaBMSHTgXREsaef",
+            "fields": {"Name": "This is a row!"},
+            "createdTime": "2019-05-08T19:37:58.000Z"
+        },
+        {
+            "id": "recObtmLUrD5dOnmD",
+            "fields": {"Name": "This is a row!", "SecondColumn": ""},
+            "createdTime": "2019-05-08T19:37:58.000Z"
+        },
+        {
+            "id": "recmeBNnj4cuHPOSI",
+            "fields": {"Name": "This is a row!", "SecondColumn": ""},
+            "createdTime": "2019-05-08T19:37:58.000Z"
+        }
+    ]
+}

--- a/test/test_airtable/test_airtable.py
+++ b/test/test_airtable/test_airtable.py
@@ -4,7 +4,8 @@ import requests_mock
 from parsons.airtable import Airtable
 from parsons.etl import Table
 from test.utils import assert_matching_tables
-from airtable_responses import insert_response, insert_responses, records_response
+from airtable_responses import insert_response, insert_responses, \
+    records_response, records_response_with_more_columns
 
 
 os.environ['AIRTABLE_API_KEY'] = 'SOME_KEY'
@@ -54,6 +55,24 @@ class TestAirtable(unittest.TestCase):
         self.at.get_records(max_records=1)
         # Assert that Parsons tables match
         assert_matching_tables(self.at.get_records(), tbl)
+
+    @requests_mock.Mocker()
+    def test_get_records_with_1_sample(self, m):
+
+        m.get(self.base_uri, json=records_response_with_more_columns)
+
+        airtable_res = self.at.get_records(sample_size=1)
+
+        assert airtable_res.columns == ['id', 'createdTime', 'Name']
+
+    @requests_mock.Mocker()
+    def test_get_records_with_5_sample(self, m):
+
+        m.get(self.base_uri, json=records_response_with_more_columns)
+
+        airtable_res = self.at.get_records(sample_size=5)
+
+        assert airtable_res.columns == ['id', 'createdTime', 'Name', 'SecondColumn']
 
     @requests_mock.Mocker()
     def test_insert_record(self, m):

--- a/test/test_airtable/test_airtable.py
+++ b/test/test_airtable/test_airtable.py
@@ -75,6 +75,17 @@ class TestAirtable(unittest.TestCase):
         assert airtable_res.columns == ['id', 'createdTime', 'Name', 'SecondColumn']
 
     @requests_mock.Mocker()
+    def test_get_records_with_explicit_headers(self, m):
+
+        m.get(self.base_uri, json=records_response_with_more_columns)
+
+        fields = ['Name', 'SecondColumn']
+
+        airtable_res = self.at.get_records(fields, sample_size=1)
+
+        assert airtable_res.columns == ['id', 'createdTime', 'Name', 'SecondColumn']
+
+    @requests_mock.Mocker()
     def test_insert_record(self, m):
 
         m.post(self.base_uri, json=insert_response)


### PR DESCRIPTION
PR for issue #454 

The notes in the issue linked above go through the investigation. In their I laid out 2 different solutions:

1. give the `header` manually.
2. Make the `sample` larger.

This PR enables the developer to do both of those. 

The default `sample_size` remains 1000 but the developer can make that larger (or smaller) by sending that parameter to `get_records`.

Additionally, the `fields` parameter will now be sent to `petl` and it will no longer need to use sampling at all but rather will take these headers as they are.