### PR TITLE
Update init shortcuts

### DIFF
--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -57,6 +57,7 @@ if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
     from parsons.actblue.actblue import ActBlue
     from parsons.redash.redash import Redash, RedashTimeout, RedashQueryFailed
     from parsons.bluelink import Bluelink, BluelinkPerson, BluelinkIdentifier, BluelinkEmail
+    from parsons.braintree.braintree import Braintree
 
     __all__ = [
         'VAN',

--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -55,6 +55,7 @@ if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
     from parsons.alchemer.alchemer import SurveyGizmo, Alchemer
     from parsons.quickbase.quickbase import Quickbase
     from parsons.actblue.actblue import ActBlue
+    from parsons.redash.redash import Redash, RedashTimeout, RedashQueryFailed
 
     __all__ = [
         'VAN',

--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -56,6 +56,7 @@ if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
     from parsons.quickbase.quickbase import Quickbase
     from parsons.actblue.actblue import ActBlue
     from parsons.redash.redash import Redash, RedashTimeout, RedashQueryFailed
+    from parsons.bluelink import Bluelink, BluelinkPerson, BluelinkIdentifier, BluelinkEmail
 
     __all__ = [
         'VAN',

--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -51,6 +51,7 @@ if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
     from parsons.bloomerang.bloomerang import Bloomerang
     from parsons.box.box import Box
     from parsons.sisense.sisense import Sisense
+    from parsons.shopify.shopify import Shopify
     from parsons.alchemer.alchemer import SurveyGizmo, Alchemer
     from parsons.quickbase.quickbase import Quickbase
     from parsons.actblue.actblue import ActBlue
@@ -99,6 +100,7 @@ if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
         'Bloomerang',
         'Box',
         'Sisense',
+        'Shopify',
         'SurveyGizmo',
         'Alchemer',
         'Quickbase',

--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -17,6 +17,9 @@ if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
     from parsons.civis.civisclient import CivisClient
     from parsons.etl.table import Table
     from parsons.notifications.gmail import Gmail
+    from parsons.notifications.slack import Slack
+    from parsons.notifications.sendmail import SendMail
+    from parsons.notifications.smtp import SMTP
     from parsons.google.google_civic import GoogleCivic
     from parsons.google.google_sheets import GoogleSheets
     from parsons.google.google_cloud_storage import GoogleCloudStorage
@@ -24,7 +27,6 @@ if not os.environ.get('PARSONS_SKIP_IMPORT_ALL'):
     from parsons.phone2action.p2a import Phone2Action
     from parsons.mobilize_america.ma import MobilizeAmerica
     from parsons.facebook_ads.facebook_ads import FacebookAds
-    from parsons.notifications.slack import Slack
     from parsons.turbovote.turbovote import TurboVote
     from parsons.sftp.sftp import SFTP
     from parsons.action_kit.action_kit import ActionKit

--- a/parsons/shopify/shopify.py
+++ b/parsons/shopify/shopify.py
@@ -170,10 +170,12 @@ class Shopify(object):
                       query_date=None, since_id=None, completed=True):
         """
         Fast classmethod so you can get the data all at once:
-        tabledata = Shopify.load_to_table(subdomain='myorg', password='abc123',
-                                         api_key='abc123', api_version='2020-10',
-                                         query_date='2020-10-20', since_id='8414',
-                                         completed=True)
+
+            tabledata = Shopify.load_to_table(subdomain='myorg', password='abc123',
+                                            api_key='abc123', api_version='2020-10',
+                                            query_date='2020-10-20', since_id='8414',
+                                            completed=True)
+
         This instantiates the class and makes the appropriate query type to Shopify's orders
         table based on which arguments are supplied.
 

--- a/test/test_action_kit.py
+++ b/test/test_action_kit.py
@@ -2,8 +2,7 @@ import json
 import os
 import unittest
 from unittest import mock
-from parsons.action_kit.action_kit import ActionKit
-from parsons.etl.table import Table
+from parsons import ActionKit, Table
 
 from test.utils import assert_matching_tables
 

--- a/test/test_airtable/test_airtable.py
+++ b/test/test_airtable/test_airtable.py
@@ -1,8 +1,7 @@
 import unittest
 import os
 import requests_mock
-from parsons.airtable import Airtable
-from parsons.etl import Table
+from parsons import Airtable, Table
 from test.utils import assert_matching_tables
 from airtable_responses import insert_response, insert_responses, \
     records_response, records_response_with_more_columns

--- a/test/test_alchemer/test_getresponses.py
+++ b/test/test_alchemer/test_getresponses.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 import unittest.mock as mock
-from parsons.alchemer.alchemer import Alchemer
+from parsons import Alchemer
 import logging
 
 logger = logging.getLogger(__name__)

--- a/test/test_alchemer/test_getsurveys.py
+++ b/test/test_alchemer/test_getsurveys.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 import unittest.mock as mock
-from parsons.alchemer.alchemer import Alchemer
+from parsons import Alchemer
 import logging
 
 logger = logging.getLogger(__name__)

--- a/test/test_aws_async.py
+++ b/test/test_aws_async.py
@@ -1,7 +1,7 @@
 import unittest
 from test.utils import assert_matching_tables
 
-from parsons.etl.table import Table
+from parsons import Table
 from parsons.aws.aws_async import import_and_get_task, get_func_task_path
 from parsons.aws.lambda_distribute import distribute_task
 

--- a/test/test_azure/test_azure_blob_storage.py
+++ b/test/test_azure/test_azure_blob_storage.py
@@ -5,8 +5,7 @@ from urllib.parse import parse_qs, urlparse
 
 from azure.storage.blob import BlobClient, ContainerClient
 
-from parsons.azure import AzureBlobStorage
-from parsons.etl import Table
+from parsons import AzureBlobStorage, Table
 from parsons.utilities import files
 
 

--- a/test/test_bloomerang/test_bloomerang.py
+++ b/test/test_bloomerang/test_bloomerang.py
@@ -3,8 +3,7 @@ import unittest
 import requests_mock
 from unittest import mock
 from test.utils import assert_matching_tables
-from parsons.bloomerang.bloomerang import Bloomerang
-from parsons.etl import Table
+from parsons import Bloomerang, Table
 
 from test.test_bloomerang.test_data import ENV_PARAMETERS, ID, TEST_DELETE, \
     TEST_CREATE_CONSTITUENT, TEST_GET_CONSTITUENT, TEST_GET_CONSTITUENTS, \

--- a/test/test_bluelink/test_bluelink.py
+++ b/test/test_bluelink/test_bluelink.py
@@ -1,7 +1,6 @@
 import unittest
 import requests_mock
-from parsons import Table
-from parsons.bluelink import Bluelink, BluelinkPerson, BluelinkIdentifier, BluelinkEmail
+from parsons import Table, Bluelink, BluelinkPerson, BluelinkIdentifier, BluelinkEmail
 
 
 class TestBluelink(unittest.TestCase):

--- a/test/test_box/test_box_storage.py
+++ b/test/test_box/test_box_storage.py
@@ -7,8 +7,7 @@ import warnings
 
 from boxsdk.exception import BoxAPIException, BoxOAuthException
 
-from parsons.box import Box
-from parsons.etl import Table
+from parsons import Box, Table
 
 """Prior to running, you should ensure that the relevant environment
 variables have been set, e.g. via

--- a/test/test_braintree/test_braintree.py
+++ b/test/test_braintree/test_braintree.py
@@ -5,8 +5,7 @@ import unittest
 import requests_mock
 from test.utils import assert_matching_tables
 
-from parsons.etl.table import Table
-from parsons.braintree.braintree import Braintree
+from parsons import Table, Braintree
 
 _dir = os.path.dirname(__file__)
 

--- a/test/test_civis.py
+++ b/test/test_civis.py
@@ -1,7 +1,6 @@
 import unittest
 import os
-from parsons.civis import CivisClient
-from parsons.etl.table import Table
+from parsons import CivisClient, Table
 
 # from . import scratch_creds
 

--- a/test/test_controlshift/test_controlshift.py
+++ b/test/test_controlshift/test_controlshift.py
@@ -1,7 +1,7 @@
 import requests_mock
 from unittest import TestCase
 from test.utils import mark_live_test, validate_list
-from parsons.controlshift.controlshift import Controlshift
+from parsons import Controlshift
 from test.test_controlshift import test_cs_data as test_data  # type: ignore
 
 

--- a/test/test_copper/test_copper.py
+++ b/test/test_copper/test_copper.py
@@ -3,8 +3,7 @@ import os
 import json
 import requests_mock
 import sys
-from parsons.copper import Copper
-from parsons.etl import Table
+from parsons import Copper, Table
 from test.utils import assert_matching_tables
 import logging
 

--- a/test/test_crowdtangle/test_crowdtangle.py
+++ b/test/test_crowdtangle/test_crowdtangle.py
@@ -4,8 +4,7 @@ from test.utils import assert_matching_tables
 from test.test_crowdtangle.post import expected_posts
 from test.test_crowdtangle.leaderboard import expected_leaderboard
 from test.test_crowdtangle.link_post import expected_post
-from parsons.crowdtangle import CrowdTangle
-from parsons.etl import Table
+from parsons import CrowdTangle, Table
 
 CT_API_KEY = 'FAKE_KEY'
 

--- a/test/test_databases/test_mysql.py
+++ b/test/test_databases/test_mysql.py
@@ -1,6 +1,5 @@
-from parsons.databases.mysql.mysql import MySQL
+from parsons import MySQL, Table
 from parsons.databases.mysql.create_table import MySQLCreateTable
-from parsons.etl.table import Table
 from test.utils import assert_matching_tables
 import unittest
 import os

--- a/test/test_databases/test_postgres.py
+++ b/test/test_databases/test_postgres.py
@@ -1,5 +1,4 @@
-from parsons.databases.postgres import Postgres
-from parsons.etl.table import Table
+from parsons import Postgres, Table
 from test.utils import assert_matching_tables
 import unittest
 import os

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -1,10 +1,12 @@
 import unittest
 import petl
-from parsons.etl.table import Table
 import os
 import shutil
+
+from parsons import Table
 from test.utils import assert_matching_tables
 from parsons.utilities import zip_archive
+
 
 # Notes :
 # - The `Table.to_postgres()` test is housed in the Postgres tests

--- a/test/test_facebook_ads.py
+++ b/test/test_facebook_ads.py
@@ -1,8 +1,8 @@
 import unittest
 import os
 
-from parsons.facebook_ads.facebook_ads import FacebookAds
-from parsons.etl.table import Table
+from parsons import FacebookAds, Table
+
 
 users_table = Table([
     {"first": "Bob", "middle": "J", "last": "Smith", "phone": "1234567890", "cell": None,

--- a/test/test_freshdesk/test_freshdesk.py
+++ b/test/test_freshdesk/test_freshdesk.py
@@ -1,4 +1,4 @@
-from parsons.freshdesk.freshdesk import Freshdesk
+from parsons import Freshdesk
 import unittest
 import requests_mock
 from test.test_freshdesk import expected_json

--- a/test/test_geocoder/test_census_geocoder.py
+++ b/test/test_geocoder/test_census_geocoder.py
@@ -1,8 +1,7 @@
 import unittest
 import os
 from unittest import mock
-from parsons.etl import Table
-from parsons.geocode import CensusGeocoder
+from parsons import Table, CensusGeocoder
 import petl
 from test_responses import geographies_resp, locations_resp, batch_resp, coord_resp
 from test.utils import assert_matching_tables

--- a/test/test_github/test_github.py
+++ b/test/test_github/test_github.py
@@ -3,10 +3,10 @@ import unittest
 from unittest.mock import patch
 
 import requests_mock
+from parsons import Table, GitHub
 from github.GithubException import UnknownObjectException
+from parsons.github.github import ParsonsGitHubError
 
-from parsons.etl.table import Table
-from parsons.github.github import GitHub, ParsonsGitHubError
 
 _dir = os.path.dirname(__file__)
 

--- a/test/test_gmail/test_gmail.py
+++ b/test/test_gmail/test_gmail.py
@@ -1,4 +1,4 @@
-from parsons.notifications.gmail import Gmail
+from parsons import Gmail
 import json
 import os
 import requests_mock

--- a/test/test_google/test_google_bigquery.py
+++ b/test/test_google/test_google_bigquery.py
@@ -3,8 +3,7 @@ import unittest
 import unittest.mock as mock
 from google.cloud import bigquery
 from google.cloud import exceptions
-from parsons.google.google_bigquery import GoogleBigQuery
-from parsons.etl import Table
+from parsons import GoogleBigQuery, Table
 
 
 class TestGoogleBigQuery(unittest.TestCase):

--- a/test/test_google/test_google_cloud_storage.py
+++ b/test/test_google/test_google_cloud_storage.py
@@ -1,6 +1,5 @@
 import unittest
-from parsons.google.google_cloud_storage import GoogleCloudStorage
-from parsons.etl import Table
+from parsons import GoogleCloudStorage, Table
 from test.utils import assert_matching_tables
 from parsons.utilities import files
 from google.cloud import storage

--- a/test/test_google/test_google_sheets.py
+++ b/test/test_google/test_google_sheets.py
@@ -2,8 +2,7 @@ import unittest
 import gspread
 import os
 
-from parsons.google.google_sheets import GoogleSheets
-from parsons.etl.table import Table
+from parsons import GoogleSheets, Table
 from test.utils import assert_matching_tables
 
 

--- a/test/test_google/test_googlecivic.py
+++ b/test/test_google/test_googlecivic.py
@@ -1,7 +1,6 @@
 import unittest
 import requests_mock
-from parsons.etl import Table
-from parsons.google.google_civic import GoogleCivic
+from parsons import Table, GoogleCivic
 from googlecivic_responses import elections_resp, voterinfo_resp, polling_data
 from test.utils import assert_matching_tables
 

--- a/test/test_hustle/test_hustle.py
+++ b/test/test_hustle/test_hustle.py
@@ -2,8 +2,7 @@ import unittest
 import requests_mock
 from test.utils import assert_matching_tables
 from test.test_hustle import expected_json
-from parsons.etl import Table
-from parsons.hustle import Hustle
+from parsons import Table, Hustle
 from parsons.hustle.hustle import HUSTLE_URI
 
 CLIENT_ID = 'FAKE_ID'

--- a/test/test_mailchimp/test_mailchimp.py
+++ b/test/test_mailchimp/test_mailchimp.py
@@ -1,4 +1,4 @@
-from parsons.mailchimp.mailchimp import Mailchimp
+from parsons import Mailchimp
 import unittest
 import requests_mock
 from test.test_mailchimp import expected_json

--- a/test/test_mobilize_america.py
+++ b/test/test_mobilize_america.py
@@ -1,6 +1,6 @@
 import unittest
 import requests_mock
-from parsons.mobilize_america import MobilizeAmerica
+from parsons import MobilizeAmerica
 from test.utils import validate_list
 
 

--- a/test/test_newmode/test_newmode.py
+++ b/test/test_newmode/test_newmode.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 import unittest.mock as mock
-from parsons.newmode import Newmode
+from parsons import Newmode
 
 
 class TestNewmode(unittest.TestCase):

--- a/test/test_p2a.py
+++ b/test/test_p2a.py
@@ -1,9 +1,10 @@
 import unittest
 import requests_mock
 from test.utils import validate_list
-from parsons.phone2action import Phone2Action
+from parsons import Phone2Action
 import os
 import copy
+
 
 adv_json = {
     "data": [

--- a/test/test_quickbase/test_quickbase.py
+++ b/test/test_quickbase/test_quickbase.py
@@ -1,7 +1,7 @@
-from parsons.quickbase.quickbase import Quickbase
-from test.test_quickbase import test_data
 import unittest
 import requests_mock
+from parsons import Quickbase
+from test.test_quickbase import test_data
 
 
 class TestQuickbase(unittest.TestCase):

--- a/test/test_redash.py
+++ b/test/test_redash.py
@@ -2,9 +2,8 @@ import os
 import unittest
 import requests_mock
 from test.utils import assert_matching_tables
+from parsons import Table, Redash, RedashTimeout
 
-from parsons.etl.table import Table
-from parsons.redash.redash import Redash, RedashTimeout
 
 BASE_URL = 'https://redash.example.com'
 API_KEY = 'abc123'

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -1,6 +1,4 @@
-from parsons.databases.redshift import Redshift
-from parsons.aws import S3
-from parsons.etl.table import Table
+from parsons import Redshift, S3, Table
 from test.utils import assert_matching_tables
 import unittest
 import os

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -2,8 +2,7 @@ import unittest
 import os
 from datetime import datetime
 import pytz
-from parsons.aws.s3 import S3
-from parsons.etl.table import Table
+from parsons import S3, Table
 import urllib
 import time
 from test.utils import assert_matching_tables

--- a/test/test_salesforce/test_salesforce.py
+++ b/test/test_salesforce/test_salesforce.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 import unittest.mock as mock
-from parsons.salesforce.salesforce import Salesforce, Table
+from parsons import Salesforce, Table
 
 
 class TestSalesforce(unittest.TestCase):

--- a/test/test_sftp.py
+++ b/test/test_sftp.py
@@ -4,8 +4,7 @@ import paramiko
 from contextlib import contextmanager
 from copy import deepcopy
 from unittest.mock import MagicMock, patch, call
-from parsons.etl import Table
-from parsons.sftp import SFTP
+from parsons import Table, SFTP
 from parsons.utilities import files as file_util
 from test.utils import mark_live_test, assert_matching_tables
 from test.fixtures import simple_table, simple_csv_path, simple_compressed_csv_path  # noqa; F401

--- a/test/test_sftp_ssh.py
+++ b/test/test_sftp_ssh.py
@@ -1,7 +1,6 @@
 import pytest
 import os
-from parsons.etl import Table
-from parsons.sftp import SFTP
+from parsons import Table, SFTP
 from parsons.utilities import files
 from test.utils import mark_live_test, assert_matching_tables
 from test.fixtures import simple_table, simple_csv_path, simple_compressed_csv_path  # noqa: F401

--- a/test/test_shopify.py
+++ b/test/test_shopify.py
@@ -1,5 +1,4 @@
-from parsons.etl.table import Table
-from parsons.shopify.shopify import Shopify
+from parsons import Table, Shopify
 from test.utils import assert_matching_tables
 import requests_mock
 import unittest

--- a/test/test_sisense/test_sisense.py
+++ b/test/test_sisense/test_sisense.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from unittest import mock
 import requests_mock
-from parsons.sisense.sisense import Sisense
+from parsons import Sisense
 
 from test.test_sisense.test_data import ENV_PARAMETERS, \
     TEST_PUBLISH_SHARED_DASHBOARD, TEST_LIST_SHARED_DASHBOARDS, TEST_DELETE_SHARED_DASHBOARD

--- a/test/test_slack/test_slack.py
+++ b/test/test_slack/test_slack.py
@@ -1,5 +1,4 @@
-from parsons.etl import Table
-from parsons.notifications.slack import Slack
+from parsons import Table, Slack
 
 from slackclient.exceptions import SlackClientError
 

--- a/test/test_smtp.py
+++ b/test/test_smtp.py
@@ -1,4 +1,4 @@
-from parsons.notifications.smtp import SMTP
+from parsons import SMTP
 import base64
 import io
 import re

--- a/test/test_targetsmart/test_targetsmart_api.py
+++ b/test/test_targetsmart/test_targetsmart_api.py
@@ -1,7 +1,6 @@
 import unittest
 import requests_mock
-from parsons.targetsmart.targetsmart_api import TargetSmartAPI
-from parsons.etl.table import Table
+from parsons import TargetSmartAPI, Table
 from test.utils import validate_list
 from test.responses.ts_responses import (
     address_response, district_point, district_expected, district_zip, zip_expected,

--- a/test/test_targetsmart/test_targetsmart_automation.py
+++ b/test/test_targetsmart/test_targetsmart_automation.py
@@ -1,5 +1,4 @@
-from parsons.targetsmart.targetsmart_automation import TargetSmartAutomation
-from parsons.sftp import SFTP
+from parsons import TargetSmartAutomation, SFTP
 import unittest
 from test.utils import mark_live_test
 import os

--- a/test/test_turbovote/test_turbovote.py
+++ b/test/test_turbovote/test_turbovote.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import requests_mock
-from parsons.turbovote import TurboVote
+from parsons import TurboVote
 from test.utils import validate_list
 
 _dir = os.path.dirname(__file__)

--- a/test/test_twilio/test_twilio.py
+++ b/test/test_twilio/test_twilio.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 import unittest.mock as mock
-from parsons.twilio.twilio import Twilio
+from parsons import Twilio
 
 
 class TestTwilio(unittest.TestCase):

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -4,7 +4,7 @@ import pytest
 import shutil
 import datetime
 from unittest import mock
-from parsons.etl.table import Table
+from parsons import Table
 from parsons.utilities.datetime import date_to_timestamp, parse_date
 from parsons.utilities import files
 from parsons.utilities import check_env

--- a/test/test_van/test_activist_codes.py
+++ b/test/test_van/test_activist_codes.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import requests_mock
-from parsons.ngpvan import VAN
+from parsons import VAN
 from test.utils import validate_list
 
 os.environ['VAN_API_KEY'] = 'SOME_KEY'

--- a/test/test_van/test_bulkimport.py
+++ b/test/test_van/test_bulkimport.py
@@ -2,8 +2,7 @@ import unittest
 import os
 import requests_mock
 import unittest.mock as mock
-from parsons.ngpvan.van import VAN
-from parsons.etl.table import Table
+from parsons import VAN, Table
 from test.utils import assert_matching_tables
 from parsons.utilities import cloud_storage
 

--- a/test/test_van/test_changed_entities.py
+++ b/test/test_van/test_changed_entities.py
@@ -2,8 +2,7 @@ import unittest
 import os
 import requests_mock
 import unittest.mock as mock
-from parsons.ngpvan.van import VAN
-from parsons.etl.table import Table
+from parsons import VAN, Table
 from test.utils import assert_matching_tables
 
 

--- a/test/test_van/test_codes.py
+++ b/test/test_van/test_codes.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import requests_mock
-from parsons.ngpvan.van import VAN
+from parsons import VAN
 from test.utils import assert_matching_tables
 from requests.exceptions import HTTPError
 

--- a/test/test_van/test_custom_fields.py
+++ b/test/test_van/test_custom_fields.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import requests_mock
-from parsons.ngpvan.van import VAN
+from parsons import VAN
 from test.utils import assert_matching_tables
 
 

--- a/test/test_van/test_events.py
+++ b/test/test_van/test_events.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import requests_mock
-from parsons.ngpvan.van import VAN
+from parsons import VAN
 from test.utils import validate_list
 
 

--- a/test/test_van/test_locations.py
+++ b/test/test_van/test_locations.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import requests_mock
-from parsons.ngpvan.van import VAN
+from parsons import VAN
 from test.utils import validate_list
 from requests.exceptions import HTTPError
 

--- a/test/test_van/test_ngpvan.py
+++ b/test/test_van/test_ngpvan.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 import requests_mock
-from parsons.ngpvan.van import VAN
-from parsons.etl.table import Table
+from parsons import VAN, Table
 from test.utils import validate_list, assert_matching_tables
 from requests.exceptions import HTTPError
 

--- a/test/test_van/test_people.py
+++ b/test/test_van/test_people.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import requests_mock
-from parsons.ngpvan.van import VAN
+from parsons import VAN
 from requests.exceptions import HTTPError
 from test.test_van.responses_people import find_people_response, get_person_response
 

--- a/test/test_van/test_saved_lists.py
+++ b/test/test_van/test_saved_lists.py
@@ -2,8 +2,7 @@ import unittest
 import os
 import requests_mock
 import unittest.mock as mock
-from parsons.ngpvan.van import VAN
-from parsons.etl.table import Table
+from parsons import VAN, Table
 from test.utils import validate_list
 from parsons.utilities import cloud_storage
 

--- a/test/test_van/test_scores.py
+++ b/test/test_van/test_scores.py
@@ -2,8 +2,7 @@ import unittest
 import os
 import requests_mock
 import unittest.mock as mock
-from parsons.ngpvan.van import VAN
-from parsons.etl.table import Table
+from parsons import VAN, Table
 from test.utils import validate_list
 from parsons.utilities import cloud_storage
 

--- a/test/test_van/test_signups.py
+++ b/test/test_van/test_signups.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import requests_mock
-from parsons.ngpvan.van import VAN
+from parsons import VAN
 from test.utils import validate_list
 
 signup_status = [{'statusId': 5, 'name': 'Cancelled'},

--- a/test/test_van/test_targets.py
+++ b/test/test_van/test_targets.py
@@ -1,8 +1,7 @@
 import unittest
 import os
 import requests_mock
-from parsons.ngpvan import VAN
-from parsons.etl.table import Table
+from parsons import VAN, Table
 from test.utils import validate_list, assert_matching_tables
 
 os.environ['VAN_API_KEY'] = 'SOME_KEY'

--- a/test/test_zoom.py
+++ b/test/test_zoom.py
@@ -2,8 +2,7 @@ import unittest
 import requests_mock
 from test.utils import assert_matching_tables
 
-from parsons.etl.table import Table
-from parsons.zoom.zoom import Zoom
+from parsons import Table, Zoom
 
 API_KEY = 'fake_api_key'
 API_SECRET = 'fake_api_secret'


### PR DESCRIPTION
When attempting to do a docs update I ran into an error with the Shopify connector, which wasn't added to the handy `__init__.py` shortcut. In the contrib meeting we talked about updating the tests to always reference the shortcut so we can more easily catch when we've forgotten to add connectors to it. This PR:

- updates all the tests to import directly from Parsons, ie `from parsons import Shopify` instead of `from parsons.shopify.shopify import Shopify`
- adds missing connectors to __init__.py - in addition to Shopify we were also missing Redash, Braintree, Bluelink, SMTP and Sendmail

I'm not entirely sure SMTP and Sendmail are actively used/maintained - it looks like Sendmail doesn't have tests and neither have docs. But I added them anyway.