### PR TITLE
Zoom JWT Encryption Fix

### DIFF
--- a/parsons/zoom/zoom.py
+++ b/parsons/zoom/zoom.py
@@ -34,7 +34,7 @@ class Zoom:
         # on JWT generation using Zoom API: https://marketplace.zoom.us/docs/guides/auth/jwt
 
         payload = {"iss": self.api_key, "exp": int(datetime.datetime.now().timestamp() + 30)}
-        token = jwt.encode(payload, self.api_secret, algorithm='HS256').decode("utf-8")
+        token = jwt.encode(payload, self.api_secret, algorithm='HS256')
         self.client.headers = {'authorization': f"Bearer {token}",
                                'content-type': "application/json"}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ python-dateutil==2.8.1
 azure-storage-blob==12.3.2
 PyGitHub==1.51
 surveygizmo==1.2.3
+PyJWT==2.0.1
 
 # Testing Requirements
 requests-mock==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ python-dateutil==2.8.1
 azure-storage-blob==12.3.2
 PyGitHub==1.51
 surveygizmo==1.2.3
-PyJWT==2.0.1
+PyJWT==2.0.1 # Otherwise `import jwt` would refer to python-jwt package
 
 # Testing Requirements
 requests-mock==1.5.2


### PR DESCRIPTION
Turns out it was a comedy of errors in which both the desired package, PyJWT and another similar one, python-jwt, are both imported with `import jwt`. The latter took precedence for some reason, until we added PyJWT explicitly into requirements.txt.

That worked locally, but I'd also like to try to test this live once before merging.