### PR TITLE
Add ActBlue and QuickBase to docs sidebar

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -224,6 +224,7 @@ Indices and tables
    :caption: Integrations
    :name: integrations
 
+   actblue
    action_kit
    action_network
    airtable
@@ -251,11 +252,12 @@ Indices and tables
    ngpvan
    pdi
    p2a
+   quickbase
    redash
    rockthevote
    salesforce
-   shopify
    sftp
+   shopify
    sisense
    targetsmart
    turbovote


### PR DESCRIPTION
Noticed that these didn't actually get linked to sidebar and are currently invisible to users.

Plus I moved shopify to after sftp because that's how the alphabet works.