### PR TITLE
Update Google Group reference to Slack Group reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ sheets.append_to_sheet(sheet_id, people_with_cell_phones)
 ### Community
 We hope to foster a strong and robust community of individuals who use and contribute to further development. Individuals are encouraged to submit issues with bugs, suggestions and feature requests. [Here](https://github.com/move-coop/parsons/blob/master/CONTRIBUTING.md) are the guidelines and best practices for contributing to Parsons.
 
-You can also stay up to date by joining the [Parsons python google group](https://groups.google.com/forum/#!forum/parsons-python/join).
+You can also stay up to date by joining the Parsons Slack group, an active community of Parsons contributors and progressive data engineers. For an invite, just reach out to engineering+parsons@movementcooperative.org!


### PR DESCRIPTION
We no longer actively use the Parsons Google Group, and our Slack group is where most of the day-to-day conversation about the tool happens. This updates the README to reflect that reality.