### PR TITLE
add typecast param to insert_record

### DIFF
--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -128,7 +128,7 @@ class Airtable(object):
         logger.info('Record inserted')
         return resp
 
-    def insert_records(self, table, typecast = False):
+    def insert_records(self, table, typecast=False):
         """
         Insert multiple records into an Airtable. The columns in your Parsons table must
         exist in the Airtable. The method will attempt to map based on column name, so the

--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -128,7 +128,7 @@ class Airtable(object):
         logger.info('Record inserted')
         return resp
 
-    def insert_records(self, table):
+    def insert_records(self, table, typecast = False):
         """
         Insert multiple records into an Airtable. The columns in your Parsons table must
         exist in the Airtable. The method will attempt to map based on column name, so the
@@ -143,7 +143,7 @@ class Airtable(object):
             List of dictionaries of inserted rows
         """
 
-        resp = self.client.batch_insert(table)
+        resp = self.client.batch_insert(table, typecast=typecast)
         logger.info(f'{table.num_rows} records inserted.')
         return resp
 


### PR DESCRIPTION
Issue: [#539: Optionally Allow Modification of Allowable Multiple Choice Options in Insert Functions](https://github.com/move-coop/parsons/issues/539)

This fix adds a typecast param to the Airtable insert_records function