### PR TITLE
Don't move columns on Table.fill_column and Table.fillna_column

### DIFF
--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -80,9 +80,11 @@ class ETL(object):
             `Parsons Table` and also updates self
         """
 
-        self.add_column(column_name + '_column_fill_temp', fill_value)
-        self.remove_column(column_name)
-        self.rename_column(column_name + '_column_fill_temp', column_name)
+        if callable(fill_value):
+            self.table = petl.convert(self.table, column_name, lambda _, r: fill_value(r),
+                                      pass_row=True)
+        else:
+            self.table = petl.update(self.table, column_name, fill_value)
 
         return self
 
@@ -94,12 +96,17 @@ class ETL(object):
             column_name: str
                 The column to fill
             fill_value:
-                Fixed value only
+                A fixed or calculated value
         `Returns:`
             `Parsons Table` and also updates self
         """
 
-        self.fill_column(column_name, lambda x: x[column_name] if x[column_name] else fill_value)
+        if callable(fill_value):
+            self.table = petl.convert(self.table, column_name, lambda _, r: fill_value(r),
+                                      where=lambda r: r[column_name] is None, pass_row=True)
+        else:
+            self.table = petl.update(self.table, column_name, fill_value,
+                                     where=lambda r: r[column_name] is None)
 
         return self
 


### PR DESCRIPTION
Fix for [issue 537](https://github.com/move-coop/parsons/issues/537).

The existing `Table.fill_column` and `Table.fillna_column` methods create a temp column with the new value, drop the old column, and then rename the existing column. This results in the "old" column being moved to the end of the table.

I changed both methods to use the petl `convert` and `update` functions to update the column in-place. This has the added benefit of allowing a calculated value to be passed to `Table.fillna_column`, which previously could only handle a fixed value. This does change the API of the function, but only in the case that someone wanted to store a reference to a function object in a Parsons `Table`.

An alternative, less invasive solution would have been to note the index of the old column before it was dropped, and then move the new column to that index. I believe that is not a trivial operation, so I think this solution will be more performant.