### PR TITLE
table: improve __bool__ performance

### DIFF
--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -82,7 +82,11 @@ class Table(ETL, ToFrom):
 
     def __bool__(self):
 
-        return self.num_rows > 0
+        # Try to get a single row from our table
+        head_one = petl.head(self.table)
+
+        # See if our single row is empty
+        return petl.nrows(head_one) > 0
 
     def _repr_html_(self):
         """


### PR DESCRIPTION
This commit updates the `__bool__` magic method implementation
in the Parsons `Table` to be more performant. Before this PR the
`__bool__` method used the `num_rows` to determine whether or not
there was any data in the `Table`. The problem is that `num_rows`
will scan the whole `Table`, but `__bool__` only needs to know if
there is a single row of data. The new implementation leverages
the `petl.head` method to pull out a single row from the `Table`.