### PR TITLE
Fix error in VAN Target Export method.

### DIFF
--- a/parsons/ngpvan/targets.py
+++ b/parsons/ngpvan/targets.py
@@ -2,7 +2,6 @@
 
 from parsons.etl.table import Table
 import logging
-import json
 import requests
 
 logger = logging.getLogger(__name__)

--- a/parsons/ngpvan/targets.py
+++ b/parsons/ngpvan/targets.py
@@ -2,7 +2,7 @@
 
 from parsons.etl.table import Table
 import logging
-import requests
+import petl
 
 logger = logging.getLogger(__name__)
 
@@ -61,9 +61,8 @@ class Targets(object):
         response = self.connection.get_request(f'targetExportJobs/{export_job_id}')
         job_status = response.get('jobStatus')
         if job_status == 'Complete':
-            csv = response['file']['downloadUrl']
-            response_csv = requests.get(csv)
-            return Table.from_csv_string(response_csv.text)
+            url = response['file']['downloadUrl']
+            return Table(petl.fromcsv(url, encoding="utf-8-sig"))
         elif job_status == 'Pending' or job_status == 'InProcess':
             logger.info(f'Target export job is pending or in process for {export_job_id}.')
         else:

--- a/parsons/ngpvan/targets.py
+++ b/parsons/ngpvan/targets.py
@@ -60,15 +60,11 @@ class Targets(object):
         """
 
         response = self.connection.get_request(f'targetExportJobs/{export_job_id}')
-        json_string = json.dumps(response)
-        json_obj = json.loads(json_string)
-        for i in json_obj:
-            job_status = i['jobStatus']
+        job_status = response.get('jobStatus')
         if job_status == 'Complete':
-            for j in json_obj:
-                csv = j['file']['downloadUrl']
-                response_csv = requests.get(csv)
-                return Table.from_csv_string(response_csv.text)
+            csv = response['file']['downloadUrl']
+            response_csv = requests.get(csv)
+            return Table.from_csv_string(response_csv.text)
         elif job_status == 'Pending' or job_status == 'InProcess':
             logger.info(f'Target export job is pending or in process for {export_job_id}.')
         else:

--- a/test/test_van/test_targets.py
+++ b/test/test_van/test_targets.py
@@ -91,7 +91,7 @@ class TestTargets(unittest.TestCase):
     def test_get_target_export(self, m):
 
         export_job_id = 455961790
-        json = [{
+        json = {
             "targetId": 12827,
             "file": {
                 "downloadUrl": (
@@ -101,7 +101,7 @@ class TestTargets(unittest.TestCase):
                 "recordCount": 1016883},
             "webhookUrl": "null",
             "exportJobId": 455961790,
-            "jobStatus": "Complete"}]
+            "jobStatus": "Complete"}
 
         download_url = (
             'https://ngpvan.blob.core.windows.net/target-export-files/TargetExport_455961790.csv')


### PR DESCRIPTION
It looks like this method assumes VAN return a *list* of exported files
rather than a single target, but VAN currently only returns individual
targets: https://docs.ngpvan.com/reference/targetexportjobsexportjobid

They might've changed the API since this was last updated? In any event,
these tweaks return correct data in my recent testing!