### PR TITLE
Bump to version 0.19.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ def main():
 
     setup(
         name="parsons",
-        version='0.18.1',
+        version='0.19.0',
         author="The Movement Cooperative",
         author_email="info@movementcooperative.org",
         url='https://github.com/movementcoop/parsons',


### PR DESCRIPTION
Since we tweaked which versions of Python we actively support (but are
still at major version zero), updating the minor version made sense to
me. This'll let us publish a new version to pypi!