### PR TITLE
Fix Redshift column alteration bug

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -959,7 +959,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         # associated Parsons table columns. If they are, then alter column types to expand
         # their width.
         for c in set(rc.keys()).intersection(set(pc.keys())):
-            if rc[c] < pc[c]:
+            if rc[c] < pc[c] and rc[c] != 65535:
                 logger.info(f'{c} not wide enough. Expanding column width.')
                 # If requested size is larger than Redshift will allow,
                 # automatically set to Redshift's max varchar width

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -961,7 +961,12 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         for c in set(rc.keys()).intersection(set(pc.keys())):
             if rc[c] < pc[c]:
                 logger.info(f'{c} not wide enough. Expanding column width.')
-                self.alter_table_column_type(table_name, c, 'varchar', varchar_width=pc[c])
+                # If requested size is larger than Redshift will allow,
+                # automatically set to Redshift's max varchar width
+                new_size = 65535
+                if pc[c] < new_size:
+                    new_size = pc[c]
+                self.alter_table_column_type(table_name, c, 'varchar', varchar_width=new_size)
 
     def alter_table_column_type(self, table_name, column_name, data_type, varchar_width=None):
         """


### PR DESCRIPTION
Under current behavior, if you try to copy or upsert a Parsons table to Redshift with alter_table set to True, it'll take the incoming column widths and send them to Redshift as alteration queries. This will fail when a varchar column coming in from the Parsons table exceeds Redshift's maximum column width of 65535.

It's desirable to use the alter_table argument in combination with truncatecolumns to enact a sequence as follows:

1. Incoming Parsons table has values that are too wide for the current column width _and_ too wide for Redshift varchar constraints
2. Parsons resizes the destination columns to take up the maximum allowed width in Redshift, and then
3. Parsons successfully pushes the table to Redshift, truncating the column values that exceed 65535 characters.

As it stands, step 2 fails in this sequence because an invalid column width is sent to Redshift within an alteration query. This caps the allowable length of that alteration query. With this change, copy and upsert calls with truncatecolumns=False would still behave as expected, but calls with that argument set to true _and_ alter_table=True would exhibit the new behavior outlined above.