### PR TITLE
Updates Sphinx dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,20 @@
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
 workflows:
-  version: 2
+  version: 3
   build:
     jobs:
       - test
+      - docs-build:
+        filters:
+          branches:
+            ignore: master
       - docs-build-deploy:
           filters:
             branches:
               only: master
 
-version: 2
+version: 3
 jobs:
   test:
     docker:
@@ -57,6 +61,35 @@ jobs:
       - store_artifacts:
           path: test-reports
           destination: test-reports
+
+  docs-build:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-python3.7-{{ checksum "./docs/requirements.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-python3.7-
+      - run:
+          name: Install dependencies
+          # Note that we the circleci node image installs stuff with a user "circleci", rather
+          # than root. So we need to tell npm where to install stuff.
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r ./docs/requirements.txt
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-python3.7-{{ checksum "./docs/requirements.txt" }}
+      - run:
+          name: Build docs
+          command: |
+            . venv/bin/activate
+            cd docs/ && make html && cd ..
 
   docs-build-deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,20 +3,20 @@
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
 workflows:
-  version: 3
+  version: 2
   build:
     jobs:
       - test
       - docs-build:
-        filters:
-          branches:
-            ignore: master
+          filters:
+            branches:
+              ignore: master
       - docs-build-deploy:
           filters:
             branches:
               only: master
 
-version: 3
+version: 2
 jobs:
   test:
     docker:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.imgmath',
     'sphinx.ext.viewcode',
-    'm2r'
+    'myst_parser'
 ]
 
 # Sorting of attributes

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -2,4 +2,5 @@
 Contributing to Parsons
 =======================
 
-.. mdinclude:: ../CONTRIBUTING.md
+.. include:: ../CONTRIBUTING.md
+   :parser: myst_parser.sphinx_

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 -r ../requirements.txt
-Sphinx==1.8.3
-sphinx-rtd-theme==0.4.2
-m2r==0.2.1
+Sphinx==4.3.2
+sphinx-rtd-theme==1.0.0
+myst-parser==0.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ censusgeocode==0.4.3.post1
 airtable-python-wrapper==0.13.0
 google-cloud-storage==1.17.0
 google-cloud-bigquery==1.21.0
-docutils<0.15,>=0.10 # Botocore and Sphinx have conflicting needs.
+docutils<0.18,>=0.14
 urllib3==1.26.5
 simplejson==3.16.0
 twilio==6.30.0


### PR DESCRIPTION
This also replaces the problematic markdown parser we were using (see #608) with the recommended extension for parsing markdown in the latest version of Sphinx. 

Also experimenting with adding a new CI job to test building our docs on Pull Request submissions, so we can hopefully catch issues with our docs-builder before stuff gets merged into the main branch. 

closes #608 
