### PR TITLE
Re-named Phone2Action to Capitol Canary

### DIFF
--- a/docs/capitolcanary.rst
+++ b/docs/capitolcanary.rst
@@ -1,5 +1,5 @@
 CapitolCanary
-============
+=============
 
 ********
 Overview

--- a/docs/capitolcanary.rst
+++ b/docs/capitolcanary.rst
@@ -5,7 +5,7 @@ CapitolCanary
 Overview
 ********
 
-`CapitolCanary <https://phone2action.com/>`_ is a digital advocacy tool used by progressive organizations. This class
+`CapitolCanary <https://capitolcanary.com/>`_ is a digital advocacy tool used by progressive organizations. This class
 allows you to interact with the tool by leveraging their `API <http://docs.phone2action.com/#overview>`_.
 
 .. note::
@@ -17,7 +17,7 @@ Quick Start
 ***********
 
 To instantiate the ``CapitolCanary`` class, you can either pass in the app ID and app key as arguments or set the
-``PHONE2ACTION_APP_ID`` and ``PHONE2ACTION_APP_KEY`` environmental variables.
+``CAPITOLCANARY_APP_ID`` and ``CAPITOLCANARY_APP_KEY`` environmental variables.
 
 .. code-block:: python
 

--- a/docs/capitolcanary.rst
+++ b/docs/capitolcanary.rst
@@ -1,0 +1,50 @@
+CapitolCanary
+============
+
+********
+Overview
+********
+
+`CapitolCanary <https://phone2action.com/>`_ is a digital advocacy tool used by progressive organizations. This class
+allows you to interact with the tool by leveraging their `API <http://docs.phone2action.com/#overview>`_.
+
+.. note::
+  Authentication
+  	You will need to email CapitolCanary to request credentials to access the API. The credentials consist of an app ID and an app key.
+
+***********
+Quick Start
+***********
+
+To instantiate the ``CapitolCanary`` class, you can either pass in the app ID and app key as arguments or set the
+``PHONE2ACTION_APP_ID`` and ``PHONE2ACTION_APP_KEY`` environmental variables.
+
+.. code-block:: python
+
+   from parsons import CapitolCanary
+
+   # Instantiate the class using environment variables
+   cc = CapitolCanary()
+
+   # Get all advocates updated in the last day
+   import datetime
+   today = datetime.datetime.utcnow()
+   yesterday = today - datetime.timedelta(days=1)
+
+   # get_advocates returns a dictionary that maps the advocate data (e.g. phones) to a parsons
+   # Table with the data for each advocate
+   advocates_data = cc.get_advocates(updated_since=yesterday)
+
+   # For all of our advocates' phone numbers, opt them into SMS
+   for phone in advocates_data['phones']:
+       phone_number = phone['phones_address']
+       # Only update phone numbers that aren't already subscribed
+       if phone['subscribed']:
+           cc.update_advocate(phone['advocate_id'], phone=phone_number, sms_opt_in=True)
+
+***
+API
+***
+
+.. autoclass :: parsons.CapitolCanary
+   :inherited-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -233,6 +233,7 @@ Indices and tables
    bluelink
    box
    braintree
+   capitolcanary
    civis
    controlshift
    copper

--- a/docs/p2a.rst
+++ b/docs/p2a.rst
@@ -1,4 +1,4 @@
-phone2action
+Phone2Action
 ============
 
 ********

--- a/docs/p2a.rst
+++ b/docs/p2a.rst
@@ -5,10 +5,6 @@ phone2action
 Overview
 ********
 
-This is a deprecated class only maintained here for backwards compatibility. Phone2action has been renamed to [Capitol Canary](https://capitolcanary.com/) and the Parson object has similarly been renamed.
+This is a deprecated class only maintained here for backwards compatibility. Phone2action has been renamed to `Capitol Canary <https://capitolcanary.com/>`_ and the Parson object has similarly been renamed.
 
-
-
-
-.. autoclass :: parsons.Phone2Action
-   :inherited-members:
+To access the documentation see the `Capitol Canary page <capitolcanary.html>`_

--- a/docs/p2a.rst
+++ b/docs/p2a.rst
@@ -1,50 +1,14 @@
-Phone2Action
+phone2action
 ============
 
 ********
 Overview
 ********
 
-`Phone2Action <https://phone2action.com/>`_ is a digital advocacy tool used by progressive organizations. This class
-allows you to interact with the tool by leveraging their `API <http://docs.phone2action.com/#overview>`_.
+This is a deprecated class only maintained here for backwards compatibility. Phone2action has been renamed to [Capitol Canary](https://capitolcanary.com/) and the Parson object has similarly been renamed.
 
-.. note::
-  Authentication
-  	You will need to email Phone2Action to request credentials to access the API. The credentials consist of an app ID and an app key.
 
-***********
-Quick Start
-***********
 
-To instantiate the ``Phone2Action`` class, you can either pass in the app ID and app key as arguments or set the
-``PHONE2ACTION_APP_ID`` and ``PHONE2ACTION_APP_KEY`` environmental variables.
-
-.. code-block:: python
-
-   from parsons import Phone2Action
-
-   # Instantiate the class using environment variables
-   p2a = Phone2Action()
-
-   # Get all advocates updated in the last day
-   import datetime
-   today = datetime.datetime.utcnow()
-   yesterday = today - datetime.timedelta(days=1)
-
-   # get_advocates returns a dictionary that maps the advocate data (e.g. phones) to a parsons
-   # Table with the data for each advocate
-   advocates_data = p2a.get_advocates(updated_since=yesterday)
-
-   # For all of our advocates' phone numbers, opt them into SMS
-   for phone in advocates_data['phones']:
-       phone_number = phone['phones_address']
-       # Only update phone numbers that aren't already subscribed
-       if phone['subscribed']:
-           p2a.update_advocate(phone['advocate_id'], phone=phone_number, sms_opt_in=True)
-
-***
-API
-***
 
 .. autoclass :: parsons.Phone2Action
    :inherited-members:

--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -30,6 +30,7 @@ if not (
     from parsons.google.google_cloud_storage import GoogleCloudStorage
     from parsons.google.google_bigquery import GoogleBigQuery
     from parsons.phone2action.p2a import Phone2Action
+    from parsons.capitol_canary.capitol_canary import CapitolCanary
     from parsons.mobilize_america.ma import MobilizeAmerica
     from parsons.facebook_ads.facebook_ads import FacebookAds
     from parsons.turbovote.turbovote import TurboVote

--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -83,6 +83,7 @@ if not (
         'GoogleBigQuery',
         'GoogleSheets',
         'Phone2Action',
+        'CapitolCanary',
         'MobilizeAmerica',
         'FacebookAds',
         'Slack',

--- a/parsons/capitol_canary/__init__.py
+++ b/parsons/capitol_canary/__init__.py
@@ -1,0 +1,5 @@
+from parsons.capitol_canary.capitol_canary import CapitolCanary
+
+__all__ = [
+    'CapitolCanary'
+]

--- a/parsons/capitol_canary/capitol_canary.py
+++ b/parsons/capitol_canary/capitol_canary.py
@@ -1,29 +1,22 @@
-from requests.auth import HTTPBasicAuth
-from parsons.etl import Table
 from parsons.phone2action import Phone2Action
-from parsons.utilities import check_env
-from parsons.utilities.api_connector import APIConnector
-from parsons.utilities.datetime import date_to_timestamp
 import logging
 
 logger = logging.getLogger(__name__)
 
-PHONE2ACTION_URI = 'https://api.phone2action.com/2.0/'
-
 
 class CapitolCanary(object):
     """
-    Instantiate CapitalCanary Class
+    Instantiate CapitolCanary Class
 
     `Args:`
         app_id: str
-            The Phone2Action provided application id. Not required if ``PHONE2ACTION_APP_ID``
+            The CapitolCanary provided application id. Not required if ``PHONE2ACTION_APP_ID``
             env variable set.
         app_key: str
-            The Phone2Action provided application key. Not required if ``PHONE2ACTION_APP_KEY``
+            The CapitolCanary provided application key. Not required if ``PHONE2ACTION_APP_KEY``
             env variable set.
     `Returns:`
-        Phone2Action Class
+        CapitolCanary Class
     """
 
     def __init__(self, app_id=None, app_key=None):
@@ -109,7 +102,7 @@ class CapitolCanary(object):
 
         The list of arguments only partially covers the fields that can be set on the advocate.
         For a complete list of fields that can be updated, see
-        `the Phone2Action API documentation <https://docs.phone2action.com/#calls-create>`_.
+        `the Capitol Canary API documentation <https://docs.phone2action.com/#calls-create>`_.
 
         `Args:`
             campaigns: list
@@ -190,7 +183,7 @@ class CapitolCanary(object):
 
         The list of arguments only partially covers the fields that can be updated on the advocate.
         For a complete list of fields that can be updated, see
-        `the Phone2Action API documentation <https://docs.phone2action.com/#calls-create>`_.
+        `the Capitol Canary API documentation <https://docs.phone2action.com/#calls-create>`_.
 
         `Args:`
             advocate_id: integer

--- a/parsons/capitol_canary/capitol_canary.py
+++ b/parsons/capitol_canary/capitol_canary.py
@@ -1,12 +1,18 @@
-from parsons.phone2action import Phone2Action
+from requests.auth import HTTPBasicAuth
+from parsons.etl import Table
+from parsons.utilities import check_env
+from parsons.utilities.api_connector import APIConnector
+from parsons.utilities.datetime import date_to_timestamp
 import logging
 
 logger = logging.getLogger(__name__)
 
+CAPITOL_CANARY_URI = 'https://api.phone2action.com/2.0/'
+
 
 class CapitolCanary(object):
     """
-    Instantiate CapitolCanary Class
+    Instantiate Phone2Action Class
 
     `Args:`
         app_id: str
@@ -20,7 +26,32 @@ class CapitolCanary(object):
     """
 
     def __init__(self, app_id=None, app_key=None):
-        self.phone2action = Phone2Action(app_id, app_key)
+
+        self.app_id = check_env.check('PHONE2ACTION_APP_ID', app_id)
+        self.app_key = check_env.check('PHONE2ACTION_APP_KEY', app_key)
+        self.auth = HTTPBasicAuth(self.app_id, self.app_key)
+        self.client = APIConnector(CAPITOL_CANARY_URI, auth=self.auth)
+
+    def _paginate_request(self, url, args=None, page=None):
+        # Internal pagination method
+
+        if page is not None:
+            args['page'] = page
+
+        r = self.client.get_request(url, params=args)
+
+        json = r['data']
+
+        if page is not None:
+            return json
+
+        # If count of items is less than the total allowed per page, paginate
+        while r['pagination']['count'] == r['pagination']['per_page']:
+
+            r = self.client.get_request(r['pagination']['next_url'], args)
+            json.extend(r['data'])
+
+        return json
 
     def get_advocates(self, state=None, campaign_id=None, updated_since=None, page=None):
         """
@@ -51,7 +82,49 @@ class CapitolCanary(object):
                 * fields
                 * advocates
         """
-        return self.phone2action.get_advocates(state, campaign_id, updated_since, page)
+
+        # Convert the passed in updated_since into a Unix timestamp (which is what the API wants)
+        updated_since = date_to_timestamp(updated_since)
+
+        args = {'state': state,
+                'campaignid': campaign_id,
+                'updatedSince': updated_since}
+
+        logger.info('Retrieving advocates...')
+        json = self._paginate_request('advocates', args=args, page=page)
+
+        return self._advocates_tables(Table(json))
+
+    def _advocates_tables(self, tbl):
+        # Convert the advocates nested table into multiple tables
+
+        tbls = {
+            'advocates': tbl,
+            'emails': Table(),
+            'phones': Table(),
+            'memberships': Table(),
+            'tags': Table(),
+            'ids': Table(),
+            'fields': Table(),
+        }
+
+        if not tbl:
+            return tbls
+
+        logger.info(f'Retrieved {tbl.num_rows} advocates...')
+
+        # Unpack all of the single objects
+        # The CapitolCanary API docs says that created_at and updated_at are dictionaries, but
+        # the data returned from the server is a ISO8601 timestamp. - EHS, 05/21/2020
+        for c in ['address', 'districts']:
+            tbl.unpack_dict(c)
+
+        # Unpack all of the arrays
+        child_tables = [child for child in tbls.keys() if child != 'advocates']
+        for c in child_tables:
+            tbls[c] = tbl.long_table(['id'], c, key_rename={'id': 'advocate_id'})
+
+        return tbls
 
     def get_campaigns(self, state=None, zip=None, include_generic=False, include_private=False,
                       include_content=True):
@@ -75,8 +148,19 @@ class CapitolCanary(object):
                 See :ref:`parsons-table` for output options.
         """
 
-        return self.phone2action.get_campaigns(self, state, zip, include_generic, include_private,
-                                               include_content)
+        args = {'state': state,
+                'zip': zip,
+                'includeGeneric': str(include_generic),
+                'includePrivate': str(include_private)
+                }
+
+        tbl = Table(self.client.get_request('campaigns', params=args))
+        if tbl:
+            tbl.unpack_dict('updated_at')
+            if include_content:
+                tbl.unpack_dict('content')
+
+        return tbl
 
     def create_advocate(self,
                         campaigns,
@@ -102,7 +186,7 @@ class CapitolCanary(object):
 
         The list of arguments only partially covers the fields that can be set on the advocate.
         For a complete list of fields that can be updated, see
-        `the Capitol Canary API documentation <https://docs.phone2action.com/#calls-create>`_.
+        `the CapitolCanary API documentation <https://docs.phone2action.com/#calls-create>`_.
 
         `Args:`
             campaigns: list
@@ -147,23 +231,61 @@ class CapitolCanary(object):
         `Returns:`
             The int ID of the created advocate.
         """
-        return self.phone2action.create_advocate(
-            campaigns,
-            first_name,
-            last_name,
-            email,
-            phone,
-            address1,
-            address2,
-            city,
-            state,
-            zip5,
-            sms_optin,
-            email_optin,
-            sms_optout,
-            email_optout,
-            **kwargs
-        )
+
+        # Validate the passed in arguments
+
+        if not campaigns:
+            raise ValueError(
+                'When creating an advocate, you must specify one or more campaigns.')
+
+        if not email and not phone:
+            raise ValueError(
+                'When creating an advocate, you must provide an email address or a phone number.')
+
+        if (sms_optin or sms_optout) and not phone:
+            raise ValueError(
+                'When opting an advocate in or out of SMS messages, you must specify a valid '
+                'phone and one or more campaigns')
+
+        if (email_optin or email_optout) and not email:
+            raise ValueError(
+                'When opting an advocate in or out of email messages, you must specify a valid '
+                'email address and one or more campaigns')
+
+        # Align our arguments with the expected parameters for the API
+        payload = {
+            'email': email,
+            'phone': phone,
+            'firstname': first_name,
+            'lastname': last_name,
+            'address1': address1,
+            'address2': address2,
+            'city': city,
+            'state': state,
+            'zip5': zip5,
+            'smsOptin': 1 if sms_optin else None,
+            'emailOptin': 1 if email_optin else None,
+            'smsOptout': 1 if sms_optout else None,
+            'emailOptout': 1 if email_optout else None,
+        }
+
+        # Clean up any keys that have a "None" value
+        payload = {
+            key: val
+            for key, val in payload.items()
+            if val is not None
+        }
+
+        # Merge in any kwargs
+        payload.update(kwargs)
+
+        # Turn into a list of items so we can append multiple campaigns
+        campaign_keys = [('campaigns[]', val) for val in campaigns]
+        data = [(key, value) for key, value in payload.items()] + campaign_keys
+
+        # Call into the CapitolCanary API
+        response = self.client.post_request('advocates', data=data)
+        return response['advocateid']
 
     def update_advocate(self,
                         advocate_id,
@@ -183,7 +305,7 @@ class CapitolCanary(object):
 
         The list of arguments only partially covers the fields that can be updated on the advocate.
         For a complete list of fields that can be updated, see
-        `the Capitol Canary API documentation <https://docs.phone2action.com/#calls-create>`_.
+        `the CapitolCanary API documentation <https://docs.phone2action.com/#calls-create>`_.
 
         `Args:`
             advocate_id: integer
@@ -212,13 +334,47 @@ class CapitolCanary(object):
             **kwargs:
                 Additional fields on the advocate to update
         """
-        return self.update_advocate(
-            advocate_id,
-            campaigns,
-            email,
-            phone,
-            sms_optin,
-            email_optin,
-            sms_optout,
-            email_optout,
-            **kwargs)
+
+        # Validate the passed in arguments
+        if (sms_optin or sms_optout) and not (phone and campaigns):
+            raise ValueError(
+                'When opting an advocate in or out of SMS messages, you must specify a valid '
+                'phone and one or more campaigns')
+
+        if (email_optin or email_optout) and not (email and campaigns):
+            raise ValueError(
+                'When opting an advocate in or out of email messages, you must specify a valid '
+                'email address and one or more campaigns')
+
+        # Align our arguments with the expected parameters for the API
+        payload = {
+            'advocateid': advocate_id,
+            'campaigns': campaigns,
+            'email': email,
+            'phone': phone,
+            'smsOptin': 1 if sms_optin else None,
+            'emailOptin': 1 if email_optin else None,
+            'smsOptout': 1 if sms_optout else None,
+            'emailOptout': 1 if email_optout else None,
+            # remap first_name / last_name to be consistent with updated_advocates
+            'firstname': kwargs.pop('first_name', None),
+            'lastname': kwargs.pop('last_name', None),
+        }
+
+        # Clean up any keys that have a "None" value
+        payload = {
+            key: val
+            for key, val in payload.items()
+            if val is not None
+        }
+
+        # Merge in any kwargs
+        payload.update(kwargs)
+
+        # Turn into a list of items so we can append multiple campaigns
+        campaigns = campaigns or []
+        campaign_keys = [('campaigns[]', val) for val in campaigns]
+        data = [(key, value) for key, value in payload.items()] + campaign_keys
+
+        # Call into the CapitolCanary API
+        self.client.post_request('advocates', data=data)

--- a/parsons/capitol_canary/capitol_canary.py
+++ b/parsons/capitol_canary/capitol_canary.py
@@ -12,14 +12,14 @@ CAPITOL_CANARY_URI = 'https://api.phone2action.com/2.0/'
 
 class CapitolCanary(object):
     """
-    Instantiate Phone2Action Class
+    Instantiate CapitolCanary Class
 
     `Args:`
         app_id: str
-            The CapitolCanary provided application id. Not required if ``PHONE2ACTION_APP_ID``
+            The CapitolCanary provided application id. Not required if ``CAPITOLCANARY_APP_ID``
             env variable set.
         app_key: str
-            The CapitolCanary provided application key. Not required if ``PHONE2ACTION_APP_KEY``
+            The CapitolCanary provided application key. Not required if ``CAPITOLCANARY_APP_KEY``
             env variable set.
     `Returns:`
         CapitolCanary Class

--- a/parsons/capitol_canary/capitol_canary.py
+++ b/parsons/capitol_canary/capitol_canary.py
@@ -1,0 +1,231 @@
+from requests.auth import HTTPBasicAuth
+from parsons.etl import Table
+from parsons.phone2action import Phone2Action
+from parsons.utilities import check_env
+from parsons.utilities.api_connector import APIConnector
+from parsons.utilities.datetime import date_to_timestamp
+import logging
+
+logger = logging.getLogger(__name__)
+
+PHONE2ACTION_URI = 'https://api.phone2action.com/2.0/'
+
+
+class CapitolCanary(object):
+    """
+    Instantiate CapitalCanary Class
+
+    `Args:`
+        app_id: str
+            The Phone2Action provided application id. Not required if ``PHONE2ACTION_APP_ID``
+            env variable set.
+        app_key: str
+            The Phone2Action provided application key. Not required if ``PHONE2ACTION_APP_KEY``
+            env variable set.
+    `Returns:`
+        Phone2Action Class
+    """
+
+    def __init__(self, app_id=None, app_key=None):
+        self.phone2action = Phone2Action(app_id, app_key)
+
+    def get_advocates(self, state=None, campaign_id=None, updated_since=None, page=None):
+        """
+        Return advocates (person records).
+
+        If no page is specified, the method will automatically paginate through the available
+        advocates.
+
+        `Args:`
+            state: str
+                Filter by US postal abbreviation for a state
+                or territory e.g., "CA" "NY" or "DC"
+            campaign_id: int
+                Filter to specific campaign
+            updated_since: str or int or datetime
+                Fetch all advocates updated since the date provided; this can be a datetime
+                object, a UNIX timestamp, or a date string (ex. '2014-01-05 23:59:43')
+            page: int
+                Page number of data to fetch; if this is specified, call will only return one
+                page.
+        `Returns:`
+            A dict of parsons tables:
+                * emails
+                * phones
+                * memberships
+                * tags
+                * ids
+                * fields
+                * advocates
+        """
+        return self.phone2action.get_advocates(state, campaign_id, updated_since, page)
+
+
+    def get_campaigns(self, state=None, zip=None, include_generic=False, include_private=False,
+                      include_content=True):
+        """
+        Returns a list of campaigns
+
+        `Args:`
+            state: str
+                Filter by US postal abbreviation for a state or territory e.g., "CA" "NY" or "DC"
+            zip: int
+                Filter by 5 digit zip code
+            include_generic: boolean
+                When filtering by state or ZIP code, include unrestricted campaigns
+            include_private: boolean
+                If true, will include private campaigns in results
+            include_content: boolean
+                If true, include campaign content fields, which may vary. This may cause
+                sync errors.
+        `Returns:`
+            Parsons Table
+                See :ref:`parsons-table` for output options.
+        """
+
+        return self.phone2action.get_campaigns(self, state, zip, include_generic, include_private, include_content)
+
+    def create_advocate(self,
+                        campaigns,
+                        first_name=None,
+                        last_name=None,
+                        email=None,
+                        phone=None,
+                        address1=None,
+                        address2=None,
+                        city=None,
+                        state=None,
+                        zip5=None,
+                        sms_optin=None,
+                        email_optin=None,
+                        sms_optout=None,
+                        email_optout=None,
+                        **kwargs):
+        """
+        Create an advocate.
+
+        If you want to opt an advocate into or out of SMS / email campaigns, you must provide
+        the email address or phone number (accordingly).
+
+        The list of arguments only partially covers the fields that can be set on the advocate.
+        For a complete list of fields that can be updated, see
+        `the Phone2Action API documentation <https://docs.phone2action.com/#calls-create>`_.
+
+        `Args:`
+            campaigns: list
+                The ID(s) of campaigns to add the advocate to
+            first_name: str
+                `Optional`; The first name of the advocate
+            last_name: str
+                `Optional`; The last name of the advocate
+            email: str
+                `Optional`; An email address to add for the advocate. One of ``email`` or ``phone``
+                is required.
+            phone: str
+                `Optional`; An phone # to add for the advocate. One of ``email`` or ``phone`` is
+                required.
+            address1: str
+                `Optional`; The first line of the advocates' address
+            address2: str
+                `Optional`; The second line of the advocates' address
+            city: str
+                `Optional`; The city of the advocates address
+            state: str
+                `Optional`; The state of the advocates address
+            zip5: str
+                `Optional`; The 5 digit Zip code of the advocate
+            sms_optin: boolean
+                `Optional`; Whether to opt the advocate into receiving text messages; an SMS
+                confirmation text message will be sent. You must provide values for the ``phone``
+                and ``campaigns`` arguments.
+            email_optin: boolean
+                `Optional`; Whether to opt the advocate into receiving emails. You must provide
+                values for the ``email`` and ``campaigns`` arguments.
+            sms_optout: boolean
+                `Optional`; Whether to opt the advocate out of receiving text messages. You must
+                provide values for the ``phone`` and ``campaigns`` arguments. Once an advocate is
+                opted out, they cannot be opted back in.
+            email_optout: boolean
+                `Optional`; Whether to opt the advocate out of receiving emails. You must
+                provide values for the ``email`` and ``campaigns`` arguments. Once an advocate is
+                opted out, they cannot be opted back in.
+            **kwargs:
+                Additional fields on the advocate to update
+        `Returns:`
+            The int ID of the created advocate.
+        """
+        return self.phone2action.create_advocate(
+            campaigns,
+            first_name,
+            last_name,
+            email,
+            phone,
+            address1,
+            address2,
+            city,
+            state,
+            zip5,
+            sms_optin,
+            email_optin,
+            sms_optout,
+            email_optout,
+            **kwargs
+        )
+
+    def update_advocate(self,
+                        advocate_id,
+                        campaigns=None,
+                        email=None,
+                        phone=None,
+                        sms_optin=None,
+                        email_optin=None,
+                        sms_optout=None,
+                        email_optout=None,
+                        **kwargs):
+        """
+        Update the fields of an advocate.
+
+        If you want to opt an advocate into or out of SMS / email campaigns, you must provide
+        the email address or phone number along with a list of campaigns.
+
+        The list of arguments only partially covers the fields that can be updated on the advocate.
+        For a complete list of fields that can be updated, see
+        `the Phone2Action API documentation <https://docs.phone2action.com/#calls-create>`_.
+
+        `Args:`
+            advocate_id: integer
+                The ID of the advocate being updates
+            campaigns: list
+                `Optional`; The ID(s) of campaigns to add the user to
+            email: str
+                `Optional`; An email address to add for the advocate (or to use when opting in/out)
+            phone: str
+                `Optional`; An phone # to add for the advocate (or to use when opting in/out)
+            sms_optin: boolean
+                `Optional`; Whether to opt the advocate into receiving text messages; an SMS
+                confirmation text message will be sent. You must provide values for the ``phone``
+                and ``campaigns`` arguments.
+            email_optin: boolean
+                `Optional`; Whether to opt the advocate into receiving emails. You must provide
+                values for the ``email`` and ``campaigns`` arguments.
+            sms_optout: boolean
+                `Optional`; Whether to opt the advocate out of receiving text messages. You must
+                provide values for the ``phone`` and ``campaigns`` arguments. Once an advocate is
+                opted out, they cannot be opted back in.
+            email_optout: boolean
+                `Optional`; Whether to opt the advocate out of receiving emails. You must
+                provide values for the ``email`` and ``campaigns`` arguments. Once an advocate is
+                opted out, they cannot be opted back in.
+            **kwargs:
+                Additional fields on the advocate to update
+        """
+        return self.update_advocate(
+            advocate_id,
+            campaigns,
+            email,
+            phone,
+            sms_optin,
+            email_optin,
+            sms_optout,
+            email_optout,
+            **kwargs)

--- a/parsons/capitol_canary/capitol_canary.py
+++ b/parsons/capitol_canary/capitol_canary.py
@@ -26,9 +26,12 @@ class CapitolCanary(object):
     """
 
     def __init__(self, app_id=None, app_key=None):
+        # check first for CapitolCanary branded app key and ID
+        cc_app_id = check_env.check('CAPITOLCANARY_APP_ID', None, optional=True)
+        cc_app_key = check_env.check('CAPITOLCANARY_APP_KEY', None, optional=True)
 
-        self.app_id = check_env.check('PHONE2ACTION_APP_ID', app_id)
-        self.app_key = check_env.check('PHONE2ACTION_APP_KEY', app_key)
+        self.app_id = cc_app_id or check_env.check('PHONE2ACTION_APP_ID', app_id)
+        self.app_key = cc_app_key or check_env.check('PHONE2ACTION_APP_KEY', app_key)
         self.auth = HTTPBasicAuth(self.app_id, self.app_key)
         self.client = APIConnector(CAPITOL_CANARY_URI, auth=self.auth)
 

--- a/parsons/capitol_canary/capitol_canary.py
+++ b/parsons/capitol_canary/capitol_canary.py
@@ -53,7 +53,6 @@ class CapitolCanary(object):
         """
         return self.phone2action.get_advocates(state, campaign_id, updated_since, page)
 
-
     def get_campaigns(self, state=None, zip=None, include_generic=False, include_private=False,
                       include_content=True):
         """

--- a/parsons/capitol_canary/capitol_canary.py
+++ b/parsons/capitol_canary/capitol_canary.py
@@ -75,7 +75,8 @@ class CapitolCanary(object):
                 See :ref:`parsons-table` for output options.
         """
 
-        return self.phone2action.get_campaigns(self, state, zip, include_generic, include_private, include_content)
+        return self.phone2action.get_campaigns(self, state, zip, include_generic, include_private,
+                                               include_content)
 
     def create_advocate(self,
                         campaigns,

--- a/parsons/phone2action/p2a.py
+++ b/parsons/phone2action/p2a.py
@@ -23,6 +23,12 @@ class Phone2Action(object):
         self.capitol_canary = CapitolCanary(app_id, app_key)
         logger.warning('The Phone2Action class is being deprecated and replaced by CapitalCanary')
 
+    def __getattr__(self, name):
+        try:
+          return getattr(self.capitol_canary, name)
+        except:
+          raise AttributeError(f"{type(self).__name__} object has no attribute {name}")
+
     def get_advocates(self, state=None, campaign_id=None, updated_since=None, page=None):
         """
         Return advocates (person records).
@@ -76,7 +82,7 @@ class Phone2Action(object):
                 See :ref:`parsons-table` for output options.
         """
 
-        return self.capitol_canary.get_campaigns(self, state, zip, include_generic, include_private,
+        return self.capitol_canary.get_campaigns(state, zip, include_generic, include_private,
                                                  include_content)
 
     def create_advocate(self,

--- a/parsons/phone2action/p2a.py
+++ b/parsons/phone2action/p2a.py
@@ -1,13 +1,7 @@
-from requests.auth import HTTPBasicAuth
-from parsons.etl import Table
-from parsons.utilities import check_env
-from parsons.utilities.api_connector import APIConnector
-from parsons.utilities.datetime import date_to_timestamp
+from parsons.capitol_canary import CapitolCanary
 import logging
 
 logger = logging.getLogger(__name__)
-
-PHONE2ACTION_URI = 'https://api.phone2action.com/2.0/'
 
 
 class Phone2Action(object):
@@ -26,32 +20,7 @@ class Phone2Action(object):
     """
 
     def __init__(self, app_id=None, app_key=None):
-
-        self.app_id = check_env.check('PHONE2ACTION_APP_ID', app_id)
-        self.app_key = check_env.check('PHONE2ACTION_APP_KEY', app_key)
-        self.auth = HTTPBasicAuth(self.app_id, self.app_key)
-        self.client = APIConnector(PHONE2ACTION_URI, auth=self.auth)
-
-    def _paginate_request(self, url, args=None, page=None):
-        # Internal pagination method
-
-        if page is not None:
-            args['page'] = page
-
-        r = self.client.get_request(url, params=args)
-
-        json = r['data']
-
-        if page is not None:
-            return json
-
-        # If count of items is less than the total allowed per page, paginate
-        while r['pagination']['count'] == r['pagination']['per_page']:
-
-            r = self.client.get_request(r['pagination']['next_url'], args)
-            json.extend(r['data'])
-
-        return json
+        self.capitol_canary = CapitolCanary(app_id, app_key)
 
     def get_advocates(self, state=None, campaign_id=None, updated_since=None, page=None):
         """
@@ -82,49 +51,7 @@ class Phone2Action(object):
                 * fields
                 * advocates
         """
-
-        # Convert the passed in updated_since into a Unix timestamp (which is what the API wants)
-        updated_since = date_to_timestamp(updated_since)
-
-        args = {'state': state,
-                'campaignid': campaign_id,
-                'updatedSince': updated_since}
-
-        logger.info('Retrieving advocates...')
-        json = self._paginate_request('advocates', args=args, page=page)
-
-        return self._advocates_tables(Table(json))
-
-    def _advocates_tables(self, tbl):
-        # Convert the advocates nested table into multiple tables
-
-        tbls = {
-            'advocates': tbl,
-            'emails': Table(),
-            'phones': Table(),
-            'memberships': Table(),
-            'tags': Table(),
-            'ids': Table(),
-            'fields': Table(),
-        }
-
-        if not tbl:
-            return tbls
-
-        logger.info(f'Retrieved {tbl.num_rows} advocates...')
-
-        # Unpack all of the single objects
-        # The Phone2Action API docs says that created_at and updated_at are dictionaries, but
-        # the data returned from the server is a ISO8601 timestamp. - EHS, 05/21/2020
-        for c in ['address', 'districts']:
-            tbl.unpack_dict(c)
-
-        # Unpack all of the arrays
-        child_tables = [child for child in tbls.keys() if child != 'advocates']
-        for c in child_tables:
-            tbls[c] = tbl.long_table(['id'], c, key_rename={'id': 'advocate_id'})
-
-        return tbls
+        return self.capitol_canary.get_advocates(state, campaign_id, updated_since, page)
 
     def get_campaigns(self, state=None, zip=None, include_generic=False, include_private=False,
                       include_content=True):
@@ -148,19 +75,8 @@ class Phone2Action(object):
                 See :ref:`parsons-table` for output options.
         """
 
-        args = {'state': state,
-                'zip': zip,
-                'includeGeneric': str(include_generic),
-                'includePrivate': str(include_private)
-                }
-
-        tbl = Table(self.client.get_request('campaigns', params=args))
-        if tbl:
-            tbl.unpack_dict('updated_at')
-            if include_content:
-                tbl.unpack_dict('content')
-
-        return tbl
+        return self.capitol_canary.get_campaigns(self, state, zip, include_generic, include_private,
+                                                 include_content)
 
     def create_advocate(self,
                         campaigns,
@@ -231,61 +147,23 @@ class Phone2Action(object):
         `Returns:`
             The int ID of the created advocate.
         """
-
-        # Validate the passed in arguments
-
-        if not campaigns:
-            raise ValueError(
-                'When creating an advocate, you must specify one or more campaigns.')
-
-        if not email and not phone:
-            raise ValueError(
-                'When creating an advocate, you must provide an email address or a phone number.')
-
-        if (sms_optin or sms_optout) and not phone:
-            raise ValueError(
-                'When opting an advocate in or out of SMS messages, you must specify a valid '
-                'phone and one or more campaigns')
-
-        if (email_optin or email_optout) and not email:
-            raise ValueError(
-                'When opting an advocate in or out of email messages, you must specify a valid '
-                'email address and one or more campaigns')
-
-        # Align our arguments with the expected parameters for the API
-        payload = {
-            'email': email,
-            'phone': phone,
-            'firstname': first_name,
-            'lastname': last_name,
-            'address1': address1,
-            'address2': address2,
-            'city': city,
-            'state': state,
-            'zip5': zip5,
-            'smsOptin': 1 if sms_optin else None,
-            'emailOptin': 1 if email_optin else None,
-            'smsOptout': 1 if sms_optout else None,
-            'emailOptout': 1 if email_optout else None,
-        }
-
-        # Clean up any keys that have a "None" value
-        payload = {
-            key: val
-            for key, val in payload.items()
-            if val is not None
-        }
-
-        # Merge in any kwargs
-        payload.update(kwargs)
-
-        # Turn into a list of items so we can append multiple campaigns
-        campaign_keys = [('campaigns[]', val) for val in campaigns]
-        data = [(key, value) for key, value in payload.items()] + campaign_keys
-
-        # Call into the Phone2Action API
-        response = self.client.post_request('advocates', data=data)
-        return response['advocateid']
+        return self.capitol_canary.create_advocate(
+            campaigns,
+            first_name,
+            last_name,
+            email,
+            phone,
+            address1,
+            address2,
+            city,
+            state,
+            zip5,
+            sms_optin,
+            email_optin,
+            sms_optout,
+            email_optout,
+            **kwargs
+        )
 
     def update_advocate(self,
                         advocate_id,
@@ -334,47 +212,13 @@ class Phone2Action(object):
             **kwargs:
                 Additional fields on the advocate to update
         """
-
-        # Validate the passed in arguments
-        if (sms_optin or sms_optout) and not (phone and campaigns):
-            raise ValueError(
-                'When opting an advocate in or out of SMS messages, you must specify a valid '
-                'phone and one or more campaigns')
-
-        if (email_optin or email_optout) and not (email and campaigns):
-            raise ValueError(
-                'When opting an advocate in or out of email messages, you must specify a valid '
-                'email address and one or more campaigns')
-
-        # Align our arguments with the expected parameters for the API
-        payload = {
-            'advocateid': advocate_id,
-            'campaigns': campaigns,
-            'email': email,
-            'phone': phone,
-            'smsOptin': 1 if sms_optin else None,
-            'emailOptin': 1 if email_optin else None,
-            'smsOptout': 1 if sms_optout else None,
-            'emailOptout': 1 if email_optout else None,
-            # remap first_name / last_name to be consistent with updated_advocates
-            'firstname': kwargs.pop('first_name', None),
-            'lastname': kwargs.pop('last_name', None),
-        }
-
-        # Clean up any keys that have a "None" value
-        payload = {
-            key: val
-            for key, val in payload.items()
-            if val is not None
-        }
-
-        # Merge in any kwargs
-        payload.update(kwargs)
-
-        # Turn into a list of items so we can append multiple campaigns
-        campaigns = campaigns or []
-        campaign_keys = [('campaigns[]', val) for val in campaigns]
-        data = [(key, value) for key, value in payload.items()] + campaign_keys
-
-        # Call into the Phone2Action API
-        self.client.post_request('advocates', data=data)
+        return self.capitol_canary.update_advocate(
+            advocate_id,
+            campaigns,
+            email,
+            phone,
+            sms_optin,
+            email_optin,
+            sms_optout,
+            email_optout,
+            **kwargs)

--- a/parsons/phone2action/p2a.py
+++ b/parsons/phone2action/p2a.py
@@ -25,9 +25,9 @@ class Phone2Action(object):
 
     def __getattr__(self, name):
         try:
-          return getattr(self.capitol_canary, name)
-        except:
-          raise AttributeError(f"{type(self).__name__} object has no attribute {name}")
+            return getattr(self.capitol_canary, name)
+        except AttributeError:
+            raise AttributeError(f"{type(self).__name__} object has no attribute {name}")
 
     def get_advocates(self, state=None, campaign_id=None, updated_since=None, page=None):
         """

--- a/parsons/phone2action/p2a.py
+++ b/parsons/phone2action/p2a.py
@@ -21,6 +21,7 @@ class Phone2Action(object):
 
     def __init__(self, app_id=None, app_key=None):
         self.capitol_canary = CapitolCanary(app_id, app_key)
+        logger.warning('The Phone2Action class is being deprecated and replaced by CapitalCanary')
 
     def get_advocates(self, state=None, campaign_id=None, updated_since=None, page=None):
         """

--- a/test/test_capitol_canary.py
+++ b/test/test_capitol_canary.py
@@ -139,11 +139,21 @@ class TestP2A(unittest.TestCase):
 
         pass
 
-    def test_init_envs(self):
-        # Test initializing class with envs
+    def test_old_init_envs(self):
+        # Test initializing class with old envs
 
         os.environ['PHONE2ACTION_APP_ID'] = 'id'
         os.environ['PHONE2ACTION_APP_KEY'] = 'key'
+
+        cc_envs = CapitolCanary()
+        self.assertEqual(cc_envs.app_id, 'id')
+        self.assertEqual(cc_envs.app_key, 'key')
+
+    def test_init_envs(self):
+        # Test initializing class with envs
+
+        os.environ['CAPITOLCANARY_APP_ID'] = 'id'
+        os.environ['CAPITOLCANARY_APP_KEY'] = 'key'
 
         cc_envs = CapitolCanary()
         self.assertEqual(cc_envs.app_id, 'id')

--- a/test/test_capitol_canary.py
+++ b/test/test_capitol_canary.py
@@ -1,0 +1,287 @@
+import unittest
+import requests_mock
+from test.utils import validate_list
+from parsons import CapitolCanary
+import os
+import copy
+
+
+adv_json = {
+    "data": [
+        {
+            "id": 7125439,
+            "prefix": "Mr.",
+            "firstname": "Bob",
+            "middlename": "Smith",
+            "lastname": "Smit",
+            "suffix": None,
+            "notes": None,
+            "stage": None,
+            "connections": 3,
+            "tags": [
+                "register-to-vote-38511",
+                "registered-to-vote-for-2018-38511",
+            ],
+            "created_at": "2017-05-23 23:36:04.000000",
+            "updated_at": "2018-12-17 21:55:24.000000",
+            "address": {
+                "street1": "25255 Maine Ave",
+                "street2": "",
+                "city": "Los Angeles",
+                "state": "CA",
+                "zip5": 96055,
+                "zip4": 9534,
+                "county": "Tehama",
+                "latitude": "50.0632635",
+                "longitude": "-122.09654"
+            },
+            "districts": {
+                "congressional": "1",
+                "stateSenate": "4",
+                "stateHouse": "3",
+                "cityCouncil": None
+            },
+            "ids": [],
+            "memberships": [
+                {
+                    "id": 15151443,
+                    "campaignid": 25373,
+                    "name": "20171121 Businesses for Responsible Tax Reform - Contact Congress",
+                    "source": None,
+                    "created_at": "2017-11-21 23:28:30.000000",
+                },
+                {
+                    "id": 20025582,
+                    "campaignid": 32641,
+                    "name": "20180524 March for America",
+                    "source": None,
+                    "created_at": "2018-05-24 21:09:49.000000",
+                }
+            ],
+            "fields": [],
+            "phones": [
+                {
+                    "id": 10537860,
+                    "address": "+19995206447",
+                    "subscribed": 'false'
+                }
+            ],
+            "emails": [
+                {
+                    "id": 10537871,
+                    "address": "N@k.com",
+                    "subscribed": 'false'
+                },
+                {
+                    "id": 10950446,
+                    "address": "email@me.com",
+                    "subscribed": 'false'
+                }
+            ]
+        }
+    ],
+    "pagination": {
+        "count": 1,
+        "per_page": 100,
+        "current_page": 1,
+        "next_url": "https://api.phone2action.com/2.0/advocates?page=2"}
+}
+
+camp_json = [
+    {
+        "id": 25373,
+        "name": "20171121 Businesses for Responsible Tax Reform - Contact Congress",
+        "display_name": "Businesses for Responsible Tax Reform",
+        "subtitle": "Tell Congress: Stand up for responsible tax reform!",
+        "public": 1,
+        "topic": None,
+        "type": "CAMPAIGN",
+        "link": "http://p2a.co/KHcUyTK",
+        "restrict_allow": None,
+        "content": {
+            "summary": "",
+            "introduction": "Welcome",
+            "call_to_action": "Contact your officials in one click!",
+            "thank_you": "<p>Thanks for taking action. Please encourage others to act by "
+            "sharing on social media.</p>",
+            "background_image": None
+        },
+        "updated_at": {
+            "date": "2017-11-21 23:27:11.000000",
+            "timezone_type": 3,
+            "timezone": "UTC"
+        }
+    }
+]
+
+
+def parse_request_body(m):
+    kvs = m.split('&')
+    return {
+        kv.split('=')[0]: kv.split('=')[1]
+        for kv in kvs
+    }
+
+
+class TestP2A(unittest.TestCase):
+
+    def setUp(self):
+
+        self.cc = CapitolCanary(app_id='an_id', app_key='app_key').phone2action
+
+    def tearDown(self):
+
+        pass
+
+    def test_init_args(self):
+        # Test initializing class with args
+        # Done in the setUp
+
+        pass
+
+    def test_init_envs(self):
+        # Test initializing class with envs
+
+        os.environ['PHONE2ACTION_APP_ID'] = 'id'
+        os.environ['PHONE2ACTION_APP_KEY'] = 'key'
+
+        cc_envs = CapitolCanary()
+        self.assertEqual(cc_envs.phone2action.app_id, 'id')
+        self.assertEqual(cc_envs.phone2action.app_key, 'key')
+
+    @requests_mock.Mocker()
+    def test_get_advocates(self, m):
+
+        m.get(self.cc.client.uri + 'advocates', json=adv_json)
+
+        adv_exp = ['id', 'prefix', 'firstname', 'middlename',
+                   'lastname', 'suffix', 'notes', 'stage', 'connections',
+                   'created_at', 'updated_at',
+                   'address_city', 'address_county', 'address_latitude',
+                   'address_longitude', 'address_state', 'address_street1',
+                   'address_street2', 'address_zip4', 'address_zip5',
+                   'districts_cityCouncil', 'districts_congressional',
+                   'districts_stateHouse', 'districts_stateSenate']
+
+        self.assertTrue(validate_list(adv_exp, self.cc.get_advocates()['advocates']))
+        ids_exp = ['advocate_id', 'ids']
+
+        self.assertTrue(validate_list(ids_exp, self.cc.get_advocates()['ids']))
+
+        phone_exp = ['advocate_id', 'phones_address', 'phones_id', 'phones_subscribed']
+        self.assertTrue(validate_list(phone_exp, self.cc.get_advocates()['phones']))
+
+        tags_exp = ['advocate_id', 'tags']
+        self.assertTrue(validate_list(tags_exp, self.cc.get_advocates()['tags']))
+
+        email_exp = ['advocate_id', 'emails_address', 'emails_id', 'emails_subscribed']
+        self.assertTrue(validate_list(email_exp, self.cc.get_advocates()['emails']))
+
+        member_exp = ['advocate_id', 'memberships_campaignid', 'memberships_created_at',
+                      'memberships_id', 'memberships_name', 'memberships_source']
+        self.assertTrue(validate_list(member_exp, self.cc.get_advocates()['memberships']))
+
+        fields_exp = ['advocate_id', 'fields']
+        self.assertTrue(validate_list(fields_exp, self.cc.get_advocates()['fields']))
+
+    @requests_mock.Mocker()
+    def test_get_advocates__by_page(self, m):
+
+        response = copy.deepcopy(adv_json)
+        # Make it look like there's more data
+        response['pagination']['count'] = 100
+
+        m.get(self.cc.client.uri + 'advocates?page=1', json=adv_json)
+        m.get(self.cc.client.uri + 'advocates?page=2', exc=Exception('Should only call once'))
+
+        results = self.cc.get_advocates(page=1)
+        self.assertTrue(results['advocates'].num_rows, 1)
+
+    @requests_mock.Mocker()
+    def test_get_advocates__empty(self, m):
+
+        response = copy.deepcopy(adv_json)
+        response['data'] = []
+        # Make it look like there's more data
+        response['pagination']['count'] = 0
+
+        m.get(self.cc.client.uri + 'advocates', json=adv_json)
+
+        results = self.cc.get_advocates()
+        self.assertTrue(results['advocates'].num_rows, 0)
+
+    @requests_mock.Mocker()
+    def test_get_campaigns(self, m):
+
+        camp_exp = ['id', 'name', 'display_name', 'subtitle',
+                    'public', 'topic', 'type', 'link', 'restrict_allow',
+                    'updated_at_date', 'updated_at_timezone',
+                    'updated_at_timezone_type', 'content_background_image',
+                    'content_call_to_action', 'content_introduction',
+                    'content_summary', 'content_thank_you']
+
+        m.get(self.cc.client.uri + 'campaigns', json=camp_json)
+
+        self.assertTrue(validate_list(camp_exp, self.cc.get_campaigns()))
+
+    @requests_mock.Mocker()
+    def test_create_advocate(self, m):
+
+        m.post(self.cc.client.uri + 'advocates', json={'advocateid': 1})
+
+        # Test arg validation - create requires a phone or an email
+        self.assertRaises(ValueError,
+                          lambda: self.cc.create_advocate(campaigns=[1],
+                                                          firstname='Foo',
+                                                          lastname='bar'))
+        # Test arg validation - sms opt in requires a phone
+        self.assertRaises(ValueError,
+                          lambda: self.cc.create_advocate(campaigns=[1],
+                                                          email='foo@bar.com',
+                                                          sms_optin=True))
+
+        # Test arg validation - email opt in requires a email
+        self.assertRaises(ValueError,
+                          lambda: self.cc.create_advocate(campaigns=[1],
+                                                          phone='1234567890',
+                                                          email_optin=True))
+
+        # Test a successful call
+        advocateid = self.cc.create_advocate(campaigns=[1],
+                                             email='foo@bar.com',
+                                             email_optin=True,
+                                             firstname='Test')
+        self.assertTrue(m.called)
+        self.assertEqual(advocateid, 1)
+
+        # Check that the properties were mapped
+        data = parse_request_body(m.last_request.text)
+        self.assertEqual(data['firstname'], 'Test')
+        self.assertNotIn('lastname', data)
+        self.assertEqual(data['emailOptin'], '1')
+        self.assertEqual(data['email'], 'foo%40bar.com')
+
+    @requests_mock.Mocker()
+    def test_update_advocate(self, m):
+
+        m.post(self.cc.client.uri + 'advocates')
+
+        # Test arg validation - sms opt in requires a phone
+        self.assertRaises(ValueError,
+                          lambda: self.cc.update_advocate(advocate_id=1, sms_optin=True))
+
+        # Test arg validation - email opt in requires a email
+        self.assertRaises(ValueError,
+                          lambda: self.cc.update_advocate(advocate_id=1, email_optin=True))
+
+        # Test a successful call
+        self.cc.update_advocate(advocate_id=1, campaigns=[1], email='foo@bar.com',
+                                email_optin=True, firstname='Test')
+        self.assertTrue(m.called)
+
+        # Check that the properties were mapped
+        data = parse_request_body(m.last_request.text)
+        self.assertEqual(data['firstname'], 'Test')
+        self.assertNotIn('lastname', data)
+        self.assertEqual(data['emailOptin'], '1')
+        self.assertEqual(data['email'], 'foo%40bar.com')

--- a/test/test_capitol_canary.py
+++ b/test/test_capitol_canary.py
@@ -127,7 +127,7 @@ class TestP2A(unittest.TestCase):
 
     def setUp(self):
 
-        self.cc = CapitolCanary(app_id='an_id', app_key='app_key').phone2action
+        self.cc = CapitolCanary(app_id='an_id', app_key='app_key')
 
     def tearDown(self):
 
@@ -146,8 +146,8 @@ class TestP2A(unittest.TestCase):
         os.environ['PHONE2ACTION_APP_KEY'] = 'key'
 
         cc_envs = CapitolCanary()
-        self.assertEqual(cc_envs.phone2action.app_id, 'id')
-        self.assertEqual(cc_envs.phone2action.app_key, 'key')
+        self.assertEqual(cc_envs.app_id, 'id')
+        self.assertEqual(cc_envs.app_key, 'key')
 
     @requests_mock.Mocker()
     def test_get_advocates(self, m):

--- a/test/test_p2a.py
+++ b/test/test_p2a.py
@@ -127,7 +127,7 @@ class TestP2A(unittest.TestCase):
 
     def setUp(self):
 
-        self.p2a = Phone2Action(app_id='an_id', app_key='app_key').capitol_canary
+        self.p2a = Phone2Action(app_id='an_id', app_key='app_key')
 
     def tearDown(self):
 
@@ -146,8 +146,8 @@ class TestP2A(unittest.TestCase):
         os.environ['PHONE2ACTION_APP_KEY'] = 'key'
 
         p2a_envs = Phone2Action()
-        self.assertEqual(p2a_envs.capitol_canary.app_id, 'id')
-        self.assertEqual(p2a_envs.capitol_canary.app_key, 'key')
+        self.assertEqual(p2a_envs.app_id, 'id')
+        self.assertEqual(p2a_envs.app_key, 'key')
 
     @requests_mock.Mocker()
     def test_get_advocates(self, m):

--- a/test/test_p2a.py
+++ b/test/test_p2a.py
@@ -127,7 +127,7 @@ class TestP2A(unittest.TestCase):
 
     def setUp(self):
 
-        self.p2a = Phone2Action(app_id='an_id', app_key='app_key')
+        self.p2a = Phone2Action(app_id='an_id', app_key='app_key').capitol_canary
 
     def tearDown(self):
 
@@ -146,8 +146,8 @@ class TestP2A(unittest.TestCase):
         os.environ['PHONE2ACTION_APP_KEY'] = 'key'
 
         p2a_envs = Phone2Action()
-        self.assertEqual(p2a_envs.app_id, 'id')
-        self.assertEqual(p2a_envs.app_key, 'key')
+        self.assertEqual(p2a_envs.capitol_canary.app_id, 'id')
+        self.assertEqual(p2a_envs.capitol_canary.app_key, 'key')
 
     @requests_mock.Mocker()
     def test_get_advocates(self, m):


### PR DESCRIPTION
This is a PR for issue https://github.com/move-coop/parsons/issues/669.

I couldn't find API docs anywhere so this PR assumes all of the URLs and environment variables maintain the `phone2action` branding. 