### PR TITLE
Update from 2.8.5 to 2.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ boto3==1.17.98
 boxsdk==2.10.0
 civis==1.14.2
 slackclient==1.3.0
-psycopg2-binary==2.8.5
+psycopg2-binary==2.9.3
 xmltodict==0.11.0
 gspread==3.7.0
 oauth2client==4.1.3


### PR DESCRIPTION
Opening this PR on behalf of @Jason94. We've had tons of trouble with psycopg2-binary, maybe updating to the most recent version will fix some of them.