### PR TITLE
New Upload Saved List Method for VAN

### DIFF
--- a/parsons/ngpvan/saved_lists.py
+++ b/parsons/ngpvan/saved_lists.py
@@ -67,7 +67,7 @@ class SavedLists(object):
         else:
             return Table.from_csv(job['downloadUrl'])
 
-    def upload_saved_list_rest(self, tbl, url_type, folder_id, list_name,
+    def upload_saved_list_rest(self, tbl, folder_id, list_name,
                                description, callback_url, columns, id_column,
                                delimiter='csv', header=True, quotes=True,
                                overwrite=None, **url_kwargs):
@@ -216,7 +216,7 @@ class SavedLists(object):
         # i think we dont need this if we have the warning in the funciton description,
         # perhapse a style/standanrds decision
         if id_type == 'vanid':
-            logger.warn('The NVPVAN SOAP API is deprecated, consider using '
+            logger.warning('The NVPVAN SOAP API is deprecated, consider using '
                         'parsons.VAN.upload_saved_list_rest if you are '
                         'uploading a list of vanids.')
         # Create XML

--- a/parsons/ngpvan/saved_lists.py
+++ b/parsons/ngpvan/saved_lists.py
@@ -67,7 +67,7 @@ class SavedLists(object):
         else:
             return Table.from_csv(job['downloadUrl'])
 
-    def upload_saved_list_rest(self, tbl, folder_id, list_name,
+    def upload_saved_list_rest(self, tbl, url_type, folder_id, list_name,
                                description, callback_url, columns, id_column,
                                delimiter='csv', header=True, quotes=True,
                                overwrite=None, **url_kwargs):
@@ -217,8 +217,8 @@ class SavedLists(object):
         # perhapse a style/standanrds decision
         if id_type == 'vanid':
             logger.warning('The NVPVAN SOAP API is deprecated, consider using '
-                        'parsons.VAN.upload_saved_list_rest if you are '
-                        'uploading a list of vanids.')
+                           'parsons.VAN.upload_saved_list_rest if you are '
+                           'uploading a list of vanids.')
         # Create XML
         xml = self.connection.soap_client.factory.create('CreateAndStoreSavedListMetaData')
         xml.SavedList._Name = list_name

--- a/parsons/ngpvan/saved_lists.py
+++ b/parsons/ngpvan/saved_lists.py
@@ -87,7 +87,8 @@ class SavedLists(object):
             description: str
                 Description of the file upload job and the list.
             callback_url: string
-                The configured HTTP listener to which successful list loads will send a standard webhook.
+                The configured HTTP listener to which successful list loads will send
+                a standard webhook.
             columns: list
                 A list of column names contained in the file.
             id_column : str
@@ -96,9 +97,10 @@ class SavedLists(object):
                 The file delimiter used.
             header: boolean
                 Whether or not the source file has a header row.
-            quptes: boolean
-                 Whether or not fields are enclosed in quotation marks within each column of the file.
-            replace: boolean
+            quotes: boolean
+                 Whether or not fields are enclosed in quotation marks within each
+                 column of the file.
+            overwrite: boolean
                 Replace saved list if already exists.
             **url_kwargs: kwargs
                 Arguments to configure your cloud storage url type.
@@ -119,10 +121,10 @@ class SavedLists(object):
         if folder_id not in [x['folderId'] for x in self.get_folders()]:
             raise ValueError("Folder does not exist or is not shared with API user.")
 
-        if not replace:
+        if not overwrite:
             if list_name in [x['name'] for x in self.get_saved_lists(folder_id)]:
-                raise ValueError("Saved list already exists. Set to overwriteExistingListId argument to True or "
-                                 "change list name.")
+                raise ValueError("Saved list already exists. Set overwrite "
+                                 "argument to True or change list name.")
 
                 # To Do: Validate that it is a .zip file. Not entirely sure if this is possible
                 # as some urls might not end in ".zip".
@@ -153,14 +155,12 @@ class SavedLists(object):
                      "value": callback_url}]
                 }
 
-
         r = self.connection.post_request('fileLoadingJobs', json=json)
         job_id = r['jobId']
         logger.info(f'Score loading job {job_id} created.')
         r = self.connection.get_request(callback_url)
         logger.info(f'INSERT REAL response from Callback response.')
         return r
-
 
     def upload_saved_list(self, tbl, list_name, folder_id, url_type, id_type='vanid', replace=False,
                           **url_kwargs):
@@ -213,8 +213,9 @@ class SavedLists(object):
         # i think we dont need this if we have the warning in the funciton description,
         # perhapse a style/standanrds decision
         if id_type == 'vanid':
-            logger.warn('The NVPVAN SOAP API is deprecated, consider using parsons.VAN.upload_saved_list_rest '
-                         ' if you are uploading a list of vanids')
+            logger.warn('The NVPVAN SOAP API is deprecated, consider using '
+                        'parsons.VAN.upload_saved_list_rest if you are '
+                        'uploading a list of vanids.')
         # Create XML
         xml = self.connection.soap_client.factory.create('CreateAndStoreSavedListMetaData')
         xml.SavedList._Name = list_name
@@ -243,6 +244,7 @@ class SavedLists(object):
         if r:
             logger.info(f"Uploaded {r['ListSize']} records to {r['_Name']} saved list.")
         return r
+
 
 class Folders(object):
 

--- a/parsons/ngpvan/saved_lists.py
+++ b/parsons/ngpvan/saved_lists.py
@@ -161,7 +161,7 @@ class SavedLists(object):
         file_load_job_response = self.connection.post_request('fileLoadingJobs', json=json)
         job_id = file_load_job_response['jobId']
         logger.info(f'Score loading job {job_id} created. Reference '
-                     'callback url to check for job status')
+                    'callback url to check for job status')
         return file_load_job_response
 
     def upload_saved_list(self, tbl, list_name, folder_id, url_type, id_type='vanid', replace=False,

--- a/parsons/ngpvan/saved_lists.py
+++ b/parsons/ngpvan/saved_lists.py
@@ -114,7 +114,7 @@ class SavedLists(object):
         rando = str(uuid.uuid1())
         file_name = rando + '.csv'
         url = cloud_storage.post_file(tbl, url_type, file_path=rando + '.zip', **url_kwargs)
-        url_for_van = url.split('?')[0]  # hack around https://github.com/move-coop/parsons/issues/513
+        url_for_van = url.split('?')[0]  # hack around github.com/move-coop/parsons/issues/513
         logger.info(f'Table uploaded to {url_type}.')
 
         # VAN errors for this method are not particularly useful or helpful. For that reason, we
@@ -159,7 +159,7 @@ class SavedLists(object):
 
         logger.info(json)
         file_load_job_response = self.connection.post_request('fileLoadingJobs', json=json)
-        job_id = r['jobId']
+        job_id = file_load_job_response['jobId']
         logger.info(f'Score loading job {job_id} created.')
         callback_response = self.connection.get_request(callback_url)
         logger.info(callback_response)

--- a/parsons/ngpvan/saved_lists.py
+++ b/parsons/ngpvan/saved_lists.py
@@ -114,7 +114,7 @@ class SavedLists(object):
         rando = str(uuid.uuid1())
         file_name = rando + '.csv'
         url = cloud_storage.post_file(tbl, url_type, file_path=rando + '.zip', **url_kwargs)
-        url_for_van = url.split('?')[0] #hack around https://github.com/move-coop/parsons/issues/513
+        url_for_van = url.split('?')[0]  # hack around https://github.com/move-coop/parsons/issues/513
         logger.info(f'Table uploaded to {url_type}.')
 
         # VAN errors for this method are not particularly useful or helpful. For that reason, we
@@ -154,7 +154,6 @@ class SavedLists(object):
                      "value": callback_url}]
                 }
 
-        logger.info(json) # remove from real commit
         if overwrite:
             json["actions"][0]["overwriteExistingListId"] = overwrite
 
@@ -162,8 +161,8 @@ class SavedLists(object):
         file_load_job_response = self.connection.post_request('fileLoadingJobs', json=json)
         job_id = r['jobId']
         logger.info(f'Score loading job {job_id} created.')
-        r = self.connection.get_request(callback_url)
-        logger.info(r)
+        callback_response = self.connection.get_request(callback_url)
+        logger.info(callback_response)
         return file_load_job_response
 
     def upload_saved_list(self, tbl, list_name, folder_id, url_type, id_type='vanid', replace=False,

--- a/parsons/ngpvan/saved_lists.py
+++ b/parsons/ngpvan/saved_lists.py
@@ -160,9 +160,8 @@ class SavedLists(object):
         logger.info(json)
         file_load_job_response = self.connection.post_request('fileLoadingJobs', json=json)
         job_id = file_load_job_response['jobId']
-        logger.info(f'Score loading job {job_id} created.')
-        callback_response = self.connection.get_request(callback_url)
-        logger.info(callback_response)
+        logger.info(f'Score loading job {job_id} created. Reference '
+                     'callback url to check for job status')
         return file_load_job_response
 
     def upload_saved_list(self, tbl, list_name, folder_id, url_type, id_type='vanid', replace=False,

--- a/parsons/ngpvan/saved_lists.py
+++ b/parsons/ngpvan/saved_lists.py
@@ -213,7 +213,7 @@ class SavedLists(object):
         # i think we dont need this if we have the warning in the funciton description,
         # perhapse a style/standanrds decision
         if id_type == 'vanid':
-            logger.warn('The NVPVAN SOAP API is deprecated, consider using method=\'rest\''
+            logger.warn('The NVPVAN SOAP API is deprecated, consider using parsons.VAN.upload_saved_list_rest '
                          ' if you are uploading a list of vanids')
         # Create XML
         xml = self.connection.soap_client.factory.create('CreateAndStoreSavedListMetaData')

--- a/test/test_van/test_saved_lists.py
+++ b/test/test_van/test_saved_lists.py
@@ -68,6 +68,25 @@ class TestSavedLists(unittest.TestCase):
             tbl, 'GOTV List', 1, replace=True, url_type='S3', bucket='tmc-scratch')
         assert self.van.connection._soap_client.service.CreateAndStoreSavedList.called
 
+        @requests_mock.Mocker()
+        def test_upload_saved_list_rest(self):
+
+            cloud_storage.post_file = mock.MagicMock()
+            cloud_storage.post_file.return_value = 'https://box.com/my_file.zip'
+            self.van.get_folders = mock.MagicMock()
+            self.van.get_folders.return_value = [{'folderId': 1}]
+
+            tbl = Table([['VANID'], ['1'], ['2'], ['3']])
+            response = self.van.upload_saved_list_rest(
+                tbl=tbl, url_type="S3",
+                folder_id=1, list_name="GOTV List", description="parsons test list",
+                callback_url="https://webhook.site/69ab58c3-a3a7-4ed8-828c-1ea850cb4160",
+                columns=["VANID"], id_column="VANID",
+                bucket="tmc-scratch,
+                overwrite=517612
+                )
+            self.assertIn("jobId", response)
+                        
     @requests_mock.Mocker()
     def test_get_folders(self, m):
 

--- a/test/test_van/test_saved_lists.py
+++ b/test/test_van/test_saved_lists.py
@@ -82,11 +82,11 @@ class TestSavedLists(unittest.TestCase):
                 folder_id=1, list_name="GOTV List", description="parsons test list",
                 callback_url="https://webhook.site/69ab58c3-a3a7-4ed8-828c-1ea850cb4160",
                 columns=["VANID"], id_column="VANID",
-                bucket="tmc-scratch,
+                bucket="tmc-scratch",
                 overwrite=517612
                 )
             self.assertIn("jobId", response)
-                        
+
     @requests_mock.Mocker()
     def test_get_folders(self, m):
 


### PR DESCRIPTION
**Summary**
The SOAP endpoint used in [parsons.VAN.upload_saved_list()](https://github.com/move-coop/parsons/blob/a49dba54053b35bddf4f3d9f7881f5ece8f82cf4/parsons/ngpvan/saved_lists.py#L70) is using a deprecated endpoint. The new v4 endpoint has additional required arguments, only works with uploads based on VAN ID, and supports multiple column uploads. This PR Introduces:
- A new upload_saved_list_rest() method that supports VAN ID uploads with more than one column. 
- Adds a deprecation warning on the old method.

**Deprecation Plan**
- Create a Github issue for the future. When NGPVAN allows external ids, route all calls through the correct endpoint, flag upload_saved_list as deprecated with deprecation warning.
- After deprecation period - remove the function entirely or just continue to have it route to the correct endpoint, with validation on the new required arguments of the rest endpoint (callback url, for example)

**Other Potential Features Discovered During Development**
- Support the other listener types on all jobs that hit the /fileLoadingJobs endpoint? https://developers.ngpvan.com/van-api#file-loading-jobs
- Support other file upload methods than S3?
- Check if files are zipped prior to uploading to cloud storage If not, Zip em ourselves? If so, just go ahead and upload.
