### PR TITLE
Update Mobilize connector URI, fix display of errors, fix auth issue

### DIFF
--- a/parsons/mobilize_america/ma.py
+++ b/parsons/mobilize_america/ma.py
@@ -8,7 +8,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-MA_URI = 'http://events.mobilizeamerica.io/api/v1/'
+MA_URI = 'https://api.mobilize.us/v1'
 
 
 class MobilizeAmerica(object):

--- a/parsons/mobilize_america/ma.py
+++ b/parsons/mobilize_america/ma.py
@@ -44,6 +44,8 @@ class MobilizeAmerica(object):
 
         r = _request(req_type, url, json=post_data, params=args, headers=header)
 
+        r.raise_for_status() 
+
         if 'error' in r.json():
             raise ValueError('API Error:' + str(r.json()['error']))
 

--- a/parsons/mobilize_america/ma.py
+++ b/parsons/mobilize_america/ma.py
@@ -59,7 +59,7 @@ class MobilizeAmerica(object):
 
         while r.json()['next']:
 
-            r = self._request(r.json()['next'], req_type=req_type)
+            r = self._request(r.json()['next'], req_type=req_type, auth=auth)
             json.extend(r.json()['data'])
 
         return json

--- a/parsons/mobilize_america/ma.py
+++ b/parsons/mobilize_america/ma.py
@@ -44,7 +44,7 @@ class MobilizeAmerica(object):
 
         r = _request(req_type, url, json=post_data, params=args, headers=header)
 
-        r.raise_for_status() 
+        r.raise_for_status()
 
         if 'error' in r.json():
             raise ValueError('API Error:' + str(r.json()['error']))

--- a/parsons/mobilize_america/ma.py
+++ b/parsons/mobilize_america/ma.py
@@ -8,7 +8,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-MA_URI = 'https://api.mobilize.us/v1'
+MA_URI = 'https://api.mobilize.us/v1/'
 
 
 class MobilizeAmerica(object):


### PR DESCRIPTION
1 -  Most importantly, this updates the base URI for the Mobilize connector, which was no longer working. **WARNING** this changes from HTTP to HTTPS which may cause authentication issues? I don't know. The Mobilize Connector has its own custom requests code and doesn't use APIConnector, which I assume would handle the change fine.

2 - Also fixed an issue where the auth information wasn't getting passed from `request_paginate` to `request`, which lead to auth errors.

3 -  Also (and this is the original reason I opened this PR):

The Mobilize connector uses the following logic to check for request errors:

`if 'error' in r.json():`

Unfortunately, for most unsuccessful API calls (including 404 file not found, 401 authentication, etc) no json is returned. Because we try to parse it anyway, the user sees an unreadable JSONDecodeError, like `simplejson.errors.JSONDecodeError: Expecting value: line 1 column 1 (char 0)` instead of the more helpful error message that requests would otherwise return.

This fix uses the helper method provided by requests, `r.raise_for_status()` to surface most errors, before moving on to the line `if 'error' in r.json():` (which may still be helpful in a subset of cases).

The better fix here is to rewrite the Mobilize connector to use the APIConnector utility, which was created precisely so we wouldn't have to duplicate this kind of general request logic within each connector, but that's a bigger change I don't have time for right now.