### PR TITLE
Improved censoring of debug log regardless of supplied tokens

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -5,7 +5,7 @@ from parsons.databases.redshift.rs_table_utilities import RedshiftTableUtilities
 from parsons.databases.redshift.rs_schema import RedshiftSchema
 from parsons.databases.table import BaseTable
 from parsons.databases.alchemy import Alchemy
-from parsons.utilities import files
+from parsons.utilities import files, sql
 import psycopg2
 import psycopg2.extras
 import os
@@ -561,9 +561,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
 
                 # Copy from S3 to Redshift
                 sql = self.copy_statement(table_name, self.s3_temp_bucket, key, **copy_args)
-                sql_censored = "\n".join(["credentials: REDACTED"
-                                          if 'credentials' in x else x
-                                          for x in sql.split("\n")])
+                sql_censored = sql.redact_credentials(sql)
 
                 logger.debug(f'Copy SQL command: {sql_censored}')
                 self.query_with_connection(sql, connection, commit=False)
@@ -664,9 +662,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
 
         logger.info(f'Unloading data to s3://{bucket}/{key_prefix}')
         # Censor sensitive data
-        statement_censored = "\n".join(["credentials: REDACTED"
-                                        if 'credentials' in x else x
-                                        for x in statement.split("\n")])
+        statement_censored = sql.redact_credentials(statement)
         logger.debug(statement_censored)
 
         return self.query(statement)

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -665,8 +665,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         logger.info(f'Unloading data to s3://{bucket}/{key_prefix}')
         # Censor sensitive data
         statement_censored = "\n".join(["credentials: REDACTED"
-                                          if 'credentials' in x else x
-                                          for x in statement.split("\n")])
+                                        if 'credentials' in x else x
+                                        for x in statement.split("\n")])
         logger.debug(statement_censored)
 
         return self.query(statement)

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -189,7 +189,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
 
         with self.cursor(connection) as cursor:
 
-            logger.debug(f'SQL Query: {sql}')
+            if 'credentials' not in sql:
+                logger.debug(f'SQL Query: {sql}')
             cursor.execute(sql, parameters)
 
             if commit:

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -5,7 +5,7 @@ from parsons.databases.redshift.rs_table_utilities import RedshiftTableUtilities
 from parsons.databases.redshift.rs_schema import RedshiftSchema
 from parsons.databases.table import BaseTable
 from parsons.databases.alchemy import Alchemy
-from parsons.utilities import files, sql
+from parsons.utilities import files, sql_helpers
 import psycopg2
 import psycopg2.extras
 import os
@@ -561,7 +561,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
 
                 # Copy from S3 to Redshift
                 sql = self.copy_statement(table_name, self.s3_temp_bucket, key, **copy_args)
-                sql_censored = sql.redact_credentials(sql)
+                sql_censored = sql_helpers.redact_credentials(sql)
 
                 logger.debug(f'Copy SQL command: {sql_censored}')
                 self.query_with_connection(sql, connection, commit=False)
@@ -662,7 +662,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
 
         logger.info(f'Unloading data to s3://{bucket}/{key_prefix}')
         # Censor sensitive data
-        statement_censored = sql.redact_credentials(statement)
+        statement_censored = sql_helpers.redact_credentials(statement)
         logger.debug(statement_censored)
 
         return self.query(statement)

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -560,17 +560,9 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
 
                 # Copy from S3 to Redshift
                 sql = self.copy_statement(table_name, self.s3_temp_bucket, key, **copy_args)
-                sql_censored = sql
-                if aws_access_key_id:
-                    sql_censored = sql_censored.replace(
-                        aws_access_key_id,
-                        'XXXXXXXXXXXX'
-                    )
-                if aws_secret_access_key:
-                    sql_censored = sql_censored.replace(
-                        aws_secret_access_key,
-                        'YYYYYYYYYYYYY'
-                    )
+                sql_censored = "\n".join(["credentials: REDACTED"
+                                          if 'credentials' in x else x
+                                          for x in sql.split("\n")])
 
                 logger.debug(f'Copy SQL command: {sql_censored}')
                 self.query_with_connection(sql, connection, commit=False)
@@ -671,17 +663,9 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
 
         logger.info(f'Unloading data to s3://{bucket}/{key_prefix}')
         # Censor sensitive data
-        statement_censored = statement
-        if aws_access_key_id:
-            statement_censored.replace(
-                aws_access_key_id,
-                'XXXXXXXXXXXX'
-            )
-        if aws_secret_access_key:
-            statement_censored.replace(
-                aws_secret_access_key,
-                'YYYYYYYYYYYYY'
-            )
+        statement_censored = "\n".join(["credentials: REDACTED"
+                                          if 'credentials' in x else x
+                                          for x in statement.split("\n")])
         logger.debug(statement_censored)
 
         return self.query(statement)

--- a/parsons/utilities/sql.py
+++ b/parsons/utilities/sql.py
@@ -7,6 +7,7 @@ def redact_credentials(sql):
     Redact any credentials explicitly represented in SQL (e.g. COPY statement)
     """
 
+    pattern = "credentials\s+'(.+\n?)+[^(\\)]'"
     sql_censored = re.sub(pattern, 'CREDENTIALS REDACTED', sql, flags=re.IGNORECASE)
     
     return sql_censored

--- a/parsons/utilities/sql.py
+++ b/parsons/utilities/sql.py
@@ -1,0 +1,12 @@
+import re
+
+__all__ = ['redact_copy_sql']
+
+def redact_credentials(sql):
+    """
+    Redact any credentials explicitly represented in SQL (e.g. COPY statement)
+    """
+
+    sql_censored = re.sub(pattern, 'CREDENTIALS REDACTED', sql, flags=re.IGNORECASE)
+    
+    return sql_censored

--- a/parsons/utilities/sql_helpers.py
+++ b/parsons/utilities/sql_helpers.py
@@ -1,13 +1,14 @@
 import re
 
-__all__ = ['redact_copy_sql']
+__all__ = ['redact_credentials']
+
 
 def redact_credentials(sql):
     """
     Redact any credentials explicitly represented in SQL (e.g. COPY statement)
     """
 
-    pattern = "credentials\s+'(.+\n?)+[^(\\)]'"
+    pattern = "credentials\s+'(.+\n?)+[^(\\)]'"  # noqa: W605
     sql_censored = re.sub(pattern, 'CREDENTIALS REDACTED', sql, flags=re.IGNORECASE)
-    
+
     return sql_censored

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -9,6 +9,7 @@ from parsons.utilities.datetime import date_to_timestamp, parse_date
 from parsons.utilities import files
 from parsons.utilities import check_env
 from parsons.utilities import json_format
+from parsons.utilities import sql
 from test.conftest import xfail_value_error
 
 
@@ -126,6 +127,22 @@ def test_remove_empty_keys():
     # Assert that a nested empty string is removed
     test_dict = {'a': '', 'b': 2}
     assert json_format.remove_empty_keys(test_dict) == {'b': 2}
+
+def test_redact_credentials():
+
+    # Test with quotes, escape characters, and line breaks
+    test_str = """COPY schema.tablename
+    FROM 's3://bucket/path/to/file.csv'
+    credentials  'aws_access_key_id=string-\\'escaped-quote;
+    aws_secret_access_key='string-escape-char\\\\'
+    MANIFEST"""
+
+    test_result = """COPY schema.tablename
+    FROM 's3://bucket/path/to/file.csv'
+    CREDENTIALS REDACTED
+    MANIFEST"""
+
+    assert sql.redact_credentials(test_str) == test_result
 
 
 class TestCheckEnv(unittest.TestCase):

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -9,7 +9,7 @@ from parsons.utilities.datetime import date_to_timestamp, parse_date
 from parsons.utilities import files
 from parsons.utilities import check_env
 from parsons.utilities import json_format
-from parsons.utilities import sql
+from parsons.utilities import sql_helpers
 from test.conftest import xfail_value_error
 
 
@@ -143,7 +143,7 @@ def test_redact_credentials():
     CREDENTIALS REDACTED
     MANIFEST"""
 
-    assert sql.redact_credentials(test_str) == test_result
+    assert sql_helpers.redact_credentials(test_str) == test_result
 
 
 class TestCheckEnv(unittest.TestCase):

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -128,6 +128,7 @@ def test_remove_empty_keys():
     test_dict = {'a': '', 'b': 2}
     assert json_format.remove_empty_keys(test_dict) == {'b': 2}
 
+
 def test_redact_credentials():
 
     # Test with quotes, escape characters, and line breaks


### PR DESCRIPTION
Found that this logging was taking place even when the user doesn't supply override credentials. This way, credentials can never be logged.

@cmdelrio @elyse-weiss for visibility