### PR TITLE
Update simple-salesforce version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ docutils<0.18,>=0.14
 urllib3==1.26.5
 simplejson==3.16.0
 twilio==6.30.0
-simple-salesforce==0.74.3
+simple-salesforce==1.11.6
 suds-py3==1.3.4.0
 newmode==0.1.6
 mysql-connector-python==8.0.18


### PR DESCRIPTION
Addresses #642 by bumping [simple-salesforce](https://github.com/simple-salesforce/simple-salesforce) version from 0.74.3 to 1.11.6. 

0.74.3 was published July 4 2019, so we've got about 3 years of [changes](https://github.com/simple-salesforce/simple-salesforce/blob/master/CHANGES). I went through and looked at the tests to make sure that the client interfaces hadn't introduced breaking changes and I don't believe they have, but I don't have a Salesforce account so I couldn't actually test that. 

I did note that we have two empty tests in `test_salesforce.py` and I considered trying to add them but I don't know enough about the API to mock the data.