### PR TITLE
Always use utf-8 encoding writing to RS s3

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -390,7 +390,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
              columntypes=None, specifycols=None, alter_table=False, alter_table_cascade=False,
              aws_access_key_id=None, aws_secret_access_key=None, iam_role=None,
              cleanup_s3_file=True, template_table=None, temp_bucket_region=None,
-             strict_length=True):
+             strict_length=True, csv_encoding='utf-8'):
         """
         Copy a :ref:`parsons-table` to Redshift.
 
@@ -500,6 +500,9 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
             strict_length: bool
                 Whether or not to tightly fit the length of the table columns to the length
                 of the data in ``tbl``; if ``padding`` is specified, this argument is ignored
+            csv_ecoding: str
+                String encoding to use when writing the temporary CSV file that is uploaded to S3.
+                Defaults to 'utf-8'.
 
         `Returns`
             Parsons Table or ``None``
@@ -537,7 +540,8 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
 
             # Upload the table to S3
             key = self.temp_s3_copy(tbl, aws_access_key_id=aws_access_key_id,
-                                    aws_secret_access_key=aws_secret_access_key)
+                                    aws_secret_access_key=aws_secret_access_key,
+                                    csv_encoding=csv_encoding)
 
             try:
                 # Copy to Redshift database.

--- a/parsons/databases/redshift/rs_copy_table.py
+++ b/parsons/databases/redshift/rs_copy_table.py
@@ -122,7 +122,7 @@ class RedshiftCopyTable(object):
             aws_access_key_id,
             aws_secret_access_key)
 
-    def temp_s3_copy(self, tbl, aws_access_key_id=None, aws_secret_access_key=None):
+    def temp_s3_copy(self, tbl, aws_access_key_id=None, aws_secret_access_key=None, csv_encoding='utf-8'):
 
         if not self.s3_temp_bucket:
             raise KeyError(("Missing S3_TEMP_BUCKET, needed for transferring data to Redshift. "
@@ -141,7 +141,7 @@ class RedshiftCopyTable(object):
 
         # Convert table to compressed CSV file, to optimize the transfers to S3 and to
         # Redshift.
-        local_path = tbl.to_csv(temp_file_compression='gzip', encoding='utf-8')
+        local_path = tbl.to_csv(temp_file_compression='gzip', encoding=csv_encoding)
         # Copy table to bucket
         self.s3.put_file(self.s3_temp_bucket, key, local_path)
 

--- a/parsons/databases/redshift/rs_copy_table.py
+++ b/parsons/databases/redshift/rs_copy_table.py
@@ -141,7 +141,7 @@ class RedshiftCopyTable(object):
 
         # Convert table to compressed CSV file, to optimize the transfers to S3 and to
         # Redshift.
-        local_path = tbl.to_csv(temp_file_compression='gzip')
+        local_path = tbl.to_csv(temp_file_compression='gzip', encoding='utf-8')
         # Copy table to bucket
         self.s3.put_file(self.s3_temp_bucket, key, local_path)
 

--- a/parsons/databases/redshift/rs_copy_table.py
+++ b/parsons/databases/redshift/rs_copy_table.py
@@ -122,7 +122,8 @@ class RedshiftCopyTable(object):
             aws_access_key_id,
             aws_secret_access_key)
 
-    def temp_s3_copy(self, tbl, aws_access_key_id=None, aws_secret_access_key=None, csv_encoding='utf-8'):
+    def temp_s3_copy(self, tbl, aws_access_key_id=None, aws_secret_access_key=None,
+                     csv_encoding='utf-8'):
 
         if not self.s3_temp_bucket:
             raise KeyError(("Missing S3_TEMP_BUCKET, needed for transferring data to Redshift. "


### PR DESCRIPTION
I think I figured out why Redshift.copy gives an encoding error very frequently, like this:
```
Traceback (most recent call last):
  File "C:\Users\JasonWalker\Programming\Workspace\one-off-scripts\mobilize\events.py", line 28, in <module>
    main()
  File "C:\Users\JasonWalker\Programming\Workspace\one-off-scripts\mobilize\events.py", line 24, in main
    rs.copy(events, 'indivisible_test.org_events', if_exists='drop', compupdate=False)
  File "c:\users\jasonwalker\programming\lib\parsons\parsons\databases\redshift\redshift.py", line 539, in copy
    key = self.temp_s3_copy(tbl, aws_access_key_id=aws_access_key_id,
  File "c:\users\jasonwalker\programming\lib\parsons\parsons\databases\redshift\rs_copy_table.py", line 144, in temp_s3_copy
    local_path = tbl.to_csv(temp_file_compression='gzip')
  File "c:\users\jasonwalker\programming\lib\parsons\parsons\etl\tofrom.py", line 137, in to_csv
    petl.tocsv(self.table,
  File "C:\Users\JasonWalker\Programming\lib\petl\petl\io\csv.py", line 108, in tocsv
    tocsv_impl(table, source=source, encoding=encoding, errors=errors,
  File "C:\Users\JasonWalker\Programming\lib\petl\petl\io\csv_py3.py", line 44, in tocsv_impl
    _writecsv(table, source=source, mode='wb', **kwargs)
  File "C:\Users\JasonWalker\Programming\lib\petl\petl\io\csv_py3.py", line 62, in _writecsv
    writer.writerow(row)
  File "C:\Python310\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u2028' in position 757: character maps to <undefined>
```
Redshift.copy winds up calling petl.to_csv , the result of which is copied to s3 and then transferred to Redshift. The acceptinvchars argument to Redshift.copy (@Soren Spicknall has pointed this out past times I've had this problem) does insert the acceptinvchars statement to the SQL to load the CSV into Redshift. However, the encoding for writing the temp .csv is not specified, so it fails if it encounters non-ascii characters. 