### PR TITLE
Add missing check to distinguish between path string and json string in Google connector utility

### DIFF
--- a/parsons/google/utitities.py
+++ b/parsons/google/utitities.py
@@ -12,7 +12,8 @@ def setup_google_application_credentials(app_creds, env_var_name='GOOGLE_APPLICA
     try:
         if (type(credentials) is dict):
             credentials = json.dumps(credentials)
-        creds_path = files.string_to_temp_file(credentials, suffix='.json')
+        if json.loads(credentials):
+            creds_path = files.string_to_temp_file(credentials, suffix='.json')
     except ValueError:
         creds_path = credentials
 


### PR DESCRIPTION
_Re-doing this PR due to deleted fork weirdness._

I think I figured out the issue that I and others were having with Google authentication. A previous PR changed the way the [utilities.py](https://github.com/move-coop/parsons/blob/v0.19.0/parsons/google/utitities.py) file worked and all strings, including path strings, were being interpreted as json strings. So when we set a path as the environmental variable, setup_google_application_credentials saved it as though it was itself the json credentials file, which of course led to parsing errors down the line.

I'd like to get this reviewed and a new release cut relatively quickly, as until this is released on pypi anyone trying to set up the google connector is going to run into errors.

