### PR TITLE
VAN: Fix codes bugs.

### DIFF
--- a/parsons/ngpvan/codes.py
+++ b/parsons/ngpvan/codes.py
@@ -53,7 +53,7 @@ class Codes(object):
                 See :ref:`parsons-table` for output options.
         """
 
-        c = self.connection.request(f'codes/{code_id}')
+        c = self.connection.get_request(f'codes/{code_id}')
         logger.debug(c)
         logger.info(f'Found code {code_id}.')
         return c

--- a/parsons/ngpvan/codes.py
+++ b/parsons/ngpvan/codes.py
@@ -115,7 +115,7 @@ class Codes(object):
 
             se = [{'name': s['name'],
                    'isSearchable': s['is_searchable'],
-                   'is_applicable': s['is_applicable']} for s in supported_entities]
+                   'isApplicable': s['is_applicable']} for s in supported_entities]
 
             json['supportedEntities'] = se
 
@@ -175,7 +175,7 @@ class Codes(object):
 
             se = [{'name': s['name'],
                    'isSearchable': s['is_searchable'],
-                   'is_applicable': s['is_applicable']} for s in supported_entities]
+                   'isApplicable': s['is_applicable']} for s in supported_entities]
             post_data['supportedEntities'] = se
 
         r = self.connection.put_request(f'codes/{code_id}', json=post_data)

--- a/test/test_van/test_codes.py
+++ b/test/test_van/test_codes.py
@@ -38,6 +38,24 @@ class TestCodes(unittest.TestCase):
         assert_matching_tables(json['items'], self.van.get_codes())
 
     @requests_mock.Mocker()
+    def test_get_code(self, m):
+
+        json = {'codeId': 1004916,
+                'parentCodeId': None,
+                'name': 'Data Entry',
+                'description': 'for test.',
+                'codePath': 'Data Entry',
+                'createdByName': '',
+                'dateCreated': '2018-07-13T15:16:00Z',
+                'supportedEntities': None,
+                'codeType': 'Tag',
+                'campaign': None,
+                'contactType': None}
+
+        m.get(self.van.connection.uri + 'codes/1004916', json=json)
+        self.assertEqual(json, self.van.get_code(1004916))
+
+    @requests_mock.Mocker()
     def test_get_code_types(self, m):
 
         json = ['Tag', 'SourceCode']


### PR DESCRIPTION
Two small bug fixes:

- `get_code` : The method for the underlying VANConnector class was misnamed.
- `apply_code`: The _is_applicable_ parameter was misnamed and thus, not applying.

Furthermore, I might want to rework the _supported_entities parameter. It requests constructing a dict, which is sort of unnecessary and not keeping with the common sense abstraction of Parsons. But, that would come in another PR.