### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,3 +1,11 @@
+---
+name: Bug Report
+about: Tell us about a problem with the project's current functionality
+title: "[Bug]"
+labels: bug
+assignees: ''
+---
+
 <!--- Provide a general summary of the bug you're experiencing in the Title above -->
 
 

--- a/.github/ISSUE_TEMPLATE/proposed-feature-addition.md
+++ b/.github/ISSUE_TEMPLATE/proposed-feature-addition.md
@@ -1,3 +1,11 @@
+---
+name: Proposed Feature/Addition
+about: Suggest an addition to Parsons
+title: "[Feature/Addition]"
+labels: enhancement
+assignees: ''
+---
+
 <!--- Provide a general summary of the proposed Parsons addition in the Title above -->
 
 


### PR DESCRIPTION
In #668 the template metadata was accidentally removed. This PR adds them back and, hopefully, gets the templates working.