### PR TITLE
dbsync: add retries and configurable chunking

### DIFF
--- a/parsons/databases/db_sync.py
+++ b/parsons/databases/db_sync.py
@@ -1,5 +1,7 @@
 import logging
 
+from parsons.etl.table import Table
+
 logger = logging.getLogger(__name__)
 
 
@@ -13,21 +15,30 @@ class DBSync:
             A database object.
         destination_db: Database connection object
             A database object.
-        chunk_size: int
-            The number of rows per transaction copy when syncing a table. The
+        read_chunk_size: int
+            The number of rows to read from the source at a time when syncing a table. The
             default value is 100,000 rows.
+        write_chunk_size: int
+            The number of rows to batch up before writing out to the destination. This value
+            defaults to whatever the read_chunk_size is.
+        retries: int
+            The number of times to retry if there is an error processing a
+            chunk of data. The default value is 0.
     `Returns:`
         A DBSync object.
     """
 
-    def __init__(self, source_db, destination_db, chunk_size=100000):
+    def __init__(self, source_db, destination_db, read_chunk_size=100_000, write_chunk_size=None,
+                 retries=0):
 
         self.source_db = source_db
         self.dest_db = destination_db
-        self.chunk_size = chunk_size
+        self.read_chunk_size = read_chunk_size
+        self.write_chunk_size = write_chunk_size or read_chunk_size
+        self.retries = retries
 
     def table_sync_full(self, source_table, destination_table, if_exists='drop',
-                        **kwargs):
+                        order_by=None, **kwargs):
         """
         Full sync of table from a source database to a destination database. This will
         wipe all data from the destination table.
@@ -76,18 +87,8 @@ class DBSync:
             logger.info('Source table contains 0 rows')
             return None
 
-        # Copy rows in chunks.
-        copied_rows = 0
-        while copied_rows < source_tbl.num_rows:
-
-            # Get a chunk
-            rows = source_tbl.get_rows(offset=copied_rows, chunk_size=self.chunk_size)
-
-            # Copy the chunk
-            self.dest_db.copy(rows, destination_table, if_exists='append', **kwargs)
-
-            # Update counter
-            copied_rows += rows.num_rows
+        copied_rows = self.copy_rows(source_table, destination_table, None,
+                                     order_by, **kwargs)
 
         logger.info(f'{source_table} synced: {copied_rows} total rows copied.')
 
@@ -123,7 +124,8 @@ class DBSync:
         # Check that the destination table exists. If it does not, then run a
         # full sync instead.
         if not destination_tbl.exists:
-            self.table_sync_full(source_table, destination_table)
+            self.table_sync_full(source_table, destination_table, order_by=primary_key, **kwargs)
+            return
 
         # If the source table contains 0 rows, do not attempt to copy the table.
         if source_tbl.num_rows == 0:
@@ -157,28 +159,116 @@ class DBSync:
 
             logger.info(f'Found {new_row_count} new rows in source table.')
 
-            copied_rows = 0
-            # Copy rows in chunks.
-            while True:
-                # Get a chunk
-                rows = source_tbl.get_new_rows(primary_key=primary_key,
-                                               cutoff_value=dest_max_pk,
-                                               offset=copied_rows,
-                                               chunk_size=self.chunk_size)
+            rows_copied = self.copy_rows(source_table, destination_table, dest_max_pk,
+                                         primary_key, **kwargs)
 
-                row_count = rows.num_rows if rows else 0
-                if row_count == 0:
-                    break
-
-                # Copy the chunk
-                self.dest_db.copy(rows, destination_table, if_exists='append', **kwargs)
-
-                # Update the counter
-                copied_rows += row_count
+            logger.info('Copied %s new rows to %s.', rows_copied, destination_table)
 
         self._row_count_verify(source_tbl, destination_tbl)
 
         logger.info(f'{source_table} synced to {destination_table}.')
+
+    def copy_rows(self, source_table_name, destination_table_name, cutoff, order_by, **kwargs):
+        """
+        Copy the rows from the source to the destination.
+
+        `Args:`
+            source_table_name: str
+                Full table path (e.g. ``my_schema.my_table``)
+            destination_table_name: str
+                Full table path (e.g. ``my_schema.my_table``)
+            cutoff:
+                Start value to use as a minimum for incremental updates.
+            order_by:
+                Column to use to order the data to ensure a stable sort.
+            **kwargs: args
+                Optional copy arguments for destination database.
+        `Returns:`
+            ``None``
+        """
+
+        # Create the table objects
+        source_table = self.source_db.table(source_table_name)
+
+        # Initialize the Parsons table we will use to store rows before writing
+        buffer = Table()
+
+        # Track the number of retries we have left before giving up
+        retries_left = self.retries + 1
+
+        total_rows_downloaded = 0
+        total_rows_written = 0
+        rows_buffered = 0
+
+        # Keep going until we break out
+        while True:
+            try:
+                # Get the records to load into the database
+                if cutoff:
+                    # If we have a cut off, we are loading data incrementally -- filter out
+                    # any data before our cutoff
+                    rows = source_table.get_new_rows(primary_key=order_by,
+                                                     cutoff_value=cutoff,
+                                                     offset=total_rows_downloaded,
+                                                     chunk_size=self.read_chunk_size)
+                else:
+                    # Get a chunk
+                    rows = source_table.get_rows(offset=total_rows_downloaded,
+                                                 chunk_size=self.read_chunk_size,
+                                                 order_by=order_by)
+
+                number_of_rows = rows.num_rows
+                total_rows_downloaded += number_of_rows
+
+                # If we didn't get any data, exit the loop -- there's nothing to load
+                if number_of_rows == 0:
+                    # If we have any rows that are unwritten, flush them to the destination database
+                    if rows_buffered > 0:
+                        self.dest_db.copy(buffer, destination_table_name, if_exists='append',
+                                          **kwargs)
+                        total_rows_written += rows_buffered
+
+                        # Reset the buffer
+                        rows_buffered = 0
+                        buffer = Table()
+
+                    break
+
+                # Add the new rows to our buffer
+                buffer.concat(rows)
+                rows_buffered += number_of_rows
+
+                # If our buffer reaches our write threshold, write it out
+                if rows_buffered >= self.write_chunk_size:
+                    self.dest_db.copy(buffer, destination_table_name, if_exists='append', **kwargs)
+                    total_rows_written += rows_buffered
+
+                    # Reset the buffer
+                    rows_buffered = 0
+                    buffer = Table()
+
+            except Exception:
+                # Tick down the number of retries
+                retries_left -= 1
+
+                # If we are out of retries, fail
+                if retries_left == 0:
+                    logger.debug('No retries remaining')
+                    raise
+
+                # Otherwise, log the exception and try again
+                logger.exception('Unhandled error copying data; retrying')
+
+        return total_rows_written
+
+    def _check_column_match(self, source_table_obj, destination_table_obj):
+        """
+        Ensure that the columns from each table match
+        """
+
+        if source_table_obj.columns != destination_table_obj.columns:
+            raise ValueError("""Destination table columns do not match source table columns.
+                             Consider dropping destination table and running a full sync.""")
 
     def _row_count_verify(self, source_table_obj, destination_table_obj):
         """
@@ -195,12 +285,3 @@ class DBSync:
 
         logger.info('Source and destination table row counts match.')
         return True
-
-    def _check_column_match(self, source_table_obj, destination_table_obj):
-        """
-        Ensure that the columns from each table match
-        """
-
-        if source_table_obj.columns != destination_table_obj.columns:
-            raise ValueError("""Destination table columns do not match source table columns.
-                             Consider dropping destination table and running a full sync.""")

--- a/parsons/databases/db_sync.py
+++ b/parsons/databases/db_sync.py
@@ -205,7 +205,7 @@ class DBSync:
             try:
                 # Get the records to load into the database
                 if cutoff:
-                    # If we have a cut off, we are loading data incrementally -- filter out
+                    # If we have a cutoff, we are loading data incrementally -- filter out
                     # any data before our cutoff
                     rows = source_table.get_new_rows(primary_key=order_by,
                                                      cutoff_value=cutoff,

--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -208,8 +208,10 @@ class MySQL(MySQLCreateTable):
             chunk_size: int
                 The number of rows to insert per query.
             strict_length: bool
-                Whether or not to tightly fit the length of the table columns to the length
-                of the data in ``tbl``; if ``padding`` is specified, this argument is ignored
+                If the database table needs to be created, strict_length determines whether
+                the created table's column sizes will be sized to exactly fit the current data,
+                or if their size will be rounded up to account for future values being larger
+                then the current dataset. defaults to ``True``
         """
 
         if tbl.num_rows == 0:

--- a/parsons/databases/postgres/postgres.py
+++ b/parsons/databases/postgres/postgres.py
@@ -46,17 +46,21 @@ class Postgres(PostgresCore):
         self.timeout = timeout
         self.dialect = 'postgres'
 
-    def copy(self, tbl, table_name, if_exists='fail'):
+    def copy(self, tbl, table_name, if_exists='fail', strict_length=False):
         """
         Copy a :ref:`parsons-table` to Postgres.
 
-        tbl: parsons.Table
-            A Parsons table object
-        table_name: str
-            The destination schema and table (e.g. ``my_schema.my_table``)
-        if_exists: str
-            If the table already exists, either ``fail``, ``append``, ``drop``
-            or ``truncate`` the table.
+        `Args:`
+            tbl: parsons.Table
+                A Parsons table object
+            table_name: str
+                The destination schema and table (e.g. ``my_schema.my_table``)
+            if_exists: str
+                If the table already exists, either ``fail``, ``append``, ``drop``
+                or ``truncate`` the table.
+            strict_length: bool
+                Whether or not to tightly fit the length of the table columns to the length
+                of the data in ``tbl``; if ``padding`` is specified, this argument is ignored
         """
 
         with self.connection() as connection:
@@ -66,7 +70,7 @@ class Postgres(PostgresCore):
 
                 # Create the table
                 # To Do: Pass in the advanced configuration parameters.
-                sql = self.create_statement(tbl, table_name)
+                sql = self.create_statement(tbl, table_name, strict_length=strict_length)
 
                 self.query_with_connection(sql, connection, commit=False)
                 logger.info(f'{table_name} created.')

--- a/parsons/databases/postgres/postgres.py
+++ b/parsons/databases/postgres/postgres.py
@@ -59,8 +59,10 @@ class Postgres(PostgresCore):
                 If the table already exists, either ``fail``, ``append``, ``drop``
                 or ``truncate`` the table.
             strict_length: bool
-                Whether or not to tightly fit the length of the table columns to the length
-                of the data in ``tbl``; if ``padding`` is specified, this argument is ignored
+                If the database table needs to be created, strict_length determines whether
+                the created table's column sizes will be sized to exactly fit the current data,
+                or if their size will be rounded up to account for future values being larger
+                then the current dataset
         """
 
         with self.connection() as connection:

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -232,7 +232,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 dateformat='auto', timeformat='auto', emptyasnull=True,
                 blanksasnull=True, nullas=None, acceptinvchars=True, truncatecolumns=False,
                 columntypes=None, specifycols=None,
-                aws_access_key_id=None, aws_secret_access_key=None, bucket_region=None):
+                aws_access_key_id=None, aws_secret_access_key=None, bucket_region=None,
+                strict_length=True):
         """
         Copy a file from s3 to Redshift.
 
@@ -317,6 +318,10 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             bucket_region: str
                 The AWS region that the bucket is located in. This should be provided if the
                 Redshift cluster is located in a different region from the temp bucket.
+            strict_length: bool
+                Whether or not to tightly fit the length of the table columns to the length
+                of the data in the S3 file; if ``padding`` is specified, this argument is
+                ignored.
 
         `Returns`
             Parsons Table or ``None``
@@ -342,7 +347,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 sql = self.create_statement(tbl, table_name, padding=padding,
                                             distkey=distkey, sortkey=sortkey,
                                             varchar_max=varchar_max,
-                                            columntypes=columntypes)
+                                            columntypes=columntypes,
+                                            strict_length=strict_length)
 
                 self.query_with_connection(sql, connection, commit=False)
                 logger.info(f'{table_name} created.')
@@ -371,7 +377,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
              dateformat='auto', timeformat='auto', varchar_max=None, truncatecolumns=False,
              columntypes=None, specifycols=None, alter_table=False,
              aws_access_key_id=None, aws_secret_access_key=None, iam_role=None,
-             cleanup_s3_file=True, template_table=None, temp_bucket_region=None):
+             cleanup_s3_file=True, template_table=None, temp_bucket_region=None,
+             strict_length=True):
         """
         Copy a :ref:`parsons-table` to Redshift.
 
@@ -460,6 +467,9 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 The AWS region that the temp bucket (specified by the TEMP_S3_BUCKET environment
                 variable) is located in. This should be provided if the Redshift cluster is located
                 in a different region from the temp bucket.
+            strict_length: bool
+                Whether or not to tightly fit the length of the table columns to the length
+                of the data in ``tbl``; if ``padding`` is specified, this argument is ignored
 
         `Returns`
             Parsons Table or ``None``
@@ -484,7 +494,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                     sql = self.create_statement(tbl, table_name, padding=padding,
                                                 distkey=distkey, sortkey=sortkey,
                                                 varchar_max=varchar_max,
-                                                columntypes=columntypes)
+                                                columntypes=columntypes,
+                                                strict_length=strict_length)
                 self.query_with_connection(sql, connection, commit=False)
                 logger.info(f'{table_name} created.')
 

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -319,9 +319,11 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                 The AWS region that the bucket is located in. This should be provided if the
                 Redshift cluster is located in a different region from the temp bucket.
             strict_length: bool
-                Whether or not to tightly fit the length of the table columns to the length
-                of the data in the S3 file; if ``padding`` is specified, this argument is
-                ignored.
+                If the database table needs to be created, strict_length determines whether
+                the created table's column sizes will be sized to exactly fit the current data,
+                or if their size will be rounded up to account for future values being larger
+                then the current dataset. defaults to ``True``; this argument is ignored if
+                ``padding`` is specified
 
         `Returns`
             Parsons Table or ``None``

--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -76,6 +76,10 @@ class Table(ETL, ToFrom):
 
             return self.column_data(index)
 
+        elif isinstance(index, slice):
+            tblslice = petl.rowslice(self.table, index.start, index.stop, index.step)
+            return [row for row in tblslice]
+
         else:
 
             raise TypeError('You must pass a string or an index as a value.')

--- a/test/test_databases/fakes.py
+++ b/test/test_databases/fakes.py
@@ -1,0 +1,101 @@
+from parsons.etl.table import Table
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class FakeDatabase:
+    def __init__(self):
+        self.table_map = {}
+        self.copy_call_args = []
+
+    def setup_table(self, table_name, data, failures=0):
+        self.table_map[table_name] = {
+            'failures': failures,
+            'table': FakeTable(table_name, data)
+        }
+        return self.table_map[table_name]['table']
+
+    def table(self, table_name):
+        if table_name not in self.table_map:
+            self.setup_table(table_name, None)
+
+        return self.table_map[table_name]['table']
+
+    def copy(self, data, table_name, **kwargs):
+        logger.info('Copying %s rows', data.num_rows)
+        if table_name not in self.table_map:
+            self.setup_table(table_name, Table())
+
+        if self.table_map[table_name]['table'].data is None:
+            self.table_map[table_name]['table'].data = Table()
+
+        if self.table_map[table_name]['failures'] > 0:
+            self.table_map[table_name]['failures'] -= 1
+            raise ValueError('Canned error')
+
+        self.copy_call_args.append({
+            'data': data,
+            'table_name': table_name,
+            'kwargs': kwargs,
+        })
+
+        tbl = self.table_map[table_name]['table']
+
+        tbl.data.concat(data)
+
+
+class FakeTable:
+    def __init__(self, table_name, data):
+        self.table_name = table_name
+        self.data = data
+
+    def drop(self, cascade=False):
+        self.data = None
+
+    def truncate(self):
+        self.data = Table()
+
+    def distinct_primary_key(self, primary_key):
+        if primary_key not in self.data.columns:
+            return True
+
+        pk_values = [val for val in self.data[primary_key]]
+        pk_set = set(pk_values)
+        return len(pk_set) == len(pk_values)
+
+    @property
+    def columns(self):
+        return self.data.columns
+
+    def max_primary_key(self, primary_key):
+        if primary_key not in self.data.columns:
+            return None
+
+        return max(self.data[primary_key])
+
+    @property
+    def num_rows(self):
+        return self.data.num_rows
+
+    @property
+    def exists(self):
+        return self.data is not None
+
+    def get_rows(self, offset=0, chunk_size=None, order_by=None):
+        data = self.data.cut(*self.data.columns)
+
+        if order_by:
+            data.sort(order_by)
+
+        return Table(data[offset:chunk_size + offset])
+
+    def get_new_rows_count(self, primary_key_col, start_value=None):
+        data = self.data.select_rows(lambda row: row[primary_key_col] > start_value)
+        return data.num_rows
+
+    def get_new_rows(self, primary_key, cutoff_value, offset=0, chunk_size=None):
+        data = self.data.select_rows(lambda row: row[primary_key] > cutoff_value)
+        data.sort(primary_key)
+
+        return Table(data[offset:chunk_size + offset])

--- a/test/test_databases/test_mysql.py
+++ b/test/test_databases/test_mysql.py
@@ -164,7 +164,7 @@ class TestMySQL(unittest.TestCase):  # noqa
     def test_evaluate_table(self):
 
         table_map = [{'name': 'ID', 'type': 'smallint', 'width': 0},
-                     {'name': 'Name', 'type': 'varchar', 'width': 10},
+                     {'name': 'Name', 'type': 'varchar', 'width': 8},
                      {'name': 'Score', 'type': 'float', 'width': 0}]
         self.assertEqual(self.mysql.evaluate_table(self.tbl), table_map)
 

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -58,8 +58,8 @@ class TestRedshift(unittest.TestCase):
 
     def test_data_type(self):
 
-        # Test smallint
-        self.assertEqual(self.rs.data_type(1, ''), 'smallint')
+        # Test int
+        self.assertEqual(self.rs.data_type(1, ''), 'int')
         # Test int
         self.assertEqual(self.rs.data_type(32769, ''), 'int')
         # Test bigint
@@ -80,11 +80,11 @@ class TestRedshift(unittest.TestCase):
         # Test correct header labels
         self.assertEqual(self.mapping['headers'], ['ID', 'Name'])
         # Test correct data types
-        self.assertEqual(self.mapping['type_list'], ['smallint', 'varchar'])
+        self.assertEqual(self.mapping['type_list'], ['int', 'varchar'])
 
         self.assertEqual(
             self.mapping2['type_list'],
-            ['varchar', 'varchar', 'decimal', 'varchar', "decimal", "smallint", "varchar"])
+            ['varchar', 'varchar', 'decimal', 'varchar', "decimal", "int", "varchar"])
         # Test correct lengths
         self.assertEqual(self.mapping['longest'], [1, 5])
 
@@ -112,7 +112,7 @@ class TestRedshift(unittest.TestCase):
 
         # Test the the statement is expected
         sql = self.rs.create_sql('tmc.test', self.mapping, distkey='ID')
-        exp_sql = "create table tmc.test (\n  id smallint,\n  name varchar(5)) \ndistkey(ID) ;"
+        exp_sql = "create table tmc.test (\n  id int,\n  name varchar(5)) \ndistkey(ID) ;"
         self.assertEqual(sql, exp_sql)
 
     def test_column_validate(self):
@@ -128,7 +128,7 @@ class TestRedshift(unittest.TestCase):
 
         # Assert that copy statement is expected
         sql = self.rs.create_statement(self.tbl, 'tmc.test', distkey='ID')
-        exp_sql = """create table tmc.test (\n  "id" smallint,\n  "name" varchar(5)) \ndistkey(ID) ;"""  # noqa: E501
+        exp_sql = """create table tmc.test (\n  "id" int,\n  "name" varchar(5)) \ndistkey(ID) ;"""  # noqa: E501
         self.assertEqual(sql, exp_sql)
 
         # Assert that an error is raised by an empty table
@@ -219,7 +219,7 @@ class TestRedshiftDB(unittest.TestCase):
                     """
 
         other_sql = f"""
-                    create table {self.temp_schema}.test (id smallint,name varchar(5));
+                    create table {self.temp_schema}.test (id int,name varchar(5));
                     create view {self.temp_schema}.test_view as (
                         select * from {self.temp_schema}.test
                     );
@@ -606,11 +606,11 @@ class TestRedshiftDB(unittest.TestCase):
     def test_get_columns(self):
         cols = self.rs.get_columns(self.temp_schema, 'test')
 
-        # id smallint,name varchar(5)
+        # id int,name varchar(5)
         expected_cols = {
             'id':   {
-                'data_type': 'smallint', 'max_length': None,
-                'max_precision': 16, 'max_scale': 0, 'is_nullable': True},
+                'data_type': 'int', 'max_length': None,
+                'max_precision': 32, 'max_scale': 0, 'is_nullable': True},
             'name': {
                 'data_type': 'character varying', 'max_length': 5,
                 'max_precision': None, 'max_scale': None, 'is_nullable': True},


### PR DESCRIPTION
This commit makes a few fixes to the Parsons DBSync class
to improve the performance and stability of the functionality.

 * Add a `retries` argument to the `DBSync` class to configure
 the number of times the sync will retry reading / writing data
 if there is a failure. This should make the sync process less
 brittle.
 * Add `read_chunk_size` and `write_chunk_size` arguments to
 the `DBSync` class to allow users to configure how much data is
 downloading from the source DB or written to the destination DB
 at a time.
 * Added a `strict_length` argument to the Redshift `copy_s3` and
 all DB `copy` functions that allows users to opt out or into of new
 functionality when creating tables to use a step function when
 determining what length to specify on a `varchar` column.

---
This is one of those "went to do 1 or 2 things and ended up doing 5" kind of Pull Requests. I'm happy to rework or break up if it seems useful. I tested the DB sync script against Postgres to Postgres, Postgres to Redshift, and Redshift to Postgres.