### PR TITLE
F string in logging fix

### DIFF
--- a/parsons/ngpvan/signups.py
+++ b/parsons/ngpvan/signups.py
@@ -121,7 +121,7 @@ class Signups(object):
                   }
 
         r = self.connection.post_request('signups', json=signup)
-        logger.info('Signup {r} created.')
+        logger.info(f'Signup {r} created.')
         return r
 
     def update_signup(self, event_signup_id, shift_id=None, role_id=None, status_id=None,


### PR DESCRIPTION
A very small quick fix! I've been running create_signup a LOT lately and the logging just says "signups INFO Signup {r} created" because it's missing an f.