### PR TITLE
copper: fix copper tests

### DIFF
--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -237,7 +237,7 @@ class ETL(object):
             `Parsons Table` and also updates self
 
         .. code-block:: python
-        
+
             tbl = [{'fn': 'Jane'},
                    {'lastname': 'Doe'},
                    {'dob': '1980-01-01'}]

--- a/test/test_copper/test_copper.py
+++ b/test/test_copper/test_copper.py
@@ -122,15 +122,15 @@ class TestCopper(unittest.TestCase):
 
         # GET request.text is always None
         if request.text is None:
-            row_start = 1
-            row_finish = 10
+            row_start = 0
+            row_finish = 100
         else:
             pdict = json.loads(request.text)
             page_number = pdict['page_number'] - 1
             page_size = pdict['page_size']
 
             row_start = page_number * page_size
-            row_finish = row_start + page_size + 1
+            row_finish = row_start + page_size
 
         with open(f'{_dir}/{context.headers["filename"]}', 'r') as json_file:
             response = json.load(json_file)
@@ -813,6 +813,8 @@ class TestCopper(unittest.TestCase):
              "name": "Note"},
             {"category": "user", "count_as_interaction": True, "id": 504464, "is_disabled": False,
              "name": "Mail"},
+            {"category": "user", "count_as_interaction": True, "id": 248465, "is_disabled": False,
+             "name": "Stories from the Field"},
             {"category": "user", "count_as_interaction": True, "id": 236962, "is_disabled": False,
              "name": "Press Coverage"}
         ])


### PR DESCRIPTION
This commit fixes a few bugs in the copper tests. Namely, it
fixes the pagination being done by the test code when simulating
the server, and it aligns the the expected results for one test
with what is being given to the `Copper` connector in the test.

---

cc @crayolakat

This fixes an issue where tests seem to be passing, but adding an explicit check on the number of lines when comparing tables causes things to fail.