### PR TITLE
Create a Bluelink connector

### DIFF
--- a/docs/bluelink.rst
+++ b/docs/bluelink.rst
@@ -39,28 +39,28 @@ BLUELINK_WEBHOOK_USER and BLUELINK_WEBHOOK_PASSWORD environment variables.
    # Second approach: Pass API credentials as arguments
    bluelink = Bluelink('username', 'password')
 
-You can upsert Person data by directly using a Person object:
+You can upsert person data by directly using a BluelinkPerson object:
 
 .. code-block:: python
 
-   from parsons.bluelink import Bluelink, Person, Identifier
+   from parsons.bluelink import Bluelink, BluelinkPerson, BluelinkIdentifier
 
    # create the person object
-   person = Person(identifiers=[Identifier(source="SOURCE_VENDOR", identifier="ID")], given_name="Jane", family_name="Doe")
+   person = BluelinkPerson(identifiers=[BluelinkIdentifier(source="SOURCE_VENDOR", identifier="ID")], given_name="Jane", family_name="Doe")
 
    # use the bluelink connector to upsert
    source = "MY_ORG_NAME"
    bluelink.upsert_person(source, person)
 
-You can bulk upsert person data via a Parsons Table by providing a function that takes a row and outputs a Person:
+You can bulk upsert person data via a Parsons Table by providing a function that takes a row and outputs a BluelinkPerson:
 
 .. code-block:: python
 
-   from parsons.bluelink import Bluelink, Person, Identifier
+   from parsons.bluelink import Bluelink, BluelinkPerson, BluelinkIdentifier
 
-   # a function that takes a row and returns a Person
+   # a function that takes a row and returns a BluelinkPerson
    def row_to_person(row):
-      return Person(identifiers=[Identifier(source="SOURCE_VENDOR", identifier=row["id"])],
+      return BluelinkPerson(identifiers=[BluelinkIdentifier(source="SOURCE_VENDOR", identifier=row["id"])],
                     given_name=row["firstName"], family_name=row["lastName"])
 
    # a parsons table filled with person data

--- a/docs/bluelink.rst
+++ b/docs/bluelink.rst
@@ -7,9 +7,12 @@ Overview
 
 `Bluelink <https://bluelink.org/>`_ is an online tool for connecting the various `digital software tools <https://https://bluelink.org/product/#integrations>`_
 used by campaigns and movement groups in the political and non-profit space to allow you to seamlessly and easily sync data between them.
-This integration currently supports sending your structured person data and related tags to Bluelink, after which you can use our UI to send to any of our
+This integration currently supports sending your structured person data and related tags to Bluelink via the
+`Bluelink Webhook API <https://bluelinkdata.github.io/docs/BluelinkApiGuide#webhook>`_, after which you can use our UI to send to any of our
 `supported tools <https://bluelink.org/product/#integrations>`_. If you don't see a tool you would like to connect to, please reach out at
 hello@bluelink.org to ask us to add it.
+
+
 
 .. note::
    Authentication

--- a/docs/bluelink.rst
+++ b/docs/bluelink.rst
@@ -1,0 +1,75 @@
+Bluelink
+=============
+
+********
+Overview
+********
+
+`Bluelink <https://bluelink.org/>`_ is an online tool for connecting the various `digital software tools <https://https://bluelink.org/product/#integrations>`_
+used by campaigns and movement groups in the political and non-profit space to allow you to seamlessly and easily sync data between them.
+This integration currently supports sending your structured person data and related tags to Bluelink, after which you can use our UI to send to any of our
+`supported tools <https://bluelink.org/product/#integrations>`_. If you don't see a tool you would like to connect to, please reach out at
+hello@bluelink.org to ask us to add it.
+
+.. note::
+   Authentication
+      If you don't have a Bluelink account please complete the `form <https://bluelink.org/#form>`_ on our website or email us at hello@bluelink.org.
+      To get connection credentials select or ask an account administrator to select `Bluelink Webhook <https://app.bluelink.org/bluelink-webhook-integration>`_
+      from the apps menu. The credentials are automatically embedded into a one time secret link in case they need to be sent to you.
+      Open the link to access the user and password, that you will then either pass directly to the Bluelink connector as arguments, 
+      or set them as environment variables.
+
+==========
+Quickstart
+==========
+
+To instantiate a class, you can either pass in the user and password token as arguments or set them in the
+BLUELINK_WEBHOOK_USER and BLUELINK_WEBHOOK_PASSWORD environment variables.
+
+.. code-block:: python
+
+   from parsons.bluelink import Bluelink
+
+   # First approach: Use API credentials via environmental variables
+   bluelink = Bluelink()
+
+   # Second approach: Pass API credentials as arguments
+   bluelink = Bluelink('username', 'password')
+
+You can upsert Person data by directly using a Person object:
+
+.. code-block:: python
+
+   from parsons.bluelink import Bluelink, Person, Identifier
+
+   # create the person object
+   person = Person(identifiers=[Identifier(source="SOURCE_VENDOR", identifier="ID")], given_name="Jane", family_name="Doe")
+
+   # use the bluelink connector to upsert
+   source = "MY_ORG_NAME"
+   bluelink.upsert_person(source, person)
+
+You can bulk upsert person data via a Parsons Table by providing a function that takes a row and outputs a Person:
+
+.. code-block:: python
+
+   from parsons.bluelink import Bluelink, Person, Identifier
+
+   # a function that takes a row and returns a Person
+   def row_to_person(row):
+      return Person(identifiers=[Identifier(source="SOURCE_VENDOR", identifier=row["id"])],
+                    given_name=row["firstName"], family_name=row["lastName"])
+
+   # a parsons table filled with person data
+   parsons_tbl = get_data()
+
+   # call bulk_upsert_person
+   source = "MY_ORG_NAME"
+   bluelink.bulk_upsert_person(source, parsons_tbl, row_to_person)
+
+***
+API
+***
+
+.. autoclass :: parsons.bluelink.Bluelink
+   :inherited-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -173,6 +173,7 @@ Indices and tables
    azure
    bill_com
    bloomerang
+   bluelink
    box
    braintree
    civis

--- a/parsons/bluelink/__init__.py
+++ b/parsons/bluelink/__init__.py
@@ -1,0 +1,7 @@
+from parsons.bluelink.bluelink import Bluelink
+from parsons.bluelink.person import Person, Email, Address, Phone, Identifier, Tag, Score
+
+__all__ = [
+    'Bluelink',
+    'Person', 'Email', 'Address', 'Phone', 'Identifier', 'Tag', 'Score'
+]

--- a/parsons/bluelink/__init__.py
+++ b/parsons/bluelink/__init__.py
@@ -1,7 +1,9 @@
 from parsons.bluelink.bluelink import Bluelink
-from parsons.bluelink.person import Person, Email, Address, Phone, Identifier, Tag, Score
+from parsons.bluelink.person import BluelinkPerson, \
+    BluelinkEmail, BluelinkAddress, BluelinkPhone, BluelinkIdentifier, BluelinkTag, BluelinkScore
 
 __all__ = [
     'Bluelink',
-    'Person', 'Email', 'Address', 'Phone', 'Identifier', 'Tag', 'Score'
+    'BluelinkPerson', 'BluelinkEmail', 'BluelinkAddress', 'BluelinkPhone',
+    'BluelinkIdentifier', 'BluelinkTag', 'BluelinkScore'
 ]

--- a/parsons/bluelink/bluelink.py
+++ b/parsons/bluelink/bluelink.py
@@ -13,6 +13,7 @@ class Bluelink:
     """
     Instantiate a Bluelink connector.
     Allows for a simple method of inserting Person data to Bluelink via a webhook.
+    # see: https://bluelinkdata.github.io/docs/BluelinkApiGuide#webhook
 
     `Args:`:
         user: str

--- a/parsons/bluelink/bluelink.py
+++ b/parsons/bluelink/bluelink.py
@@ -1,6 +1,6 @@
 from parsons.utilities.api_connector import APIConnector
 from parsons.utilities import check_env
-from parsons.bluelink.person import Person
+from parsons.bluelink.person import BluelinkPerson
 import logging
 import json
 
@@ -12,7 +12,7 @@ API_URL = 'https://api.bluelink.org/webhooks/'
 class Bluelink:
     """
     Instantiate a Bluelink connector.
-    Allows for a simple method of inserting Person data to Bluelink via a webhook.
+    Allows for a simple method of inserting person data to Bluelink via a webhook.
     # see: https://bluelinkdata.github.io/docs/BluelinkApiGuide#webhook
 
     `Args:`:
@@ -32,17 +32,17 @@ class Bluelink:
 
     def upsert_person(self, source, person=None):
         """
-        Upsert a Person object into Bluelink.
+        Upsert a BluelinkPerson object into Bluelink.
         Rows will update, as opposed to being inserted, if an existing person record in
-        Bluelink has a matching Identifier (same source and id) as the Person object
+        Bluelink has a matching BluelinkIdentifier (same source and id) as the BluelinkPerson object
         passed into this function.
 
         `Args:`
             source: str
                 String to identify that the data came from your system. For example,
                 your company name.
-            person: Person
-                A Person object.
+            person: BluelinkPerson
+                A BluelinkPerson object.
                 Will be inserted to Bluelink, or updated if a matching record is found.
         `Returns:`
             int
@@ -60,7 +60,7 @@ class Bluelink:
     def bulk_upsert_person(self, source, tbl, row_to_person):
         """
         Upsert all rows into Bluelink, using the row_to_person function to
-        transform rows to Person objects.
+        transform rows to BluelinkPerson objects.
 
         `Args:`
             source: str
@@ -68,15 +68,15 @@ class Bluelink:
                 For example, your company name.
             tbl: Table
                 A parsons Table that represents people data.
-            row_to_person: Callable[[dict],Person]
+            row_to_person: Callable[[dict],BluelinkPerson]
                 A function that takes a dict representation of a row from the passed in tbl
-                and returns a Person object.
+                and returns a BluelinkPerson object.
 
         `Returns:`
             list[int]
             A list of https response status codes, one response for each row in the table.
         """
-        people = Person.from_table(tbl, row_to_person)
+        people = BluelinkPerson.from_table(tbl, row_to_person)
         responses = []
         for person in people:
             response = self.upsert_person(source, person)

--- a/parsons/bluelink/bluelink.py
+++ b/parsons/bluelink/bluelink.py
@@ -1,0 +1,83 @@
+from parsons.utilities.api_connector import APIConnector
+from parsons.utilities import check_env
+from parsons.bluelink.person import Person
+import logging
+import json
+
+logger = logging.getLogger(__name__)
+
+API_URL = 'https://api.bluelink.org/webhooks/'
+
+
+class Bluelink:
+    """
+    Instantiate a Bluelink connector.
+    Allows for a simple method of inserting Person data to Bluelink via a webhook.
+
+    `Args:`:
+        user: str
+            Bluelink webhook user name.
+        password: str
+            Bluelink webhook password.
+    """
+    def __init__(self, user=None, password=None):
+        self.user = check_env.check('BLUELINK_WEBHOOK_USER', user)
+        self.password = check_env.check('BLUELINK_WEBHOOK_PASSWORD', password)
+        self.headers = {
+            "Content-Type": "application/json",
+        }
+        self.api_url = API_URL
+        self.api = APIConnector(self.api_url, auth=(self.user, self.password), headers=self.headers)
+
+    def upsert_person(self, source, person=None):
+        """
+        Upsert a Person object into Bluelink.
+        Rows will update, as opposed to being inserted, if an existing person record in
+        Bluelink has a matching Identifier (same source and id) as the Person object
+        passed into this function.
+
+        `Args:`
+            source: str
+                String to identify that the data came from your system. For example,
+                your company name.
+            person: Person
+                A Person object.
+                Will be inserted to Bluelink, or updated if a matching record is found.
+        `Returns:`
+            int
+            An http status code from the http post request to the Bluelink webhook.
+        """
+        data = {
+            'source': source,
+            'person': person
+        }
+        jdata = json.dumps(data,
+                           default=lambda o: {k: v for k, v in o.__dict__.items() if v is not None})
+        resp = self.api.post_request(url=self.api_url, data=jdata)
+        return resp
+
+    def bulk_upsert_person(self, source, tbl, row_to_person):
+        """
+        Upsert all rows into Bluelink, using the row_to_person function to
+        transform rows to Person objects.
+
+        `Args:`
+            source: str
+                String to identify that the data came from your system.
+                For example, your company name.
+            tbl: Table
+                A parsons Table that represents people data.
+            row_to_person: Callable[[dict],Person]
+                A function that takes a dict representation of a row from the passed in tbl
+                and returns a Person object.
+
+        `Returns:`
+            list[int]
+            A list of https response status codes, one response for each row in the table.
+        """
+        people = Person.from_table(tbl, row_to_person)
+        responses = []
+        for person in people:
+            response = self.upsert_person(source, person)
+            responses.append(response)
+        return responses

--- a/parsons/bluelink/person.py
+++ b/parsons/bluelink/person.py
@@ -4,36 +4,36 @@ import json
 logger = logging.getLogger(__name__)
 
 
-class Person(object):
+class BluelinkPerson(object):
     """
-    Instantiate Person Class.
+    Instantiate BluelinkPerson Class.
     Used for to upserting via Bluelink connector.
     See: https://bluelinkdata.github.io/docs/BluelinkApiGuide#person-object
 
     `Args:`
-        identifiers: list[Identifier]
-            A list of Identifier objects.
-            A Person must have at least 1 identifier.
+        identifiers: list[BluelinkIdentifier]
+            A list of BluelinkIdentifier objects.
+            A BluelinkPerson must have at least 1 identifier.
         given_name: str
             First name / given name.
         family_name: str
             Last name / family name.
-        phones: list[Phone]
-            A list of Phone objects representing phone numbers.
-        emails: list[Email]
-            A list of Email objects representing email addresses.
-        addresses: list[Address]
-            A list of Address objects representing postal addresses.
-        tags: list[Tag]
+        phones: list[BluelinkPhone]
+            A list of BluelinkPhone objects representing phone numbers.
+        emails: list[BluelinkEmail]
+            A list of BluelinkEmail objects representing email addresses.
+        addresses: list[BluelinkAddress]
+            A list of BluelinkAddress objects representing postal addresses.
+        tags: list[BluelinkTag]
             Simple tags that apply to the person, eg DONOR.
         employer: str
             Name of the persons employer.
-        employer_address: Address
-            Address of the persons employer.
+        employer_address: BluelinkAddress
+            BluelinkAddress of the persons employer.
         occupation: str
             Occupation.
-        scores: list[Score]
-            List of Score objects. Scores are numeric scores, ie partisanship model.
+        scores: list[BluelinkScore]
+            List of BluelinkScore objects. Scores are numeric scores, ie partisanship model.
         birthdate: str
             ISO 8601 formatted birth date: 'YYYY-MM-DD'
         details: dict
@@ -44,7 +44,8 @@ class Person(object):
                  occupation=None, scores=None, birthdate=None, details=None):
 
         if not identifiers:
-            raise Exception("Person requires list of Identifiers with at least 1 Identifier")
+            raise Exception("BluelinkPerson requires list of BluelinkIdentifiers with "
+                            "at least 1 BluelinkIdentifier")
 
         self.identifiers = identifiers
         self.addresses = addresses
@@ -63,7 +64,7 @@ class Person(object):
         self.details = details
 
     def __json__(self):
-        """The json str representation of this Person object"""
+        """The json str representation of this BluelinkPerson object"""
         return json.dumps(self, default=lambda obj: obj.__dict__)
 
     def __eq__(self, other):
@@ -78,25 +79,25 @@ class Person(object):
     @staticmethod
     def from_table(tbl, dict_to_person):
         """
-        Return a list of Person objects from a Parsons Table.
+        Return a list of BluelinkPerson objects from a Parsons Table.
 
         `Args:`
             tbl: Table
                 A parsons Table.
-            dict_to_person: Callable[[dict],Person]
+            dict_to_person: Callable[[dict],BluelinkPerson]
                 A function that takes a dictionary representation of a table row,
-                and returns a Person.
+                and returns a BluelinkPerson.
         `Returns:`
-           list[Person]
-           A list of Person objects.
+           list[BluelinkPerson]
+           A list of BluelinkPerson objects.
         """
         return [dict_to_person(row) for row in tbl]
 
 
-class Identifier(object):
+class BluelinkIdentifier(object):
     """
-    Instantiate an Identifier object.
-    Identifier is necessary for updating Person records.
+    Instantiate an BluelinkIdentifier object.
+    BluelinkIdentifier is necessary for updating BluelinkPerson records.
 
     `Args:`
         source: str
@@ -116,9 +117,9 @@ class Identifier(object):
         self.details = details
 
 
-class Email(object):
+class BluelinkEmail(object):
     """
-    Instantiate an Email object.
+    Instantiate an BluelinkEmail object.
 
     `Args:`
         address: str
@@ -137,9 +138,9 @@ class Email(object):
         self.status = status
 
 
-class Address(object):
+class BluelinkAddress(object):
     """
-    Instantiate an Address object.
+    Instantiate an BluelinkAddress object.
 
     `Args`:
         address_lines: list[str]
@@ -175,9 +176,9 @@ class Address(object):
         self.status = status
 
 
-class Phone(object):
+class BluelinkPhone(object):
     """
-    Instantiate a Phone object.
+    Instantiate a BluelinkPhone object.
 
     `Args:`
         number: str
@@ -209,20 +210,20 @@ class Phone(object):
         self.details = details
 
 
-class Tag(object):
+class BluelinkTag(object):
     """
-    Instantiate a Tag object.
+    Instantiate a BluelinkTag object.
 
     `Args:`
         tag: str
-            Tag string; convention is either a simple string
+            A tag string; convention is either a simple string
             or a string with a prefix separated by a colon, e.g., “DONOR:GRASSROOTS”
     """
     def __init__(self, tag):
         self.tag = tag
 
 
-class Score(object):
+class BluelinkScore(object):
     """
     Instantiate a score object.
     Represents some kind of numeric score.

--- a/parsons/bluelink/person.py
+++ b/parsons/bluelink/person.py
@@ -1,0 +1,241 @@
+import logging
+import json
+
+logger = logging.getLogger(__name__)
+
+
+class Person(object):
+    """
+    Instantiate Person Class.
+    Used for to upserting via Bluelink connector.
+    See: https://bluelinkdata.github.io/docs/BluelinkApiGuide#person-object
+
+    `Args:`
+        identifiers: list[Identifier]
+            A list of Identifier objects.
+            A Person must have at least 1 identifier.
+        given_name: str
+            First name / given name.
+        family_name: str
+            Last name / family name.
+        phones: list[Phone]
+            A list of Phone objects representing phone numbers.
+        emails: list[Email]
+            A list of Email objects representing email addresses.
+        addresses: list[Address]
+            A list of Address objects representing postal addresses.
+        tags: list[Tag]
+            Simple tags that apply to the person, eg DONOR.
+        employer: str
+            Name of the persons employer.
+        employer_address: Address
+            Address of the persons employer.
+        occupation: str
+            Occupation.
+        scores: list[Score]
+            List of Score objects. Scores are numeric scores, ie partisanship model.
+        birthdate: str
+            ISO 8601 formatted birth date: 'YYYY-MM-DD'
+        details: dict
+            additional custom data. must be json serializable.
+    """
+    def __init__(self, identifiers, given_name=None, family_name=None, phones=None, emails=None,
+                 addresses=None, tags=None, employer=None, employer_address=None,
+                 occupation=None, scores=None, birthdate=None, details=None):
+
+        if not identifiers:
+            raise Exception("Person requires list of Identifiers with at least 1 Identifier")
+
+        self.identifiers = identifiers
+        self.addresses = addresses
+        self.emails = emails
+        self.phones = phones
+        self.tags = tags
+        self.scores = scores
+
+        self.given_name = given_name
+        self.family_name = family_name
+
+        self.employer = employer
+        self.employer_address = employer_address
+        self.occupation = occupation
+        self.birthdate = birthdate
+        self.details = details
+
+    def __json__(self):
+        """The json str representation of this Person object"""
+        return json.dumps(self, default=lambda obj: obj.__dict__)
+
+    def __eq__(self, other):
+        """A quick and dirty equality check"""
+        dself = json.loads(self.__json__())
+        dother = json.loads(other.__json__())
+        return dself == dother
+
+    def __repr__(self):
+        return self.__json__()
+
+    @staticmethod
+    def from_table(tbl, dict_to_person):
+        """
+        Return a list of Person objects from a Parsons Table.
+
+        `Args:`
+            tbl: Table
+                A parsons Table.
+            dict_to_person: Callable[[dict],Person]
+                A function that takes a dictionary representation of a table row,
+                and returns a Person.
+        `Returns:`
+           list[Person]
+           A list of Person objects.
+        """
+        return [dict_to_person(row) for row in tbl]
+
+
+class Identifier(object):
+    """
+    Instantiate an Identifier object.
+    Identifier is necessary for updating Person records.
+
+    `Args:`
+        source: str
+            External system to which this ID belongs, e.g., “VAN:myCampaign”.
+            Bluelink has standardized strings for source. Using these will
+            allow Bluelink to correctly understand the external IDs you add.
+            source (unlike identifier) is case insensitive.
+            examples: BLUELINK, PDI, SALESFORCE, VAN:myCampaign, VAN:myVoters
+        identifier: str
+            Case-sensitive ID in the external system.
+        details: dict
+            dictionary of custom fields. must be serializable to json.
+    """
+    def __init__(self, source, identifier, details=None):
+        self.source = source
+        self.identifier = identifier
+        self.details = details
+
+
+class Email(object):
+    """
+    Instantiate an Email object.
+
+    `Args:`
+        address: str
+            An email address. ie "user@example.com"
+        primary: bool
+            True if this is known to be the primary email.
+        type: str
+            Type, eg: "personal", "work"
+        status: str
+            One of "Potential", "Subscribed", "Unsubscribed", "Bouncing", or "Spam Complaints"
+    """
+    def __init__(self, address, primary=None, type=None, status=None):
+        self.address = address
+        self.primary = primary
+        self.type = type
+        self.status = status
+
+
+class Address(object):
+    """
+    Instantiate an Address object.
+
+    `Args`:
+        address_lines: list[str]
+            A list of street address lines.
+        city: str
+            City or other locality.
+        state: str
+            State in ISO 3166-2.
+        postal_code: str
+            Zip or other postal code.
+        country: str
+            ISO 3166-1 Alpha-2 country code.
+        type: str
+            The type. ie: "home", "mailing".
+        venue: str
+            The venue name, if relevant.
+        status: str
+            A value representing the status of the address. "Potential", "Verified" or "Bad"
+    """
+    def __init__(self,
+                 address_lines=None,
+                 city=None, state=None, postal_code=None, country=None,
+                 type=None, venue=None, status=None):
+
+        self.address_lines = address_lines or []
+        self.city = city
+        self.state = state
+        self.postal_code = postal_code
+        self.country = country
+
+        self.type = type
+        self.venue = venue
+        self.status = status
+
+
+class Phone(object):
+    """
+    Instantiate a Phone object.
+
+    `Args:`
+        number: str
+            A phone number. May or may not include country code.
+        primary: bool
+            True if this is known to be the primary phone.
+        description: str
+            Free for description.
+        type: str
+            Type, eg: "Home", "Work", "Mobile"
+        country: str
+            ISO 3166-1 Alpha-2 country code.
+        sms_capable: bool
+            True if this number can accept SMS.
+        do_not_call: bool
+            True if this number is on the US FCC Do Not Call Registry.
+        details: dict
+            Additional data dictionary. Must be json serializable.
+    """
+    def __init__(self, number, primary=None, description=None, type=None, country=None,
+                 sms_capable=None, do_not_call=None, details=None):
+        self.number = number
+        self.primary = primary
+        self.description = description
+        self.type = type
+        self.country = country
+        self.sms_capable = sms_capable
+        self.do_not_call = do_not_call
+        self.details = details
+
+
+class Tag(object):
+    """
+    Instantiate a Tag object.
+
+    `Args:`
+        tag: str
+            Tag string; convention is either a simple string
+            or a string with a prefix separated by a colon, e.g., “DONOR:GRASSROOTS”
+    """
+    def __init__(self, tag):
+        self.tag = tag
+
+
+class Score(object):
+    """
+    Instantiate a score object.
+    Represents some kind of numeric score.
+
+    `Args`:
+        score: float
+            Numeric score.
+        score_type: str
+            Type, eg: "Partisanship model".
+        source: str
+            Original source of this score.
+    """
+    def __init__(self, score, score_type, source):
+        self.score = score
+        self.score_type = score_type
+        self.source = source

--- a/test/test_bluelink/test_bluelink.py
+++ b/test/test_bluelink/test_bluelink.py
@@ -1,6 +1,5 @@
 import unittest
 import requests_mock
-import json
 from parsons import Table
 from parsons.bluelink import Bluelink, Person, Identifier, Email
 
@@ -63,10 +62,12 @@ class TestBluelink(unittest.TestCase):
         m.post(self.bluelink.api_url)
 
         # create a Person object
-        # The Identifier is pretending that the user can be identified in SALESFORCE with FAKE_ID as her id
-        person = Person(identifiers=Identifier(source="SALESFORCE", identifier="FAKE_ID"),
-                     given_name="Jane", family_name="Doe",
-                     emails=[Email(address="jdoe@example.com", primary=True)])
+        # The Identifier is pretending that the user can be
+        # identified in SALESFORCE with FAKE_ID as her id
+        person = Person(identifiers=[Identifier(source="SALESFORCE",
+                                                identifier="FAKE_ID")],
+                        given_name="Jane", family_name="Doe",
+                        emails=[Email(address="jdoe@example.com", primary=True)])
 
         # String to identify that the data came from your system. For example, your company name.
         source = "BLUELINK-PARSONS-TEST"
@@ -85,12 +86,13 @@ class TestBluelink(unittest.TestCase):
         actual_people = Person.from_table(tbl, self.row_to_person)
 
         # expected:
-        person1 = Person(identifiers=[Identifier(source="FAKESOURCE", identifier="bart@springfield.net")],
+        person1 = Person(identifiers=[Identifier(source="FAKESOURCE",
+                                                 identifier="bart@springfield.net")],
                          emails=[Email(address="bart@springfield.net", primary=True)],
                          family_name="Simpson", given_name="Bart")
-        person2 = Person(identifiers=[Identifier(source="FAKESOURCE", identifier="homer@springfield.net")],
+        person2 = Person(identifiers=[Identifier(source="FAKESOURCE",
+                                                 identifier="homer@springfield.net")],
                          emails=[Email(address="homer@springfield.net", primary=True)],
                          family_name="Simpson", given_name="Homer")
         expected_people = [person1, person2]
         self.assertEqual(actual_people, expected_people)
-

--- a/test/test_bluelink/test_bluelink.py
+++ b/test/test_bluelink/test_bluelink.py
@@ -1,0 +1,96 @@
+import unittest
+import requests_mock
+import json
+from parsons import Table
+from parsons.bluelink import Bluelink, Person, Identifier, Email
+
+
+class TestBluelink(unittest.TestCase):
+
+    @requests_mock.Mocker()
+    def setUp(self, m):
+        self.bluelink = Bluelink("fake_user", "fake_password")
+
+    @staticmethod
+    def row_to_person(row):
+        """
+        dict -> Person
+        Transforms a parsons Table row to a Person.
+        This function is passed into bulk_upsert_person along with a Table
+        """
+        email = row["email"]
+        return Person(
+            identifiers=[
+                Identifier(source="FAKESOURCE", identifier=email),
+            ],
+            emails=[Email(address=email, primary=True)],
+            family_name=row["family_name"],
+            given_name=row["given_name"],
+        )
+
+    @staticmethod
+    def get_table():
+        return Table([
+            {"given_name": "Bart", "family_name": "Simpson", "email": "bart@springfield.net"},
+            {"given_name": "Homer", "family_name": "Simpson", "email": "homer@springfield.net"},
+        ])
+
+    @requests_mock.Mocker()
+    def test_bulk_upsert_person(self, m):
+        """
+        This function demonstrates how to use a "row_to_person" function to bulk
+        insert people using a Table as the data source
+        """
+        # Mock POST requests to api
+        m.post(self.bluelink.api_url)
+
+        # get data as a parsons Table
+        tbl = self.get_table()
+
+        # String to identify that the data came from your system. For example, your company name.
+        source = "BLUELINK-PARSONS-TEST"
+
+        # call bulk_upsert_person
+        # passing in the source, the Table, and the function that maps a Table row -> Person
+        self.bluelink.bulk_upsert_person(source, tbl, self.row_to_person)
+
+    @requests_mock.Mocker()
+    def test_upsert_person(self, m):
+        """
+        This function demonstrates how to insert a single Person record
+        """
+        # Mock POST requests to api
+        m.post(self.bluelink.api_url)
+
+        # create a Person object
+        # The Identifier is pretending that the user can be identified in SALESFORCE with FAKE_ID as her id
+        person = Person(identifiers=Identifier(source="SALESFORCE", identifier="FAKE_ID"),
+                     given_name="Jane", family_name="Doe",
+                     emails=[Email(address="jdoe@example.com", primary=True)])
+
+        # String to identify that the data came from your system. For example, your company name.
+        source = "BLUELINK-PARSONS-TEST"
+
+        # call upsert_person
+        self.bluelink.upsert_person(source, person)
+
+    def test_table_to_people(self):
+        """
+        Test transforming a parsons Table -> list[Person]
+        """
+        # setup
+        tbl = self.get_table()
+
+        # function under test
+        actual_people = Person.from_table(tbl, self.row_to_person)
+
+        # expected:
+        person1 = Person(identifiers=[Identifier(source="FAKESOURCE", identifier="bart@springfield.net")],
+                         emails=[Email(address="bart@springfield.net", primary=True)],
+                         family_name="Simpson", given_name="Bart")
+        person2 = Person(identifiers=[Identifier(source="FAKESOURCE", identifier="homer@springfield.net")],
+                         emails=[Email(address="homer@springfield.net", primary=True)],
+                         family_name="Simpson", given_name="Homer")
+        expected_people = [person1, person2]
+        self.assertEqual(actual_people, expected_people)
+

--- a/test/test_bluelink/test_bluelink.py
+++ b/test/test_bluelink/test_bluelink.py
@@ -1,7 +1,7 @@
 import unittest
 import requests_mock
 from parsons import Table
-from parsons.bluelink import Bluelink, Person, Identifier, Email
+from parsons.bluelink import Bluelink, BluelinkPerson, BluelinkIdentifier, BluelinkEmail
 
 
 class TestBluelink(unittest.TestCase):
@@ -13,16 +13,16 @@ class TestBluelink(unittest.TestCase):
     @staticmethod
     def row_to_person(row):
         """
-        dict -> Person
-        Transforms a parsons Table row to a Person.
+        dict -> BluelinkPerson
+        Transforms a parsons Table row to a BluelinkPerson.
         This function is passed into bulk_upsert_person along with a Table
         """
         email = row["email"]
-        return Person(
+        return BluelinkPerson(
             identifiers=[
-                Identifier(source="FAKESOURCE", identifier=email),
+                BluelinkIdentifier(source="FAKESOURCE", identifier=email),
             ],
-            emails=[Email(address=email, primary=True)],
+            emails=[BluelinkEmail(address=email, primary=True)],
             family_name=row["family_name"],
             given_name=row["given_name"],
         )
@@ -50,24 +50,24 @@ class TestBluelink(unittest.TestCase):
         source = "BLUELINK-PARSONS-TEST"
 
         # call bulk_upsert_person
-        # passing in the source, the Table, and the function that maps a Table row -> Person
+        # passing in the source, the Table, and the function that maps a Table row -> BluelinkPerson
         self.bluelink.bulk_upsert_person(source, tbl, self.row_to_person)
 
     @requests_mock.Mocker()
     def test_upsert_person(self, m):
         """
-        This function demonstrates how to insert a single Person record
+        This function demonstrates how to insert a single BluelinkPerson record
         """
         # Mock POST requests to api
         m.post(self.bluelink.api_url)
 
-        # create a Person object
-        # The Identifier is pretending that the user can be
+        # create a BluelinkPerson object
+        # The BluelinkIdentifier is pretending that the user can be
         # identified in SALESFORCE with FAKE_ID as her id
-        person = Person(identifiers=[Identifier(source="SALESFORCE",
-                                                identifier="FAKE_ID")],
-                        given_name="Jane", family_name="Doe",
-                        emails=[Email(address="jdoe@example.com", primary=True)])
+        person = BluelinkPerson(identifiers=[BluelinkIdentifier(source="SALESFORCE",
+                                                                identifier="FAKE_ID")],
+                                given_name="Jane", family_name="Doe",
+                                emails=[BluelinkEmail(address="jdoe@example.com", primary=True)])
 
         # String to identify that the data came from your system. For example, your company name.
         source = "BLUELINK-PARSONS-TEST"
@@ -77,22 +77,24 @@ class TestBluelink(unittest.TestCase):
 
     def test_table_to_people(self):
         """
-        Test transforming a parsons Table -> list[Person]
+        Test transforming a parsons Table -> list[BluelinkPerson]
         """
         # setup
         tbl = self.get_table()
 
         # function under test
-        actual_people = Person.from_table(tbl, self.row_to_person)
+        actual_people = BluelinkPerson.from_table(tbl, self.row_to_person)
 
         # expected:
-        person1 = Person(identifiers=[Identifier(source="FAKESOURCE",
-                                                 identifier="bart@springfield.net")],
-                         emails=[Email(address="bart@springfield.net", primary=True)],
-                         family_name="Simpson", given_name="Bart")
-        person2 = Person(identifiers=[Identifier(source="FAKESOURCE",
-                                                 identifier="homer@springfield.net")],
-                         emails=[Email(address="homer@springfield.net", primary=True)],
-                         family_name="Simpson", given_name="Homer")
+        person1 = BluelinkPerson(
+            identifiers=[BluelinkIdentifier(source="FAKESOURCE",
+                                            identifier="bart@springfield.net")],
+            emails=[BluelinkEmail(address="bart@springfield.net", primary=True)],
+            family_name="Simpson", given_name="Bart")
+        person2 = BluelinkPerson(
+            identifiers=[BluelinkIdentifier(source="FAKESOURCE",
+                                            identifier="homer@springfield.net")],
+            emails=[BluelinkEmail(address="homer@springfield.net", primary=True)],
+            family_name="Simpson", given_name="Homer")
         expected_people = [person1, person2]
         self.assertEqual(actual_people, expected_people)


### PR DESCRIPTION
This PR is for creating a Bluelink connector that works with Bluelink's Webhook API.

[Bluelink](https://bluelink.org/) is an online tool for connecting the various [digital software tools](https://https://bluelink.org/product/#integrations) used by campaigns and movement groups in the political and non-profit space to allow you to seamlessly and easily sync data between them.

This integration currently supports sending your structured person data and related tags to Bluelink via the
[Bluelink Webhook API](https://bluelinkdata.github.io/docs/BluelinkApiGuide#webhook), after which you can use our UI to send to any of our [supported tools](https://https://bluelink.org/product/#integrations).

The bluelink package provides a Person class that follows the Bluelink data model. A Person object can be populated with data via the constructor and then upserted via the connector.

The connector allows for bulk upserting of people data via a Parson's Table, using a passed in function that can transform a Table row into a Person object.

Examples are provided in the documentation, and also the unit tests.
