### PR TITLE
Simple docs for the SMTP connector

### DIFF
--- a/docs/notifications.rst
+++ b/docs/notifications.rst
@@ -184,10 +184,10 @@ To initialize the SMTP class you will need to tell it how to connect to the SMTP
 
 .. note::
   Environment Variables
-  * Instead of passing in values to initialize an instance of the SMTP class, you can set environment
-    variables to hold the values. The names of the environment variables are the names of the arguments
-    capitalized and prefixed with ``SMTP_``. For example, ``SMTP_HOST`` or ``SMTP_PASSWORD``. If both
-    an environment variable and an initialization argument are present, the argument will take precedence.
+    - Instead of passing in values to initialize an instance of the SMTP class, you can set environment
+      variables to hold the values. The names of the environment variables are the names of the arguments
+      capitalized and prefixed with ``SMTP_``. For example, ``SMTP_HOST`` or ``SMTP_PASSWORD``. If both
+      an environment variable and an initialization argument are present, the argument will take precedence.
 
 The easiest way to send a message:
 

--- a/docs/notifications.rst
+++ b/docs/notifications.rst
@@ -143,3 +143,82 @@ API
 ***
 .. autoclass:: parsons.Gmail
   :inherited-members:
+
+==========
+SMTP
+==========
+
+
+********
+Overview
+********
+
+The SMTP module enables the sending of email through a generic SMTP server. If you have an email server other
+than Gmail this is likely the best way to send emails with Parsons.
+
+.. note::
+  Credentials
+     - Credentials are required to use the class. You'll need to provide a valid username and password for
+       the SMTP server you are using.
+
+.. toctree::
+	:maxdepth: 1
+
+**********
+QuickStart
+**********
+
+To initialize the SMTP class you will need to tell it how to connect to the SMTP server:
+
+
+.. code-block:: python
+
+ from parsons import SMTP
+
+ smtp = SMTP(
+     host="fake.host.com",
+     port=9999,
+     username="my_username",
+     password="dont_use_this_password"
+ )
+
+.. note::
+  Environment Variables
+  * Instead of passing in values to initialize an instance of the SMTP class, you can set environment
+    variables to hold the values. The names of the environment variables are the names of the arguments
+    capitalized and prefixed with ``SMTP_``. For example, ``SMTP_HOST`` or ``SMTP_PASSWORD``. If both
+    an environment variable and an initialization argument are present, the argument will take precedence.
+
+The easiest way to send a message:
+
+.. code-block:: python
+
+  smtp.send_email(
+      "sender@email.com",
+      "recipient@email.com",
+      "The Subject",
+      "This is the text body of the email"
+  )
+
+The current version also supports sending html emails and emails with
+attachments.
+
+.. code-block:: python
+
+  smtp.send_email(
+      "sender@email.com",
+      "recipient@email.com",
+      "An html email with attachments",
+      "This is the text body of the email",
+      html="<p>This is the html part of the email</p>",
+      files=['file1.txt', 'file2.txt']
+  )
+
+***
+API
+***
+.. autoclass:: parsons.SMTP
+  :inherited-members:
+
+
+


### PR DESCRIPTION
I added some really simple documentation for the STMP class. It's based on the docs for the Gmail connector, with tweaks where appropriate. I have fairly limited knowledge of both SMTP and the class itself, so if I'm missing anything obvious please let me know!

This, along with #703 and #717, closes #635. 