### PR TITLE
Redshift: only drop dependent views if they exist

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -526,7 +526,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                                                 varchar_max=varchar_max,
                                                 columntypes=columntypes,
                                                 strict_length=strict_length)
-                    logger.info(f'Create statement: {sql}')
+                    print(f'Create statement: {sql}')
                 self.query_with_connection(sql, connection, commit=False)
                 logger.info(f'{table_name} created.')
 

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -526,7 +526,6 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                                                 varchar_max=varchar_max,
                                                 columntypes=columntypes,
                                                 strict_length=strict_length)
-                    print(f'Create statement: {sql}')
                 self.query_with_connection(sql, connection, commit=False)
                 logger.info(f'{table_name} created.')
 

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -526,6 +526,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
                                                 varchar_max=varchar_max,
                                                 columntypes=columntypes,
                                                 strict_length=strict_length)
+                    logger.info(f'Create statement: {sql}')
                 self.query_with_connection(sql, connection, commit=False)
                 logger.info(f'{table_name} created.')
 

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -920,9 +920,10 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             connection.set_session(autocommit=True)
             tbl = self.query_with_connection(sql_depend, connection)
             dropped_views = [row['table_name'] for row in tbl]
-            sql_drop = "\n".join([f"drop view {view};" for view in dropped_views])
-            tbl = self.query_with_connection(sql_drop, connection)
-            logger.info(f"Dropped the following views: {dropped_views}")
+            if dropped_views:
+                sql_drop = "\n".join([f"drop view {view};" for view in dropped_views])
+                tbl = self.query_with_connection(sql_drop, connection)
+                logger.info(f"Dropped the following views: {dropped_views}")
 
         return tbl
 


### PR DESCRIPTION
Previously, `drop_dependencies_for_cols` would attempt to run an empty query if no dependent views were found, resulting in an error. This commit fixes that bug.