### PR TITLE
Zoom Webinar Registrant Endpoint Fix

### DIFF
--- a/parsons/zoom/zoom.py
+++ b/parsons/zoom/zoom.py
@@ -214,6 +214,6 @@ class Zoom:
                 See :ref:`parsons-table` for output options.
         """
 
-        tbl = self._get_request(f'report/webinars/{webinar_id}/registrants', 'registrants')
+        tbl = self._get_request(f'webinars/{webinar_id}/registrants', 'registrants')
         logger.info(f'Retrieved {tbl.num_rows} webinar registrants.')
         return tbl

--- a/test/test_zoom.py
+++ b/test/test_zoom.py
@@ -388,5 +388,5 @@ class TestZoom(unittest.TestCase):
             }
         ])
 
-        m.get(ZOOM_URI + 'report/webinars/123/registrants', json=registrants)
+        m.get(ZOOM_URI + 'webinars/123/registrants', json=registrants)
         assert_matching_tables(self.zoom.get_webinar_registrants(123), tbl)


### PR DESCRIPTION
For whatever reason, the path for the end point for retrieving webinar registrants _doesn't_ include `report`, even though the path for retrieving past webinar participants _does_, and [the documentation](https://marketplace.zoom.us/docs/api-reference/zoom-api/webinars/listwebinarparticipants) doesn't suggest any such difference between the two.