### PR TITLE
Convert None to "" in convert_columns_to_str

### DIFF
--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -181,11 +181,16 @@ class ETL(object):
 
         cols = self.get_columns_type_stats()
 
+        def str_or_empty(x):
+            if x is None:
+                return ""
+            return str(x)
+
         for col in cols:
             # If there's more than one type (or no types), convert to str
             # Also if there is one type and it's not str, convert to str
             if len(col['type']) != 1 or col['type'][0] != 'str':
-                self.convert_column(col['name'], str)
+                self.convert_column(col['name'], str_or_empty)
 
         return self
 


### PR DESCRIPTION
The function `parsons.Table.convert_columns_to_str()` converts `None` to `"None"`. I think that converting it to the empty string is more intuitive and more helpful. It does make it harder to deserialize the result of `convert_columns_to_str`, but the `str` function is not generally deserializable anyway.