### PR TITLE
Only deploy Parson docs on branches tagged as releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,10 @@ workflows:
               ignore: master
       - docs-build-deploy:
           filters:
+            tags:
+              only: /^v.*/
             branches:
-              only: master
+              ignore: /.*/
 
 version: 2
 jobs:
@@ -132,4 +134,4 @@ jobs:
             git config user.email "ci-build@movementcooperative.org"
             git config user.name "ci-build"
             export PATH=/home/circleci/npm/bin:$PATH
-            gh-pages --dotfiles --dist docs
+            gh-pages --dotfiles --message "[skip ci] Updates" --dist docs


### PR DESCRIPTION
Should also now skip build for the auto-generated gh-pages branch

For more info, see: https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag