### PR TITLE
Attempt to filter expand_fields before stringifying them

### DIFF
--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -360,15 +360,15 @@ class People(object):
         id_type = '' if id_type in ('vanid', None) else f"{id_type}:"
         url += id_type + str(id)
 
-        expand_fields = ','.join([json_format.arg_format(f) for f in expand_fields])
-
         # Removing the fields that are not returned in MyVoters
         NOT_IN_MYVOTERS = ['codes', 'contribution_history', 'organization_roles']
 
         if self.connection.db_code == 0:
             expand_fields = [v for v in expand_fields if v not in NOT_IN_MYVOTERS]
 
-        logger.info(f'Getting person with {id_type} of {id} at url {url}')
+        expand_fields = ','.join([json_format.arg_format(f) for f in expand_fields])
+
+        logger.info(f'Getting person with {id_type or "vanid"} of {id} at url {url}')
         return self.connection.get_request(url, params={'$expand': expand_fields})
 
     def apply_canvass_result(self, id, result_code_id, id_type='vanid', contact_type_id=None,


### PR DESCRIPTION
[Two years ago](https://github.com/move-coop/parsons/commit/fb54f5b849198cdb3dbb2a2e33603ce6e493fa2a), filter logic was added to the `get_person` VAN method to remove fields that didn't exist on particular databases. Unfortunately, it was added after the logic which turns `expand_fields` from an array into a string, leading to weirdness like this:

![Screenshot from 2022-06-08 18-13-06](https://user-images.githubusercontent.com/1179362/172726490-a99713a4-89fa-480b-98e7-abc49bd79545.png)

This in turn leads to 404 errors. Has `get_person` just always returned 404 errors for the last two years? Is no one using the `expand_fields` parameter? Have people been silently working around this? I am deeply curious.