### PR TITLE
Quickbase Materialization Intervention

### DIFF
--- a/parsons/quickbase/quickbase.py
+++ b/parsons/quickbase/quickbase.py
@@ -70,6 +70,7 @@ class Quickbase(object):
             for column in resp_tbl.columns:
                 row_dict[column] = row[column]['value']
             cleaned_tbl.concat(Table([row_dict]))
+            cleaned_tbl.materialize
 
         column_resp = req_resp['fields']
         column_map = {}

--- a/parsons/quickbase/quickbase.py
+++ b/parsons/quickbase/quickbase.py
@@ -70,7 +70,7 @@ class Quickbase(object):
             for column in resp_tbl.columns:
                 row_dict[column] = row[column]['value']
             cleaned_tbl.concat(Table([row_dict]))
-            cleaned_tbl.materialize
+            cleaned_tbl.materialize()
 
         column_resp = req_resp['fields']
         column_map = {}


### PR DESCRIPTION
In the Quickbase query_records function, materializes the target table between API calls to avoid issues with lazy loading potentially running afoul of Python recursion depth limits.