### PR TITLE
feat(CivisClient): Modify methods to return futures

### DIFF
--- a/parsons/civis/civisclient.py
+++ b/parsons/civis/civisclient.py
@@ -60,13 +60,11 @@ class CivisClient(object):
                                    polling_interval=polling_interval, hidden=hidden)
 
         if not wait:
-
-            return None
+            return fut
 
         result = fut.result()
 
         if result['result_rows'] is None:
-
             return None
 
         result['result_rows'].insert(0, result['result_columns'])
@@ -116,5 +114,6 @@ class CivisClient(object):
                                           headers=True, **civisargs)
 
         if wait:
+            return fut.result()
 
-            fut.result()
+        return fut

--- a/parsons/civis/civisclient.py
+++ b/parsons/civis/civisclient.py
@@ -50,9 +50,9 @@ class CivisClient(object):
                 If ``True`` (the default), this job will not appear in the Civis UI.
             wait: boolean
                 If ``True``, will wait for query to finish executing before exiting
-                the method.
+                the method. If ``False``, returns the future object.
         `Returns`
-            Parsons Table
+            Parsons Table or ``civis.CivisFuture``
                 See :ref:`parsons-table` for output options.
         """
 
@@ -101,9 +101,10 @@ class CivisClient(object):
             sortkey2: str
                 The second column in a compound sortkey for the table.
             wait: boolean
-                Wait for write job to complete before exiting method.
+                Wait for write job to complete before exiting method. If ``False``, returns
+                the future object.
         `Returns`
-            ``None``
+            ``None`` or ``civis.CivisFuture``
         """ # noqa: E501,E261
 
         fut = civis.io.dataframe_to_civis(table_obj.to_dataframe(), database=self.db,


### PR DESCRIPTION
The CivisClient methods have an option to 'wait' for an underlying civis methods to complete. However, if 'wait' if set to False then there is not access the results of the method call.