### PR TITLE
Removing MySQLTable class so as not to override BaseTable query methods

### DIFF
--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -308,45 +308,6 @@ class MySQL(MySQLCreateTable):
             return False
 
     def table(self, table_name):
-        # Return a MySQL table object
+        # Return a BaseTable table object
 
-        return MySQLTable(self, table_name)
-
-
-class MySQLTable(BaseTable):
-    # MySQL table object.
-
-    def get_rows(self, offset=0, chunk_size=None):
-        """
-        Get rows from a table.
-        """
-
-        sql = f"SELECT * FROM {self.table}"
-
-        if chunk_size:
-            sql += f" LIMIT {chunk_size}"
-
-        if offset:
-            sql += f" ,{offset}"
-
-        return self.db.query(sql)
-
-    def get_new_rows(self, primary_key, cutoff_value, offset=0, chunk_size=None):
-        """
-        Get rows that have a greater primary key value than the one
-        provided.
-
-        It will select every value greater than the provided value.
-        """
-
-        sql = f"""
-               SELECT
-               *
-               FROM {self.table}
-               WHERE {primary_key} > {cutoff_value}
-               """
-
-        if chunk_size:
-            sql += f" LIMIT {chunk_size}, {offset};"
-
-        return self.db.query(sql)
+        return BaseTable(self, table_name)

--- a/test/test_databases/test_mysql.py
+++ b/test/test_databases/test_mysql.py
@@ -1,4 +1,4 @@
-from parsons.databases.mysql.mysql import MySQL, MySQLTable
+from parsons.databases.mysql.mysql import MySQL
 from parsons.etl.table import Table
 from test.utils import assert_matching_tables
 import unittest
@@ -63,7 +63,7 @@ class TestMySQL(unittest.TestCase):
                                 ('you', 'hey', '3')
                          """)
 
-        self.tbl = MySQLTable(self.mysql, 'test')
+        self.tbl = BaseTable(self.mysql, 'test')
 
     def tearDown(self):
 
@@ -90,7 +90,7 @@ class TestMySQL(unittest.TestCase):
 
         self.assertTrue(self.tbl.exists)
 
-        tbl_bad = MySQLTable(self.mysql, 'bad_test')
+        tbl_bad = BaseTable(self.mysql, 'bad_test')
         self.assertFalse(tbl_bad.exists)
 
     def test_drop(self):

--- a/test/test_databases/test_mysql.py
+++ b/test/test_databases/test_mysql.py
@@ -1,4 +1,5 @@
 from parsons.databases.mysql.mysql import MySQL
+from parsons.databases.table import BaseTable
 from parsons.etl.table import Table
 from test.utils import assert_matching_tables
 import unittest


### PR DESCRIPTION
I discovered that the actual cause of the strange powers of 2 problem when using DBSync to do a full refresh from a MySQL table with (significantly) more rows than the chunk size was that the LIMIT clause in the `MySQLTable()` class's override of the `get_rows()` method was configured incorrectly, such that OFFSET and LIMIT were switched. The default SQL provided by the `BaseTable()` class, however, would actually work properly in MySQL.

Considering that the only purpose of the `MySQLTable()` class appeared to be to override that method as well as `get_new_rows()`, and that issue #453 makes the same observation about _that_ method, it seemed simplest to remove the `MySQLTable()` class entirely, and default to the `BaseTable()` class, instead.