### PR TITLE
Fix bug in 'make html'

### DIFF
--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,4 +1,4 @@
-{% if display_versions_lower_left %}
+{% if display_versions_lower_left and current_version %}
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="{{ _('Versions') }}">
     <span class="rst-current-version" data-toggle="rst-current-version">
       <span class="fa fa-book"> Read the Docs</span>


### PR DESCRIPTION
When I added versioning in #639 I intended to leave it so `make html` still works to quickly check your docs build, but I added a variable to the templates that only gets created when you `make deploy_docs`. This PR is a simple fix which checks that the variable is actually there and skips that template if not.