### PR TITLE
Only unpack dicts in P2A campaigns response if the response has data

### DIFF
--- a/parsons/phone2action/p2a.py
+++ b/parsons/phone2action/p2a.py
@@ -155,9 +155,10 @@ class Phone2Action(object):
                 }
 
         tbl = Table(self.client.get_request('campaigns', params=args))
-        tbl.unpack_dict('updated_at')
-        if include_content:
-            tbl.unpack_dict('content')
+        if tbl:
+            tbl.unpack_dict('updated_at')
+            if include_content:
+                tbl.unpack_dict('content')
 
         return tbl
 


### PR DESCRIPTION
This fixes a bug that caused late-loading failures in `get_campaigns` responses when an account doesn't have any campaigns associated with it. The previous version of this code attempted to expand a column that doesn't exist when there aren't campaigns returned. It does not impact the type of returned object under empty conditions, so is backwards compatible with existing workarounds that people might have privately composed.