### PR TITLE
Multiversion docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
           name: Build docs
           command: |
             . venv/bin/activate
-            cd docs/ && make html && cd ..
+            cd docs/ && ./deploy_docs.sh && cd ..
 
   docs-build-deploy:
     docker:
@@ -130,7 +130,7 @@ jobs:
           # that start with an underscore like _static/).
           command: |
             . venv/bin/activate
-            cd docs/ && make html && cd ..
+            cd docs/ && ./deploy_docs.sh && cd ..
             git config user.email "ci-build@movementcooperative.org"
             git config user.name "ci-build"
             export PATH=/home/circleci/npm/bin:$PATH

--- a/docs/_templates/versioning.html
+++ b/docs/_templates/versioning.html
@@ -1,0 +1,8 @@
+{% if versions %}
+<h3>{{ _('Versions') }}</h3>
+<ul>
+  {%- for item in versions %}
+  <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+  {%- endfor %}
+</ul>
+{% endif %}

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,0 +1,29 @@
+{% if display_versions_lower_left %}
+  <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="{{ _('Versions') }}">
+    <span class="rst-current-version" data-toggle="rst-current-version">
+      <span class="fa fa-book"> Read the Docs</span>
+      {{ current_version.name }}
+      <span class="fa fa-caret-down"></span>
+    </span>
+    <div class="rst-other-versions">
+      <dl>
+        <dt>{{ _('Most Common') }}</dt>
+        <!-- Show latest & stable first -->
+        {% for version in versions %}
+            {% if version.name|first != "v" %}
+                  <dd><a href="{{ version.url }}">{{ version.name }}</a></dd>
+            {% endif %}
+        {% endfor %}
+
+        <dt>{{ _('By Version Number') }}</dt>
+        <!-- Show other versions -->
+        {% for version in versions %}
+            {% if version.name|first == "v" %}
+                  <dd><a href="{{ version.url }}">{{ version.name }}</a></dd>
+            {% endif %}
+        {% endfor %}
+
+      </dl>
+    </div>
+  </div>
+{% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,8 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.imgmath',
     'sphinx.ext.viewcode',
-    'myst_parser'
+    'myst_parser',
+    'sphinx_multiversion',
 ]
 
 # Sorting of attributes
@@ -89,7 +90,9 @@ html_theme = 'sphinx_rtd_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'display_version': True,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -104,7 +107,11 @@ html_static_path = ['_static']
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
 #
-# html_sidebars = {}
+html_sidebars = {
+    '**': [
+        'versioning.html',
+    ],
+}
 
 
 # -- Options for HTMLHelp output ---------------------------------------------
@@ -165,3 +172,17 @@ texinfo_documents = [
 
 
 # -- Extension configuration -------------------------------------------------
+
+# sphinx-multiversion overrides
+
+# # Whitelist pattern for tags (set to None to ignore all tags)
+# smv_tag_whitelist = None  # don't use tags to generate docs
+
+# Whitelist pattern for branches (set to None to ignore all branches)
+smv_branch_whitelist = r'^master|main$'  # creates version for latest master/main branch
+
+# # Pattern for released versions
+# smv_released_pattern = r'^tags/v\d\.$'  # matches tags starting with v0.x v1.x etc (will break at v10.x)
+
+# Pattern for released versions
+smv_tag_whitelist = r'^tags/v\d\.$'  # matches tags starting with v0.x v1.x etc (will break at v10.x)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,10 +108,15 @@ html_static_path = ['_static']
 # 'searchbox.html']``.
 #
 html_sidebars = {
-    '**': [
-        'versioning.html',
-    ],
+    '**': [ 'versions.html']
 }
+
+try:
+    html_context
+except NameError:
+    html_context = dict()
+
+html_context['display_versions_lower_left'] = True
 
 
 # -- Options for HTMLHelp output ---------------------------------------------
@@ -175,14 +180,11 @@ texinfo_documents = [
 
 # sphinx-multiversion overrides
 
-# # Whitelist pattern for tags (set to None to ignore all tags)
-# smv_tag_whitelist = None  # don't use tags to generate docs
+# TODO: define elsewhere and import?
+DOCUMENTED_VERSIONS = ["v0.18.1", "v0.18.0", "v0.17.0", "v0.16.0", "v0.15.0", "v0.14.0"]
 
-# Whitelist pattern for branches (set to None to ignore all branches)
+# Whitelist pattern for branches
 smv_branch_whitelist = r'^master|main$'  # creates version for latest master/main branch
 
-# # Pattern for released versions
-# smv_released_pattern = r'^tags/v\d\.$'  # matches tags starting with v0.x v1.x etc (will break at v10.x)
-
-# Pattern for released versions
-smv_tag_whitelist = r'^tags/v\d\.$'  # matches tags starting with v0.x v1.x etc (will break at v10.x)
+# Get tags to whitelist from DOCUMENTED_VERSIONS const
+smv_tag_whitelist = "|".join(["^" + version + "$" for version in DOCUMENTED_VERSIONS])

--- a/docs/deploy_docs.sh
+++ b/docs/deploy_docs.sh
@@ -1,0 +1,7 @@
+git checkout -b latest
+git checkout $(git tag -l --sort=creatordate |tail -1)
+git checkout -b stable
+git checkout main
+
+sphinx-multiversion . html
+cp ./index-redirect.html html/index.html

--- a/docs/index-redirect.html
+++ b/docs/index-redirect.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to latest release</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=./latest/index.html">
+    <link rel="canonical" href="https://move-coop.github.io/parsons/latest/index.html">
+  </head>
+</html>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@
 Sphinx==4.3.2
 sphinx-rtd-theme==1.0.0
 myst-parser==0.16.1
+sphinx-multiversion


### PR DESCRIPTION
Here's a first stab at setting up multiversioning for the docs using https://github.com/Holzhaus/sphinx-multiversion

Deployment is a bit more complicated, so I've stuck the steps in a `deploy_docs.sh` script. I couldn't figure out the Makefiles so I left them alone for now.