### PR TITLE
Switch default handling of py floats as RS floats

### DIFF
--- a/parsons/databases/redshift/constants.py
+++ b/parsons/databases/redshift/constants.py
@@ -1,6 +1,6 @@
 COL_NAME_MAX_LEN = 120
 
-DECIMAL = 'decimal'
+DECIMAL = 'float'
 
 REPLACE_CHARS = {" ": ""}
 

--- a/parsons/databases/redshift/constants.py
+++ b/parsons/databases/redshift/constants.py
@@ -1,6 +1,6 @@
 COL_NAME_MAX_LEN = 120
 
-DECIMAL = 'float'
+FLOAT = 'float'
 
 REPLACE_CHARS = {" ": ""}
 

--- a/parsons/databases/redshift/rs_create_table.py
+++ b/parsons/databases/redshift/rs_create_table.py
@@ -20,7 +20,7 @@ class RedshiftCreateTable(DatabaseCreateStatement):
         self.MEDIUMINT = self.INT
 
         # Currently py floats are coded as Redshift decimals
-        self.FLOAT = consts.DECIMAL
+        self.FLOAT = consts.FLOAT
 
         self.VARCHAR_MAX = consts.VARCHAR_MAX
         self.VARCHAR_STEPS = consts.VARCHAR_STEPS

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -66,8 +66,8 @@ class TestRedshift(unittest.TestCase):
         self.assertEqual(self.rs.data_type(2147483648, ''), 'bigint')
         # Test varchar that looks like an int
         self.assertEqual(self.rs.data_type('00001', ''), 'varchar')
-        # Test a float as a decimal
-        self.assertEqual(self.rs.data_type(5.001, ''), 'decimal')
+        # Test a float as a float
+        self.assertEqual(self.rs.data_type(5.001, ''), 'float')
         # Test varchar
         self.assertEqual(self.rs.data_type('word', ''), 'varchar')
         # Test int with underscore
@@ -84,7 +84,7 @@ class TestRedshift(unittest.TestCase):
 
         self.assertEqual(
             self.mapping2['type_list'],
-            ['varchar', 'varchar', 'decimal', 'varchar', "decimal", "int", "varchar"])
+            ['varchar', 'varchar', 'float', 'varchar', "float", "int", "varchar"])
         # Test correct lengths
         self.assertEqual(self.mapping['longest'], [1, 5])
 


### PR DESCRIPTION
Definitely want a second pair of eyes to see if there are any terrible data implications to switching from `DECIMAL` as the default data type to `FLOAT`.