### PR TITLE
URGENT: fix van connector because of ngpvan api change

### DIFF
--- a/parsons/ngpvan/van_connector.py
+++ b/parsons/ngpvan/van_connector.py
@@ -73,7 +73,9 @@ class VANConnector(object):
         data = self.api.data_parse(r)
 
         # Paginate
-        while isinstance(r, dict) and len(r['items']) > 0:
+        while isinstance(r, dict) and self.api.next_page_check_url(r):
+            if endpoint == 'savedLists' and not r['items']:
+                break
             r = self.api.get_request(r[self.pagination_key], **kwargs)
             data.extend(self.api.data_parse(r))
 

--- a/parsons/ngpvan/van_connector.py
+++ b/parsons/ngpvan/van_connector.py
@@ -73,7 +73,7 @@ class VANConnector(object):
         data = self.api.data_parse(r)
 
         # Paginate
-        while isinstance(r, dict) and self.api.next_page_check_url(r):
+        while isinstance(r, dict) and len(r['items']) > 0:
             r = self.api.get_request(r[self.pagination_key], **kwargs)
             data.extend(self.api.data_parse(r))
 


### PR DESCRIPTION
The NGPVAN API just had a [change to get saved lists pagination](https://docs.ngpvan.com/changelog) which causes the `get_saved_lists()` function to keep paginating forever. This is a quick fix that should correct the issue, although I will admit I had to solve it pretty quickly this morning and there might be a more elegant way to do it/I haven't checked whether any other paginations are weird.