### PR TITLE
Added updated NGPVAN API documentation URLs to repo docs

### DIFF
--- a/docs/html/_modules/parsons/ngpvan/people.html
+++ b/docs/html/_modules/parsons/ngpvan/people.html
@@ -267,7 +267,7 @@
 
 <span class="sd">        .. note::</span>
 <span class="sd">            A full list of possible values for the json, and its structure can be found</span>
-<span class="sd">            `here &lt;https://developers.ngpvan.com/van-api#match-candidates&gt;`_.</span>
+<span class="sd">            `here &lt;https://docs.ngpvan.com/reference/people#common-models&gt;`_.</span>
 
 <span class="sd">        `Args:`</span>
 <span class="sd">            match_json: dict</span>
@@ -341,7 +341,7 @@
 
 <span class="sd">        .. note::</span>
 <span class="sd">            A full list of possible values for the json, and its structure can be found</span>
-<span class="sd">            `here &lt;https://developers.ngpvan.com/van-api#match-candidates&gt;`_.</span>
+<span class="sd">            `here &lt;https://docs.ngpvan.com/reference/people#common-models&gt;`_.</span>
 
 <span class="sd">        `Args:`</span>
 <span class="sd">            id: str</span>
@@ -424,7 +424,7 @@
 
 <span class="sd">        .. note::</span>
 <span class="sd">            A full list of possible values for the json, and its structure can be found</span>
-<span class="sd">            `here &lt;https://developers.ngpvan.com/van-api#match-candidates&gt;`_. `vanId` can</span>
+<span class="sd">            `here &lt;https://docs.ngpvan.com/reference/people#common-models&gt;`_. `vanId` can</span>
 <span class="sd">            be passed to ensure the correct record is updated.</span>
 
 <span class="sd">        .. warning::</span>
@@ -637,7 +637,7 @@
 <span class="sd">        Apply responses such as survey questions, activist codes, and volunteer actions</span>
 <span class="sd">        to a person record. This method allows you apply multiple responses (e.g. two survey</span>
 <span class="sd">        questions) at the same time. It is a low level method that requires that you</span>
-<span class="sd">        conform to the VAN API `response object format &lt;https://developers.ngpvan.com/van-api#people-post-people--vanid--canvassresponses&gt;`_.</span>
+<span class="sd">        conform to the VAN API `response object format &lt;https://docs.ngpvan.com/reference/people#peoplevanidcanvassresponses&gt;`_.</span>
 
 <span class="sd">        `Args:`</span>
 <span class="sd">            id: str</span>

--- a/docs/html/_sources/ngpvan.rst.txt
+++ b/docs/html/_sources/ngpvan.rst.txt
@@ -7,7 +7,7 @@ Overview
 ********
 
 The VAN module leverages the VAN API and generally follows the naming convention of their API endpoints. It
-is recommended that you reference their `API documentation <https://developers.ngpvan.com/van-api#van>`_ to
+is recommended that you reference their `API documentation <https://docs.ngpvan.com/reference/overview>`_ to
 additional details and information.
 
 .. note::

--- a/docs/html/_sources/van.rst.txt
+++ b/docs/html/_sources/van.rst.txt
@@ -7,7 +7,7 @@ Overview
 ********
 
 The VAN module leverages the VAN API and generally follows the naming convention of their API endpoints. It
-is recommended that you reference their `API documentation <https://developers.ngpvan.com/van-api#van>`_ to
+is recommended that you reference their `API documentation <https://docs.ngpvan.com/reference/overview>`_ to
 additional details and information.
 
 .. note::

--- a/docs/html/ngpvan.html
+++ b/docs/html/ngpvan.html
@@ -232,7 +232,7 @@
 <div class="section" id="overview">
 <h2>Overview<a class="headerlink" href="#overview" title="Permalink to this headline">¶</a></h2>
 <p>The VAN module leverages the VAN API and generally follows the naming convention of their API endpoints. It
-is recommended that you reference their <a class="reference external" href="https://developers.ngpvan.com/van-api#van">API documentation</a> to
+is recommended that you reference their <a class="reference external" href="https://docs.ngpvan.com/reference/overview">API documentation</a> to
 additional details and information.</p>
 <div class="admonition note">
 <p class="first admonition-title">Note</p>
@@ -516,7 +516,7 @@ a search.</p>
 <div class="admonition note">
 <p class="first admonition-title">Note</p>
 <p class="last">A full list of possible values for the json, and its structure can be found
-<a class="reference external" href="https://developers.ngpvan.com/van-api#match-candidates">here</a>.</p>
+<a class="reference external" href="https://docs.ngpvan.com/reference/people#common-models">here</a>.</p>
 </div>
 <dl class="docutils">
 <dt><cite>Args:</cite></dt>
@@ -581,7 +581,7 @@ main phone or ‘F’ for fax line. Defaults to home phone.</dd>
 <div class="admonition note">
 <p class="first admonition-title">Note</p>
 <p class="last">A full list of possible values for the json, and its structure can be found
-<a class="reference external" href="https://developers.ngpvan.com/van-api#match-candidates">here</a>.</p>
+<a class="reference external" href="https://docs.ngpvan.com/reference/people#common-models">here</a>.</p>
 </div>
 <dl class="docutils">
 <dt><cite>Args:</cite></dt>
@@ -662,7 +662,7 @@ main phone or ‘F’ for fax line. Defaults to home phone.</dd>
 <div class="admonition note">
 <p class="first admonition-title">Note</p>
 <p class="last">A full list of possible values for the json, and its structure can be found
-<a class="reference external" href="https://developers.ngpvan.com/van-api#match-candidates">here</a>. <cite>vanId</cite> can
+<a class="reference external" href="https://docs.ngpvan.com/reference/people#common-models">here</a>. <cite>vanId</cite> can
 be passed to ensure the correct record is updated.</p>
 </div>
 <div class="admonition warning">
@@ -776,7 +776,7 @@ can be found by using the <code class="xref py py-meth docutils literal notransl
 <dd><p>Apply responses such as survey questions, activist codes, and volunteer actions
 to a person record. This method allows you apply multiple responses (e.g. two survey
 questions) at the same time. It is a low level method that requires that you
-conform to the VAN API <a class="reference external" href="https://developers.ngpvan.com/van-api#people-post-people--vanid--canvassresponses">response object format</a>.</p>
+conform to the VAN API <a class="reference external" href="https://docs.ngpvan.com/reference/people#peoplevanidcanvassresponses">response object format</a>.</p>
 <dl class="docutils">
 <dt><cite>Args:</cite></dt>
 <dd><dl class="first docutils">

--- a/docs/html/van.html
+++ b/docs/html/van.html
@@ -188,7 +188,7 @@
 <div class="section" id="overview">
 <h2>Overview<a class="headerlink" href="#overview" title="Permalink to this headline">¶</a></h2>
 <p>The VAN module leverages the VAN API and generally follows the naming convention of their API endpoints. It
-is recommended that you reference their <a class="reference external" href="https://developers.ngpvan.com/van-api#van">API documentation</a> to
+is recommended that you reference their <a class="reference external" href="https://docs.ngpvan.com/reference/overview">API documentation</a> to
 additional details and information.</p>
 <div class="admonition note">
 <p class="first admonition-title">Note</p>

--- a/docs/ngpvan.rst
+++ b/docs/ngpvan.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 The VAN module leverages the VAN API and generally follows the naming convention of their API endpoints. It
-is recommended that you reference their `API documentation <https://developers.ngpvan.com/van-api#van>`_ to
+is recommended that you reference their `API documentation <https://docs.ngpvan.com/reference/overview>`_ for
 additional details and information.
 
 .. note::
@@ -33,7 +33,7 @@ additional details and information.
 QuickStart
 **********
 
-To call the VAN class you can either store the api key as an environmental variable VAN_API_KEY or pass it in as an argument..
+To call the VAN class you can either store the api key as an environmental variable VAN_API_KEY or pass it in as an argument.
 
 .. code-block:: python
 
@@ -72,9 +72,9 @@ Bulk Import
 ===========
 For some methods, VAN allows you to bulk import multiple records to create or modify them. 
 
-The bulk upload endpoint requires access to file on the public internet as it runs the upload
-asynchronously. Therefore, in order to bulk import, you must pass in cloud storage credentials,
-either AWS S3 or Google Cloud Storage, so that the file can be posted.
+The bulk upload endpoint requires access to files on the public internet as it runs the upload
+asynchronously. Therefore, in order to bulk import, you must pass in cloud storage credentials
+(either AWS S3 or Google Cloud Storage) so that the file can be posted.
 
 **Bulk Apply Activist Codes**
 

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -446,7 +446,7 @@ class People(object):
         Apply responses such as survey questions, activist codes, and volunteer actions
         to a person record. This method allows you apply multiple responses (e.g. two survey
         questions) at the same time. It is a low level method that requires that you
-        conform to the VAN API `response object 
+        conform to the VAN API `response object
         format <https://docs.ngpvan.com/reference/people#peoplevanidcanvassresponses>`_.
 
         `Args:`

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -150,7 +150,7 @@ class People(object):
 
         .. note::
             A full list of possible values for the json, and its structure can be found
-            `here <https://developers.ngpvan.com/van-api#match-candidates>`_.
+            `here <https://docs.ngpvan.com/reference/people#common-models>`_.
 
         `Args:`
             id: str
@@ -233,7 +233,7 @@ class People(object):
 
         .. note::
             A full list of possible values for the json, and its structure can be found
-            `here <https://developers.ngpvan.com/van-api#match-candidates>`_. `vanId` can
+            `here <https://docs.ngpvan.com/reference/people#common-models>`_. `vanId` can
             be passed to ensure the correct record is updated.
 
         .. warning::
@@ -446,7 +446,8 @@ class People(object):
         Apply responses such as survey questions, activist codes, and volunteer actions
         to a person record. This method allows you apply multiple responses (e.g. two survey
         questions) at the same time. It is a low level method that requires that you
-        conform to the VAN API `response object format <https://developers.ngpvan.com/van-api#people-post-people--vanid--canvassresponses>`_.
+        conform to the VAN API `response object 
+        format <https://docs.ngpvan.com/reference/people#peoplevanidcanvassresponses>`_.
 
         `Args:`
             id: str


### PR DESCRIPTION
Updated API URLs in repo docs using https://docs.ngpvan.com/reference/overview. 

I'm a newbie, so please let me know if the URLs I've added are incorrect or you need additional changes. Committed to getting this right. Thanks for the opportunity!