### PR TITLE
Big Query NoneType Mapping Bug

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -15,6 +15,7 @@ from parsons.utilities.files import create_temp_file
 
 BIGQUERY_TYPE_MAP = {
     'str': 'STRING',
+    'NoneType': 'STRING',
     'float': 'FLOAT',
     'int': 'INTEGER',
     'bool': 'BOOLEAN',

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -15,7 +15,6 @@ from parsons.utilities.files import create_temp_file
 
 BIGQUERY_TYPE_MAP = {
     'str': 'STRING',
-    'NoneType': 'STRING',
     'float': 'FLOAT',
     'int': 'INTEGER',
     'bool': 'BOOLEAN',
@@ -23,6 +22,7 @@ BIGQUERY_TYPE_MAP = {
     'datetime.date': 'DATE',
     'datetime.time': 'TIME',
     'dict': 'RECORD',
+    'NoneType': 'STRING'
 }
 
 # Max number of rows that we query at a time, so we can avoid loading huge


### PR DESCRIPTION
To ensure that columns with different data types are stored accordingly after running the copy function to big query, we have added a mapping line to the python to Big Query data type map `'NoneType': 'String'`.

The other alternative was a set of codes that filtered out NoneType from the get_column_stats function and kept the first type that was available other than NoneType, i.e., string, int, float.  

We landed on the addition below as it will provide more flexibility when multiple data types are present in the column. 