### PR TITLE
add phone to ngpvan apply canvass result

### DIFF
--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -509,9 +509,9 @@ class People(object):
             "omitActivistCodeContactHistory": omit_contact},
             "resultCodeId": result_code_id}
 
-        if input_type_id == 1 or input_type_id == 37:
+        if contact_type_id == 1 or contact_type_id == 37:
             if phone:
-                json['phone'] = {
+                json['canvassContext']['phone'] = {
                     "dialingPrefix": "1",
                     "phoneNumber": phone
                 }

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -372,7 +372,7 @@ class People(object):
         return self.connection.get_request(url, params={'$expand': expand_fields})
 
     def apply_canvass_result(self, id, result_code_id, id_type='vanid', contact_type_id=None,
-                             input_type_id=None, date_canvassed=None):
+                             input_type_id=None, date_canvassed=None, phone=None):
         """
         Apply a canvass result to a person. Use this end point for attempts that do not
         result in a survey response or an activist code (e.g. Not Home).
@@ -392,6 +392,8 @@ class People(object):
                 `Optional`; Defaults to 11 (API Input)
             date_canvassed : str
                 `Optional`; ISO 8601 formatted date. Defaults to todays date
+            phone: str
+                `Optional`; Phone number of any type (Work, Cell, Home)
         `Returns:`
             ``None``
         """
@@ -399,7 +401,7 @@ class People(object):
         logger.info(f'Applying result code {result_code_id} to {id_type} {id}.')
         self.apply_response(id, None, id_type=id_type, contact_type_id=contact_type_id,
                             input_type_id=input_type_id, date_canvassed=date_canvassed,
-                            result_code_id=result_code_id)
+                            result_code_id=result_code_id, phone=phone)
 
     def toggle_volunteer_action(self, id, volunteer_activity_id, action, id_type='vanid',
                                 result_code_id=None, contact_type_id=None, input_type_id=None,
@@ -444,7 +446,7 @@ class People(object):
 
     def apply_response(self, id, response, id_type='vanid', contact_type_id=None,
                        input_type_id=None, date_canvassed=None, result_code_id=None,
-                       omit_contact=False):
+                       omit_contact=False, phone=None):
         """
         Apply responses such as survey questions, activist codes, and volunteer actions
         to a person record. This method allows you apply multiple responses (e.g. two survey
@@ -477,6 +479,8 @@ class People(object):
                 Omit adding contact history to the response. This is particularly
                 useful when adding activist codes that are not based on contact
                 attempts.
+            phone: str
+                `Optional`; Phone number of any type (Work, Cell, Home)
         `Returns:`
             ``True`` if successful
 
@@ -504,6 +508,15 @@ class People(object):
             "dateCanvassed": date_canvassed,
             "omitActivistCodeContactHistory": omit_contact},
             "resultCodeId": result_code_id}
+
+        if input_type_id == 1 or input_type_id == 37:
+            if phone:
+                json['phone'] = {
+                    "dialingPrefix": "1",
+                    "phoneNumber": phone
+                }
+            else:
+                raise Exception('')
 
         if response:
             json['responses'] = response

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -516,7 +516,7 @@ class People(object):
                     "phoneNumber": phone
                 }
             else:
-                raise Exception('')
+                raise Exception('A phone number must be provided if canvassed via phone call or SMS')
 
         if response:
             json['responses'] = response

--- a/test/test_van/test_people.py
+++ b/test/test_van/test_people.py
@@ -132,6 +132,13 @@ class TestNGPVAN(unittest.TestCase):
         m.post(self.van.connection.uri + 'people/DWID:2335282/canvassResponses', status_code=204)
         self.van.apply_canvass_result(2335282, 18, id_type='DWID')
 
+        # test canvassing via phone or sms without providing phone number
+        self.assertRaises(Exception, self.van.apply_canvass_result, 2335282, 18, contact_type_id=37)
+
+        # test canvassing via phone or sms with providing phone number
+        m.post(self.van.connection.uri + 'people/2335282/canvassResponses', status_code=204)
+        self.van.apply_canvass_result(2335282, 18, contact_type_id=37, phone='(516)-555-2342')
+
     @requests_mock.Mocker()
     def test_apply_survey_question(self, m):
 


### PR DESCRIPTION
This is a fix for issue #525.

It's pretty straightforward in that it creates a new names param `phone` for `apply_canvass_result` which continues to send that to `apply_response`. In `apply_response` there is some logic to ensure that the `phone` param was provided if the `canvassTypeId` is either `1` or `37`. If it wasn't provided, throw an error, if it was provided, append it to the request as the API needs.