### PR TITLE
Google Sheets: Add optional folder_id to create_spreadsheet

### DIFF
--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -165,23 +165,25 @@ class GoogleSheets:
         logger.info(f'Retrieved permissions for {spreadsheet_id} spreadsheet.')
         return tbl
 
-    def create_spreadsheet(self, title, editor_email=None):
+    def create_spreadsheet(self, title, editor_email=None, folder_id=None):
         """
         Create a Google spreadsheet from a Parsons table. Optionally shares the new doc with
-        the given email address.
+        the given email address. Optionally creates the sheet in a specified folder.
 
         `Args:`
             title: str
                 The human-readable title of the new spreadsheet
             editor_email: str (optional)
                 Email address which should be given permissions on this spreadsheet
+            folder_id: str (optional)
+                ID of the Google folder where the spreadsheet should be created. Tip: Get this from the folder URL. Anyone shared on the folder will have access to the spreadsheet.
 
         `Returns:`
             str
                 The spreadsheet ID
         """
 
-        spreadsheet = self.gspread_client.create(title)
+        spreadsheet = self.gspread_client.create(title, folder_id=folder_id)
 
         if editor_email:
             self.gspread_client.insert_permission(

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -176,7 +176,8 @@ class GoogleSheets:
             editor_email: str (optional)
                 Email address which should be given permissions on this spreadsheet
             folder_id: str (optional)
-                ID of the Google folder where the spreadsheet should be created. Tip: Get this from the folder URL.
+                ID of the Google folder where the spreadsheet should be created.
+                Tip: Get this from the folder URL.
                 Anyone shared on the folder will have access to the spreadsheet.
 
         `Returns:`

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -176,7 +176,8 @@ class GoogleSheets:
             editor_email: str (optional)
                 Email address which should be given permissions on this spreadsheet
             folder_id: str (optional)
-                ID of the Google folder where the spreadsheet should be created. Tip: Get this from the folder URL. Anyone shared on the folder will have access to the spreadsheet.
+                ID of the Google folder where the spreadsheet should be created. Tip: Get this from the folder URL.
+                Anyone shared on the folder will have access to the spreadsheet.
 
         `Returns:`
             str


### PR DESCRIPTION
Added optional parameter of folder_id to the create_spreadsheet() method in the Google Sheets class.

Addresses issue #509 