### PR TITLE
Update docs to account for wheels.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -161,10 +161,11 @@ these patterns trade immediate accessibility against ease of integration.
 
 In environments where Parsons is not the primary application, or in scenarios where Parsons must
 run with limited resources, we recommend users install only the dependencies they need at loose
-version constraints. To do this, simply set the `PARSONS_LIMITED_DEPENDENCIES` environment
-variable to "true" before installing Parsons and keep it while running:
+version constraints. To do this, simply set two environment variables before installing Parsons
+and keep one while running:
 
 ```
+export PIP_NO_BINARY=parsons
 export PARSONS_LIMITED_DEPENDENCIES=true
 pip install parsons
 ```
@@ -174,11 +175,12 @@ export PARSONS_LIMITED_DEPENDENCIES=true
 python myparsons_script.py
 ```
 
-When the `PARSONS_LIMITED_DEPENDENCIES` environment variable is set, pip will install the bare
-minimum dependencies needed to run Parsons. Users may also install extra dependencies
-appropriate to their environment, e.g.
+`PIP_NO_BINARY` tells pip to use the source distribution of Parsons, which then allows
+`PARSONS_LIMITED_DEPENDENCIES` to dynamically limit to the bare minimum dependencies needed to
+run Parsons.  Users may also install extra dependencies appropriate to their environment, e.g.
 
 ```
+export PIP_NO_BINARY=parsons
 export PARSONS_LIMITED_DEPENDENCIES=true
 pip install parsons[google]
 ```
@@ -186,6 +188,7 @@ pip install parsons[google]
 or
 
 ```
+export PIP_NO_BINARY=parsons
 export PARSONS_LIMITED_DEPENDENCIES=true
 pip install parsons[google,ngpvan]
 ```


### PR DESCRIPTION
Parsons is hosted on pypi as both a source distribution and a binary
wheel package. The later is faster, but skips over configurations in
setup.py (more specifically: whatever environment vars were set on the
building machine are the ones that stuck). To allow
`PARSONS_LIMITED_DEPENDENCIES` to work, we need to tell pip that it
should skip the wheel for Parsons.