### PR TITLE
Remove leading and trailing whitespace from table and schema name in RS utility method table_exists_with_connection()

### DIFF
--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -28,6 +28,7 @@ class RedshiftTableUtilities(object):
 
     def table_exists_with_connection(self, table_name, connection, view=True):
         table_name = table_name.lower().split('.')
+        table_name = [x.strip() for x in table_name]
 
         # Check in pg tables for the table
         sql = """select count(*) from pg_tables where schemaname='{}' and


### PR DESCRIPTION
I ran into a very weird bug where splitting the Redshift table name string passed to an rs.copy() call over two lines in order to make my code PEP 8 compliant meant the table name had a leading whitespace character when passed to table_exists_to_connection(), meaning that the latter check failed, because no table with a leading whitespace in the name exists. This in turn caused rs.copy() to think it needed to create a new table even though one already existed, which caused a database error.

I think this small change should ensure that even if the table name string is split over two lines, the table name will not contain extra whitespace characters that will cause the lookup in pg_tables to fail.