### PR TITLE
run docs build on any change to master/main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
       - docs-build-deploy:
           filters:
             branches:
-              only: master
+              only: main
 
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,11 @@ workflows:
   build:
     jobs:
       - test
-      - docs-build:
-          filters:
-            branches:
-              ignore: master
+      - docs-build
       - docs-build-deploy:
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              ignore: /.*/
+              only: master
 
 version: 2
 jobs:


### PR DESCRIPTION
Oversight in #639 - right now CircleCI only runs when there's a change to a release branch, we want to now build the docs every time, since we'll need to update 'latest'.