### PR TITLE
Update Parsons version number to match release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def main():
 
     setup(
         name="parsons",
-        version='0.16.0',
+        version='0.17.0',
         author="The Movement Cooperative",
         author_email="info@movementcooperative.org",
         url='https://github.com/movementcoop/parsons',


### PR DESCRIPTION
Just a small fix in `setup.py`, updating the version number to match yesterday's new Parsons release.