### PR TITLE
misc connector docs updates

### DIFF
--- a/docs/airtable.rst
+++ b/docs/airtable.rst
@@ -5,10 +5,10 @@ Airtable
 Overview
 ********
 
-The Airtable class allows you to interact with an `Airtable <https://airtable.com/>`_. base. In order to use this class
+The Airtable class allows you to interact with an `Airtable <https://airtable.com/>`_ base. In order to use this class
 you must generate an Airtable API Key which can be found in your Airtable `account settings <https://airtable.com/account>`_.
 
-.. note:: 
+.. note::
    Finding The Base Key
    	The easiest place to find the ``base_key`` for the base that you wish to interact with is via the Airtable API documentation.
     * Go to the `Airtable API Base List <https://airtable.com/api>`_ and select the base.

--- a/docs/bluelink.rst
+++ b/docs/bluelink.rst
@@ -5,22 +5,13 @@ Bluelink
 Overview
 ********
 
-`Bluelink <https://bluelink.org/>`_ is an online tool for connecting the various `digital software tools <https://https://bluelink.org/product/#integrations>`_
-used by campaigns and movement groups in the political and non-profit space to allow you to seamlessly and easily sync data between them.
-This integration currently supports sending your structured person data and related tags to Bluelink via the
-`Bluelink Webhook API <https://bluelinkdata.github.io/docs/BluelinkApiGuide#webhook>`_, after which you can use our UI to send to any of our
-`supported tools <https://bluelink.org/product/#integrations>`_. If you don't see a tool you would like to connect to, please reach out at
-hello@bluelink.org to ask us to add it.
-
-
+`Bluelink <https://bluelink.org/>`_ is an online tool for connecting various `digital software tools <https://https://bluelink.org/product/#integrations>`_ used by campaigns and movement groups in the political and non-profit space so you can sync data between them. This integration currently supports sending your structured person data and related tags to Bluelink via the `Bluelink Webhook API <https://bluelinkdata.github.io/docs/BluelinkApiGuide#webhook>`_, after which you can use Bluelink's UI to send to any of their `supported tools <https://bluelink.org/product/#integrations>`_. If you don't see a tool you would like to connect to, please reach out at hello@bluelink.org to ask them to add it.
 
 .. note::
    Authentication
-      If you don't have a Bluelink account please complete the `form <https://bluelink.org/#form>`_ on our website or email us at hello@bluelink.org.
-      To get connection credentials select or ask an account administrator to select `Bluelink Webhook <https://app.bluelink.org/bluelink-webhook-integration>`_
-      from the apps menu. The credentials are automatically embedded into a one time secret link in case they need to be sent to you.
-      Open the link to access the user and password, that you will then either pass directly to the Bluelink connector as arguments, 
-      or set them as environment variables.
+      If you don't have a Bluelink account please complete the `form <https://bluelink.org/#form>`_ on the Bluelink website or email them at hello@bluelink.org. To get connection credentials select `Bluelink Webhook <https://app.bluelink.org/bluelink-webhook-integration>`_ from the apps menu. If you don't see this option, you may need to ask an account administrator to do this step for you.
+
+      The credentials are automatically embedded into a one time secret link in case they need to be sent to you. Open the link to access the user and password.
 
 ==========
 Quickstart

--- a/docs/build_a_connector.rst
+++ b/docs/build_a_connector.rst
@@ -238,7 +238,7 @@ The method can return more than one record, so the results of the call to the AP
 Sandbox Access
 --------------
 
-When developing a Parsons connector, it's helpful to be able to test your changes against a non-production account. We have set up test accounts with some vendors which you can use for testing by following the steps below.
+When developing a Parsons connector, it's helpful to be able to test your changes against a non-production account. We have set up test accounts with some vendors which you can use for testing by following the steps below. We also maintain :ref:`a list of vendors with free accounts<create-sandbox>` that you can use as sandboxes.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Accessing and Using Credentials
@@ -285,7 +285,13 @@ Since the sandbox accounts are shared with multiple people, we ask contributors 
 Connector-Specific Guidance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+##################
+API Keys Available
+##################
+
 The following connectors have sandbox API keys available. Some connectors have specific best practices or additional information to send along when you request the key from us.
+
+**ActionKit**: No additional information needed, but please be mindful that this sandbox is shared across many organizations, not just Parsons-affiliated organizations. Be extra careful not to modify existing data.
 
 **ActionNetwork**: In order to access the ActionNetwork sandbox account, we’ll need the email address associated with your ActionNetwork account. Please make an ActionNetwork account if you don’t have one already, and include the associated email in your access request to us.
 
@@ -296,6 +302,24 @@ The following connectors have sandbox API keys available. Some connectors have s
 **Mobilize**:  No connector-specific guidance.
 
 **Strive**:  No connector-specific guidance.
+
+.. _create-sandbox:
+
+#######################
+Create Your Own Sandbox
+#######################
+
+The following connectors are confirmed to have free accounts which can be used to make sandboxes.
+
+**Airtable**: You can create `free accounts <https://support.airtable.com/hc/en-us/articles/115010928147-Airtable-plans#1>`_ on the Airtable website.
+
+**Braintree**: You can create `free sandbox accounts <https://www.braintreepayments.com/sandbox>`_ on the Braintree website.
+
+**Github**: You can create `free accounts <https://github.com/pricing#compare-features>`_ on the Github website.
+
+**Salesforce**: You can create `free developer accounts <https://developer.salesforce.com/signup>`_ directly on the Salesforce website, which you can use to `create a sandbox <https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs.htm>`_.
+
+**Twilio**: You can create a `free account <https://www.twilio.com/pricing>`_ on the Twilio website which gets you access to their `test credentials <https://www.twilio.com/docs/iam/test-credentials>`_.
 
 ------------
 Finishing up
@@ -351,7 +375,7 @@ Adding automated tests
         def test_get_things(self, m):
 
             # Test that campaigns are returned correctly.
-            m.get(‘http://yourconnector.com/v1/things’, json=[])
+            m.get('http://yourconnector.com/v1/things', json=[])
             yc = YourConnector()
             tbl = yc.get_things()
 


### PR DESCRIPTION
- add ActionKit to list of connectors we have a sandbox with credentials for
- create new section for connectors that have create-your-own sandbox options
- add Airtable, Braintree, Github, Salesforce and Twilio to new section
- update Bluelink intro to be in third person and more in line with other connector intros
- fix typo in airtable intro