### PR TITLE
Support Python 3.9 and 3.10; drop 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Parsons offers simplified interactions with these services and tools, including 
 
 This project is maintained by [The Movement Cooperative](https://movementcooperative.org/) and is named after [Lucy Parsons](https://en.wikipedia.org/wiki/Lucy_Parsons). The Movement Cooperative is a member-led organization focused on providing data, tools, and strategic support for the progressive community.
 
-Parsons is only compatible with Python 3.6/7/8
+Parsons is only compatible with Python 3.7-10
 
 ### License and Usage
 Usage of Parsons is governed by a [modified Apache License with author attribution statement](https://github.com/move-coop/parsons/blob/main/LICENSE.md).

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ xmltodict==0.11.0
 gspread==3.7.0
 oauth2client==4.1.3
 google-auth==2.6.2
-facebook-business==6.0.0
+facebook-business==13.0.0
 google-api-python-client==1.7.7
 google-resumable-media!=0.4.0,<0.5.0dev,>=0.3.1
 httplib2==0.19.0
@@ -41,8 +41,8 @@ requests_oauthlib==1.3.0
 # Testing Requirements
 requests-mock==1.5.2
 flake8==4.0.1
-testfixtures==6.4.3
-pytest==5.2.0
+testfixtures==6.18.5
+pytest==7.1.1
 pytest-datadir==1.3.0
 
 # Stuff for TMC scripts

--- a/setup.py
+++ b/setup.py
@@ -73,13 +73,12 @@ def main():
         classifiers=[
             'Development Status :: 3 - Alpha',
             'Intended Audience :: Developers',
-            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8'
             'Programming Language :: Python :: 3.9'
             'Programming Language :: Python :: 3.10'
         ],
-        python_requires=">=3.6.0,<3.11.0",
+        python_requires=">=3.7.0,<3.11.0",
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ def main():
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8'
-        ]
+            'Programming Language :: Python :: 3.9'
+            'Programming Language :: Python :: 3.10'
+        ],
+        python_requires=">=3.6.0,<3.11.0",
     )
 
 


### PR DESCRIPTION
Attempting to `import parsons` from Python 3.10 currently errors out due to outdated dependencies, so I bumped up the facebook dep and some testing libraries. Unfortunately I don't have a Facebook ads account to verify no breaking changes, but the changelog _seemed_ innocuous. I've ran tests in Python 3.7 through 10 without problem.

It drops support for Python 3.6, which had completely different errors (including `google-cloud-storage` no longer supporting 3.6).

This also prevents pip from installing parsons on Python <3.7 or >3.10. We could set this to just >= 3.7, but it seems better to me to proactively claim support (particularly considering 3.10 support was broken).