### PR TITLE
VAN: Activist Code Apply - Omit Contact History

### DIFF
--- a/parsons/ngpvan/activist_codes.py
+++ b/parsons/ngpvan/activist_codes.py
@@ -45,7 +45,7 @@ class ActivistCodes(object):
     def toggle_activist_code(self, id, activist_code_id, action, id_type='vanid',
                              omit_contact=True):
         # Internal method to apply/remove activist codes. Was previously a public method,
-        # but for the sake of simplicity, breaking out into two public methods.
+        # but for the sake of simplicity, breaking out into two public methods. 
 
         response = {"activistCodeId": activist_code_id,
                     "action": action_parse(action),

--- a/parsons/ngpvan/activist_codes.py
+++ b/parsons/ngpvan/activist_codes.py
@@ -106,7 +106,4 @@ class ActivistCodes(object):
             ``None``
         """
 
-        return self.toggle_activist_code(id,
-                                         activist_code_id,
-                                         'Remove',
-                                         id_type=id_type)
+        return self.toggle_activist_code(id, activist_code_id, 'Remove', id_type=id_type)

--- a/parsons/ngpvan/activist_codes.py
+++ b/parsons/ngpvan/activist_codes.py
@@ -45,7 +45,7 @@ class ActivistCodes(object):
     def toggle_activist_code(self, id, activist_code_id, action, id_type='vanid',
                              omit_contact=True):
         # Internal method to apply/remove activist codes. Was previously a public method,
-        # but for the sake of simplicity, breaking out into two public methods. 
+        # but for the sake of simplicity, breaking out into two public  methods.
 
         response = {"activistCodeId": activist_code_id,
                     "action": action_parse(action),

--- a/parsons/ngpvan/activist_codes.py
+++ b/parsons/ngpvan/activist_codes.py
@@ -42,22 +42,26 @@ class ActivistCodes(object):
         logger.info(f'Found activist code {activist_code_id}.')
         return r
 
-    def toggle_activist_code(self, id, activist_code_id, action, id_type='vanid'):
+    def toggle_activist_code(self, id, activist_code_id, action, id_type='vanid',
+                             omit_contact=True):
         # Internal method to apply/remove activist codes. Was previously a public method,
         # but for the sake of simplicity, breaking out into two public methods.
 
         response = {"activistCodeId": activist_code_id,
                     "action": action_parse(action),
-                    "type": "activistCode"}
+                    "type": "activistCode",
+                    "omitActivistCodeContactHistory": omit_contact
+                    }
 
-        r = self.apply_response(id, response, id_type)
+        r = self.apply_response(id, response, id_type, omit_contact=omit_contact)
 
         logger.info(f'{id_type.upper()} {id} {action.capitalize()} ' +
                     f'activist code {activist_code_id}')
 
         return r
 
-    def apply_activist_code(self, id, activist_code_id, id_type='vanid'):
+    def apply_activist_code(self, id, activist_code_id, id_type='vanid',
+                            omit_contact=True):
         """
         Apply an activist code to or from a person.
 
@@ -71,11 +75,18 @@ class ActivistCodes(object):
             id_type: str
                 A known person identifier type available on this VAN instance
                 such as ``dwid``
+            omit_contact: boolean
+                If set to false the contact history will be updated with a contact
+                attempt.
         Returns:
             ``None``
         """
 
-        return self.toggle_activist_code(id, activist_code_id, 'Apply', id_type=id_type)
+        return self.toggle_activist_code(id,
+                                         activist_code_id,
+                                         'Apply',
+                                         id_type=id_type,
+                                         omit_contact=omit_contact)
 
     def remove_activist_code(self, id, activist_code_id, id_type='vanid'):
         """
@@ -95,4 +106,7 @@ class ActivistCodes(object):
             ``None``
         """
 
-        return self.toggle_activist_code(id, activist_code_id, 'Remove', id_type=id_type)
+        return self.toggle_activist_code(id,
+                                         activist_code_id,
+                                         'Remove',
+                                         id_type=id_type)

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -443,7 +443,8 @@ class People(object):
         """
 
     def apply_response(self, id, response, id_type='vanid', contact_type_id=None,
-                       input_type_id=None, date_canvassed=None, result_code_id=None):
+                       input_type_id=None, date_canvassed=None, result_code_id=None,
+                       omit_contact=False):
         """
         Apply responses such as survey questions, activist codes, and volunteer actions
         to a person record. This method allows you apply multiple responses (e.g. two survey
@@ -471,6 +472,11 @@ class People(object):
             date_canvassed : str
                 `Optional`; ISO 8601 formatted date. Defaults to todays date
             responses : list or dict
+                The responses to apply.
+            omit_contact: boolean
+                Omit adding contact history to the response. This is particularly
+                useful when adding activist codes that are not based on contact
+                attempts.
         `Returns:`
             ``True`` if successful
 
@@ -495,7 +501,8 @@ class People(object):
         json = {"canvassContext": {
             "contactTypeId": contact_type_id,
             "inputTypeId": input_type_id,
-            "dateCanvassed": date_canvassed},
+            "dateCanvassed": date_canvassed,
+            "omitActivistCodeContactHistory": omit_contact},
             "resultCodeId": result_code_id}
 
         if response:


### PR DESCRIPTION
The ``van.apply_activist_code`` method currently applies a contact response (e.g. canvass status) when it is run. This is problematic in that many use cases for applying activist codes are not the result of contacts. Instead they are arbitrary flags applied to records. This can be a pain as it introduces fake contact attempts which muck up reporting for organizations (i.e. me).

Here is an example of what happens when you currently apply an activist code.

![ss3](https://user-images.githubusercontent.com/5530043/163013340-3ae9e198-4bfc-4ba6-b16b-156491f7f9ad.png)

There was an old issue #445 which lifted up, but it seems like in the meantime, VAN has addressed it. This PR adds in a kwarg ``omit_contact`` that omits, by default, a contact response being added when an activist code is applied. 

I have coded this such that the default is to omit the contact, which, while it would represent a change in functionality compared to the previous version of the method, I believe is representative of the desired defaults of most use cases.