### PR TITLE
Prototype for modular dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,38 @@ import os
 from setuptools import find_packages
 from distutils.core import setup
 
-THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
 def main():
-    with open(os.path.join(THIS_DIR, 'requirements.txt')) as reqs:
-        requirements = reqs.read().strip().split('\n')
+    limited_deps = os.environ.get("PARSONS_LIMITED_DEPENDENCIES", "")
+    if limited_deps.strip().upper() in ("1", "YES", "TRUE", "ON"):
+        install_requires = [
+            "petl",
+            "python-dateutil",
+            "requests",
+            "simplejson",
+        ]
+        extras_require = {
+            "google": [
+                "google-cloud-bigquery",
+                "google-cloud-storage",
+                "gspread",
+                "oauth2client",
+            ],
+            "ngpvan": [
+                "suds-py3",
+            ],
+        }
+        extras_require["all"] = sorted({
+            lib
+            for libs in extras_require.values()
+            for lib in libs
+        })
+    else:
+        THIS_DIR = os.path.abspath(os.path.dirname(__file__))
+        with open(os.path.join(THIS_DIR, 'requirements.txt')) as reqs:
+            install_requires = reqs.read().strip().split('\n')
+        extras_require = {}
 
     setup(
         name="parsons",
@@ -17,7 +43,8 @@ def main():
         url='https://github.com/movementcoop/parsons',
         keywords=['PROGRESSIVE', 'API', 'ETL'],
         packages=find_packages(),
-        install_requires=requirements,
+        install_requires=install_requires,
+        extras_require=extras_require,
         classifiers=[
             'Development Status :: 3 - Alpha',
             'Intended Audience :: Developers',


### PR DESCRIPTION
For #517 , I wanted to propose a backwards-compatible solution!

Currently, setup.py declares that Parson requires a ton of pinned
dependencies. This is problematic for incorportating Parsons into a
larger code base for a few reasons:
* Extra dependencies increase the attack surface, which is a bad
trade-off if they aren't ever used
* Extra dependencies increase the build size, which, in turn increases
testing and deployment time
* Pinning to specific versions often causes conflicts (dependency hell)

The docs recommend installing parsons separately from the rest of an
app's dependencies, using the "--no-deps" flag, but that doesn't play
well with package locking tools like pipenv and poetry.

This prototype tries to give us a backwards-compatible offramp.
Following the process used in python-slugify 1.x.x, it changes which
dependencies are available at install time, dependending on an
environment variable. So,

```sh
pip install parsons  # retain current behavior
PARSONS_LIMITED_DEPENDENCIES=true pip install parsons  # core dependencies only
PARSONS_LIMITED_DEPENDENCIES=true pip install parsons[ngpvan]  # core + ngpvan(suds)
PARSONS_LIMITED_DEPENDENCIES=true pip install parsons[google,ngpvan]  # core + google + ngpvan
PARSONS_LIMITED_DEPENDENCIES=true pip install parsons[all]  # core + all optional deps
```

In some future, major release we can remove the guard and recommend
`parsons[all]` where appropriate.

This does *not* attempt to find all optional dependencies -- I wanted to
throw the proof of concept up for review first.