### PR TITLE
Redshift: updated PR for #373 - Add dist/sort keys to upsert

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -737,7 +737,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         return manifest
 
     def upsert(self, table_obj, target_table, primary_key, vacuum=True, distinct_check=True,
-               cleanup_temp_table=True, alter_table=True, from_s3=False, distkey=None, sortkey=None, **copy_args):
+               cleanup_temp_table=True, alter_table=True, from_s3=False, distkey=None,
+               sortkey=None, **copy_args):
         """
         Preform an upsert on an existing table. An upsert is a function in which rows
         in a table are updated and inserted at the same time.
@@ -795,8 +796,6 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         date_stamp = datetime.datetime.now().strftime('%Y%m%d_%H%M')
         # Generate a temp table like "table_tmp_20200210_1230_14212"
         staging_tbl = '{}_stg_{}_{}'.format(target_table, date_stamp, noise)
-
-
 
         if distinct_check:
             primary_keys_statement = ', '.join(primary_keys)

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -780,7 +780,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         # Set distkey and sortkey to argument or primary key. These keys will be used
         # for the staging table and, if it does not already exist, the destination table.
         distkey = distkey or primary_keys[0]
-        sortkey = sortkey or primary_keys
+        sortkey = sortkey or primary_key
 
         if not self.table_exists(target_table):
             logger.info('Target table does not exist. Copying into newly \


### PR DESCRIPTION
This cherry-picks original changes from #373 on top of the latest so it's easier to read. Also implements the original requested changes for handling primary key and sort key lists.