### PR TITLE
Update auth info for Google Sheets

### DIFF
--- a/docs/google.rst
+++ b/docs/google.rst
@@ -3,7 +3,7 @@ Google
 
 Google Cloud services allow you to upload and manipulate Tables as spreadsheets (via GoogleSheets) or query them as SQL database tables (via GoogleBigQuery). You can also upload/store/download them as binary objects (via GoogleCloudStorage). Google also offers an API for civic information using GoogleCivic and admin information using the Google Workspace Admin SDK.
 
-For all of these services you will need to enable the APIs for your Google Cloud account and obtain authentication tokens to access them from your scripts. If you are the administrator of your Google Cloud account, you can do both of these at `Google Cloud Console APIs and Services <https://console.cloud.google.com/apis/credentials/serviceaccountkey?_ga=2.116342342.-1334320118.1565013288>`_.
+For all of these services you will need to enable the APIs for your Google Cloud account and obtain authentication tokens or other credentials to access them from your scripts. If you are the administrator of your Google Cloud account, you can do both of these at `Google Cloud Console APIs and Services <https://console.cloud.google.com/apis/dashboard>`_. The connectors below have more specific information about how to authenticate.
 
 .. _gbq:
 
@@ -252,13 +252,21 @@ Overview
 
 The GoogleSheets class allows you to interact with Google service account spreadsheets, called "Google Sheets." You can create, modify, read, format, share and delete sheets with this connector.
 
-In order to instantiate the class, you must pass Google service account credentials as a dictionary, or store the credentials as a JSON string in the ``GOOGLE_DRIVE_CREDENTIALS`` environment variable. Typically you'll get the credentials from the Google Developer Console (look for the "Google Drive API").
+In order to instantiate the class, you must pass Google service account credentials as a dictionary, or store the credentials as a JSON file locally and pass the path to the file as a string in the ``GOOGLE_DRIVE_CREDENTIALS`` environment variable. You can follow these steps:
+
+- Go to the `Google Developer Console <https://console.cloud.google.com/apis/dashboard>`_ and make sure the "Google Drive API" and the "Google Sheets API" are both enabled.
+- Go to the credentials page via the lefthand sidebar. On the credentials page, click "create credentials".
+- Choose the "Service Account" option and fill out the form provided. This should generate your credentials.
+- Select your newly created Service Account on the credentials main page.
+- select "keys", then "add key", then "create new key". Pick the key type JSON. The credentials should start to automatically download.
+
+You can now copy and paste the data from the key into your script or (recommended) save it locally as a JSON file.
 
 ==========
 Quickstart
 ==========
 
-To instantiate the GoogleSheets class, you can either pass the constructor a dict containing your Google service account credentials or define the environment variable ``GOOGLE_DRIVE_CREDENTIALS`` to contain a JSON encoding of the dict.
+To instantiate the GoogleSheets class, you can either pass the constructor a dict containing your Google service account credentials or define the environment variable ``GOOGLE_DRIVE_CREDENTIALS`` to contain a path to the JSON file containing the dict.
 
 .. code-block:: python
 


### PR DESCRIPTION
I've been working with the Google Sheets connector a bit recently and found the authentication info was out of date. I've updated the guidance here as well as tweaked the intro to the Google connectors as a whole, including fixing a link and using slightly broader language.

Google Admin, BigQuery and Cloud Storage all have somewhat similar instructions to the old Google Sheets instructions. I wonder if they might be out of date too?