### PR TITLE
dbsync: improve performance

### DIFF
--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -112,5 +112,7 @@ logger.addHandler(_handler)
 if os.environ.get('TESTING'):
     # Log less stuff in automated tests
     logger.setLevel('WARNING')
+elif os.environ.get('DEBUG'):
+    logger.setLevel('DEBUG')
 else:
     logger.setLevel('INFO')

--- a/parsons/databases/mysql/create_table.py
+++ b/parsons/databases/mysql/create_table.py
@@ -96,9 +96,9 @@ class MySQLCreateTable(DatabaseCreateStatement):
     @staticmethod
     def round_longest(longest):
         # Find the value that will work best to fit our longest column value
-        for step in MySQLCreateTable.VARCHAR_STEPS:
+        for step in consts.VARCHAR_STEPS:
             # Make sure we have padding
             if longest < step / 2:
                 return step
 
-        return MySQLCreateTable.VARCHAR_MAX
+        return consts.VARCHAR_MAX

--- a/parsons/databases/postgres/postgres_create_statement.py
+++ b/parsons/databases/postgres/postgres_create_statement.py
@@ -192,9 +192,9 @@ class PostgresCreateStatement(DatabaseCreateStatement):
     @staticmethod
     def round_longest(longest):
         # Find the value that will work best to fit our longest column value
-        for step in PostgresCreateStatement.VARCHAR_STEPS:
+        for step in consts.VARCHAR_STEPS:
             # Make sure we have padding
             if longest < step / 2:
                 return step
 
-        return PostgresCreateStatement.VARCHAR_MAX
+        return consts.VARCHAR_MAX


### PR DESCRIPTION
This commit improves performance of the `DBSync` class by making
distinct checks and row counts optional. The commit is meant to
allow users to opt out of these features to workaround issues
seen with really big tables.

This commit also fixes a bug from a previous commit where an
invalid class attribute was being accessed. The value is now
pulled in via a constant in another module.