### PR TITLE
Add GCS as option for Cloud Storage Utility.

### DIFF
--- a/docs/ngpvan.rst
+++ b/docs/ngpvan.rst
@@ -72,9 +72,9 @@ Bulk Import
 ===========
 For some methods, VAN allows you to bulk import multiple records to create or modify them. 
 
-The bulk upload endpoint, requires access to file on the public internet as it runs the upload
-asynchronously. Therefore, in order to bulk import, you must pass in cloud storage credentials
-so that the file can be posted. Currently, only S3 is supported.
+The bulk upload endpoint requires access to file on the public internet as it runs the upload
+asynchronously. Therefore, in order to bulk import, you must pass in cloud storage credentials,
+either AWS S3 or Google Cloud Storage, so that the file can be posted.
 
 **Bulk Apply Activist Codes**
 
@@ -82,7 +82,7 @@ so that the file can be posted. Currently, only S3 is supported.
 
    from parsons import VAN, Table
 
-   van = VAN(db=EveryAction)
+   van = VAN(db='EveryAction')
 
    # Load a table containing the VANID, activistcodeid and other options.
    tbl = Table.from_csv('new_volunteers.csv')
@@ -94,6 +94,33 @@ so that the file can be posted. Currently, only S3 is supported.
 
    # The bulk import job is run asynchronously, so you may poll the status of a job.
    job_status = van.get_bulk_import_job(job_id)
+
+**Upload Saved List**
+
+.. code-block:: python
+
+   from parsons import VAN, Table
+
+   van = VAN(db='MyVoters')
+
+   # Load a table containing VANIDs
+   tbl = Table.from_csv('gcs_test.csv')
+
+   # The destination folder id. You can get a list of folder ids by running the
+   # VAN.get_folders() method. Remember to share the folder with your API user
+   # or you will not be able to access it.
+   folder_id = 1171
+
+   # The destination list name
+   list_name = 'My Winning List v1.0'
+
+   # The cloud storage service and kwargs specific to GCS. 
+   url_type = 'GCS'
+   bucket_name = 'my_bucket'
+   app_creds = 'my_creds.json' # Not required if stored as env variable.
+
+   van.upload_saved_list(tbl, list_name, folder_id, url_type, replace=true, 
+                         bucket_name=bucket_name, app_creds=app_creds)
 
 ============================
 Scores: Loading and Updating

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -7,22 +7,26 @@ Utilities
 Cloud Storage
 =============
 The Parsons cloud storage utility was created to interact with APIs that require access to files
-to run an asynchronous process. While this utility currently only works with ``S3``, the goal
-is add functionality for additional cloud storage services in the future.
+to run an asynchronous process. 
 
 The cloud storage utility is currently being utilitized primarily by the NGPVAN class
-methods such as :func:`~parsons.ngpvan.van.Scores.upload_scores` and Bulk Import methods.
+methods such as :func:`~parsons.ngpvan.van.Scores.upload_scores` and 
+:func:`~parsons.ngpvan.van.SavedLists.upload_saved_list`.
 
 These methods have arguments specific their method, but all also contain the following cloud 
 storage arguments:
 
-* ``url_type`` - The type of cloud storage to utilize. Currently only ``S3``.
+* ``url_type`` - The type of cloud storage to utilize. Currently ``S3`` or ``GCS``.
 
-* ``**url_kwargs`` - These are arguments specific to the cloud storage type in order to initialize.
+* ``**url_kwargs`` - These are arguments specific to the cloud storage type in order to initialize. They
+  are listed below based on the url type.
 
-**S3**
+The file will then be converted to a CSV, compressed and posted to the cloud storage. A presigned url will
+be generated and active by default for 60 minutes, but you can adjust the time.
 
-When you select the ``url_type`` S3, the Parsons table will be converted to a csv and compressed. The file will be posted to an S3 bucket. A presigned public url will be generated and returned. The url will be active by default for 60 minutes, however you may adjust that time.
+**Amazon S3**
+
+Below are the required and optional arguments utilizing Amazon S3 as the cloud storage service:
 
 .. list-table::
     :widths: 25 25 100
@@ -44,4 +48,24 @@ When you select the ``url_type`` S3, the Parsons table will be converted to a cs
       - No
       - Defaults is 60 minutes.
 
+**Google Cloud Storage**
+
+Below are the required and optional arguments utilizing Google Cloud Storage as the cloud storage service:
+
+.. list-table::
+    :widths: 25 25 100
+    :header-rows: 1
+
+    * - Argument
+      - Required
+      - Description
+    * - ``bucket``
+      - Yes
+      - The S3 bucket to post the file
+    * - ``app_creds``
+      - No
+      - Required if ``GOOGLE_APPLICATION_CREDENTIALS`` env variable not set.
+    * - ``public_url_expire``
+      - No
+      - Defaults is 60 minutes.
 

--- a/parsons/ngpvan/bulk_import.py
+++ b/parsons/ngpvan/bulk_import.py
@@ -137,11 +137,11 @@ class BulkImport(object):
             table: Parsons table
                 A Parsons table.
             url_type: str
-                The cloud file storage to use to post the file. Currently only ``S3``.
+                The cloud file storage to use to post the file (``S3`` or ``GCS``).
+                See :ref:`Cloud Storage <cloud-storage>` for more details.
             **url_kwargs: kwargs
-                Arguments to configure your cloud storage url type.
-                    * S3 requires ``bucket`` argument and, if not stored as env variables
-                      ``aws_access_key`` and ``aws_secret_access_key``.
+                Arguments to configure your cloud storage url type. See
+                :ref:`Cloud Storage <cloud-storage>` for more details.
         `Returns:`
             int
                 The bulk import job id

--- a/parsons/ngpvan/saved_lists.py
+++ b/parsons/ngpvan/saved_lists.py
@@ -79,7 +79,8 @@ class SavedLists(object):
             tbl: parsons.Table
                 A parsons table object containing one column of person ids.
             url_type: str
-                The cloud file storage to use to post the file. Currently only ``S3``.
+                The cloud file storage to use to post the file (``S3`` or ``GCS``).
+                See :ref:`Cloud Storage <cloud-storage>` for more details.
             folder_id: int
                 The folder id where the list will be stored.
             list_name: str
@@ -103,9 +104,8 @@ class SavedLists(object):
             overwrite: int
                 Replace saved list if already exists.
             **url_kwargs: kwargs
-                Arguments to configure your cloud storage url type.
-                    * S3 requires ``bucket`` argument and, if not stored as env variables
-                      ``aws_access_key`` and ``aws_secret_access_key``.
+                Arguments to configure your cloud storage url type. See
+                :ref:`Cloud Storage <cloud-storage>` for more details.
         `Returns:`
             dict
                 Upload results information included the number of matched and saved
@@ -181,16 +181,16 @@ class SavedLists(object):
             folder_id: int
                 The folder id where the list will be stored.
             url_type: str
-                The cloud file storage to use to post the file. Currently only ``S3``.
+                The cloud file storage to use to post the file (``S3`` or ``GCS``).
+                See :ref:`Cloud Storage <cloud-storage>` for more details.
             id_type: str
                 The primary key type. The options, beyond ``vanid`` are specific to your
                 instance of VAN.
             replace: boolean
                 Replace saved list if already exists.
             **url_kwargs: kwargs
-                Arguments to configure your cloud storage url type.
-                    * S3 requires ``bucket`` argument and, if not stored as env variables
-                      ``aws_access_key`` and ``aws_secret_access_key``.
+                Arguments to configure your cloud storage url type. See
+                :ref:`Cloud Storage <cloud-storage>` for more details.
         `Returns:`
             dict
                 Upload results information included the number of matched and saved

--- a/parsons/ngpvan/scores.py
+++ b/parsons/ngpvan/scores.py
@@ -148,7 +148,7 @@ class Scores(object):
                    {'score2_id' : int, score2_column': str}]
 
             url_type: str
-                The cloud file storage to use to post the file.
+                The cloud file storage to use to post the file (``S3`` or ``GCS``).
                 See :ref:`Cloud Storage <cloud-storage>` for more details.
             email: str
                 An email address to send job load status updates.

--- a/parsons/utilities/cloud_storage.py
+++ b/parsons/utilities/cloud_storage.py
@@ -3,8 +3,8 @@ import csv
 """
 This utility method is a generalizable method for moving files to an
 online file storage class. It is used by methods that require access
-to a file via a public url (e.g. VAN). Currently only includes S3, but
-in the future, might include SFTP, and Google Cloud Storage.
+to a file via a public url (e.g. VAN). Currently only includes Amazon S3 and
+Google Cloud Storage.
 """
 
 
@@ -20,7 +20,7 @@ def post_file(tbl, type, file_path=None, quoting=csv.QUOTE_MINIMAL, **file_stora
         tbl: object
             parsons.Table
         type: str
-            ``S3``
+            ``S3`` or ``GCS`` (Google Cloud Storage)
         file_path: str
             The file path to store the file. Not required if provided with
             the **file_storage_args.
@@ -32,7 +32,7 @@ def post_file(tbl, type, file_path=None, quoting=csv.QUOTE_MINIMAL, **file_stora
         ``None``
     """
 
-    if type.capitalize() == 'S3':
+    if type.upper() == 'S3':
 
         # Overwrite the file_path if key is passed
         if 'key' in file_storage_args:
@@ -40,7 +40,11 @@ def post_file(tbl, type, file_path=None, quoting=csv.QUOTE_MINIMAL, **file_stora
 
         return tbl.to_s3_csv(public_url=True, key=file_path, quoting=quoting, **file_storage_args)
 
-    # To Do: Add in SFTP, GoogleCloud Storage
+    elif type.upper() == 'GCS':
+
+        return tbl.to_gcs_csv(public_url=True, blob_name=file_path, quoting=quoting,
+                              **file_storage_args)
 
     else:
-        raise ValueError('Type must be S3.')
+
+        raise ValueError('Type must be S3 or GCS.')


### PR DESCRIPTION
This PR adds Google Cloud Storage as an option for the Cloud Storage Utility. Previously, you were only able to use S3 at the cloud storage service. This utility is leveraged by the VAN methods that require an asynchronous load from a publicly accessible source on the internet. 

These methods include `VAN.upload_saved_list()`, `VAN.upload_scores` and `VAN.apply_activist_codes`. Additionally, the documentation was cleaned up to reflect this new option.