### PR TITLE
updating airtable-python-wrapper to v0.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ paramiko==2.7.1
 xmltodict==0.11.0
 joblib==0.14.1
 censusgeocode==0.4.3.post1
-airtable-python-wrapper==0.11.3.post1
+airtable-python-wrapper==0.13.0
 google-cloud-storage==1.17.0
 google-cloud-bigquery==1.21.0
 docutils<0.15,>=0.10 # Botocore and Sphinx have conflicting needs.


### PR DESCRIPTION
This version of the airtable-python-wrapper includes a [patch](https://github.com/gtalarico/pyairtable/pull/61/commits/880844bd20acc2957e5e93855af3a9a8be3f2e32) for the `_batch_request` and `batch_insert` functions that allow the creation of new multi- and single-select values when inserting records via the Parsons connector.

I was able to run an Airtable sync [script](https://github.com/sunrisedatadept/engineering-general/blob/feature/airtable_sync/airtable/redshift_to_airtable_sync/civis_to_airtable.py) on Civis by including the following `sed` statements that accomplish the exact same thing as the above patch so I am hoping that means there aren't any conflicts with other parts of Parsons!

```
sed -i -e 's/def _batch_request(self, func, iterable):/def _batch_request(self, func, iterable, **kwargs):/' /usr/local/lib/python3.7/site-packages/airtable/airtable.py
sed -i -e 's/responses.append(func(item))/responses.append(func(item, **kwargs))/' /usr/local/lib/python3.7/site-packages/airtable/airtable.py
sed -i -e 's/return self._batch_request(self.insert, records)/return self._batch_request(self.insert, records, typecast=typecast)/' /usr/local/lib/python3.7/site-packages/airtable/airtable.py
```