### PR TITLE
Sendmail connector is now an abstract base class

### DIFF
--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -65,7 +65,6 @@ for module_path, connector_name in (
     ("parsons.newmode.newmode", "Newmode"),
     ("parsons.ngpvan.van", "VAN"),
     ("parsons.notifications.gmail", "Gmail"),
-    ("parsons.notifications.sendmail", "SendMail"),
     ("parsons.notifications.slack", "Slack"),
     ("parsons.notifications.smtp", "SMTP"),
     ("parsons.pdi.pdi", "PDI"),

--- a/parsons/notifications/sendmail.py
+++ b/parsons/notifications/sendmail.py
@@ -27,6 +27,17 @@ logger = logging.getLogger(__name__)
 
 class SendMail(ABC):
     """SendMail base class for sending emails.
+
+    This class is not designed to be used directly,
+    as it has useful methods for composing messages and validating emails
+    but does not contain all the required functionality in order
+    to send a message. Rather it should be subclassed for each different type of
+    email service, and those subclasses should define an __init__
+    method (to set any instance attributes such as credentials) and a _send_message
+    method (to implement the actual sending of the message).
+
+    For an example of this subclassing in practice, look at the Gmail notification
+    connector in parsons.notifications.gmail.
     """
 
     log = logger

--- a/parsons/notifications/sendmail.py
+++ b/parsons/notifications/sendmail.py
@@ -1,4 +1,5 @@
 # Adapted from Gmail API tutorial https://developers.google.com/gmail/api
+from abc import ABC, abstractmethod
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.image import MIMEImage
@@ -24,14 +25,20 @@ import os
 logger = logging.getLogger(__name__)
 
 
-class SendMail(object):
+class SendMail(ABC):
     """SendMail base class for sending emails.
     """
 
     log = logger
 
+    @abstractmethod
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
     def _send_message(self, message):
-        raise NotImplementedError("_send_message must be implemented for send_email to run")
+        pass
+        #raise NotImplementedError("_send_message must be implemented for send_email to run")
 
     def _create_message_simple(self, sender, to, subject, message_text):
         """Create a text-only message for an email.

--- a/parsons/notifications/sendmail.py
+++ b/parsons/notifications/sendmail.py
@@ -38,7 +38,6 @@ class SendMail(ABC):
     @abstractmethod
     def _send_message(self, message):
         pass
-        #raise NotImplementedError("_send_message must be implemented for send_email to run")
 
     def _create_message_simple(self, sender, to, subject, message_text):
         """Create a text-only message for an email.


### PR DESCRIPTION
After the work I did in #703 and a [subsequent Slack discussion](https://tmc-parsons.slack.com/archives/C018UUEMPJ5/p1657762357561899), here is a PR that makes the Sendmail connector an abstract base class. It also removes the connector from the parsons global `init`, since users aren't supposed to call it directly. I _think_ this covers all the usages of it, and the tests all passed locally, but if I missed something please don't hesitate to point it out.