### PR TITLE
Temporarily roll back JSON loading changes

### DIFF
--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -644,7 +644,19 @@ class ToFrom(object):
             Parsons Table
                 See :ref:`parsons-table` for output options.
         """
-        return cls(petl.fromjson(local_path, header=header, lines=line_delimited))
+        
+        if line_delimited:
+            if files.is_gzip_path(local_path):
+                open_fn = gzip.open
+            else:
+                open_fn = open
+
+            with open_fn(local_path, 'r') as file:
+                rows = [json.loads(line) for line in file]
+            return cls(rows)
+
+        else:
+            return cls(petl.fromjson(local_path, header=header))
 
     @classmethod
     def from_redshift(cls, sql, username=None, password=None, host=None,

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -644,7 +644,7 @@ class ToFrom(object):
             Parsons Table
                 See :ref:`parsons-table` for output options.
         """
-        
+
         if line_delimited:
             if files.is_gzip_path(local_path):
                 open_fn = gzip.open


### PR DESCRIPTION
We merged #488 yesterday with the intent of reducing memory use when loading multi-line JSON files, but something isn't being handled as expected and is causing errors in certain TMC jobs. It seems we have an edge case not caught by testing, so this PR will roll back the changes of #488 in order to stabilize things while we investigate the issue.