### PR TITLE
Enhancement: Allow Subfolders for Temp S3 Bucket in Redshift Operations

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -79,6 +79,12 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         self.timeout = timeout
         self.dialect = 'redshift'
         self.s3_temp_bucket = s3_temp_bucket or os.environ.get('S3_TEMP_BUCKET')
+        # Set prefix for temp S3 bucket paths that include subfolders
+        self.s3_temp_bucket_prefix = None
+        if '/' in self.s3_temp_bucket:
+            split_temp_bucket_name = self.s3_temp_bucket.split('/', 1)
+            self.s3_temp_bucket = split_temp_bucket_name[0]
+            self.s3_temp_bucket_prefix = split_temp_bucket_name[1]
         # We don't check/load the environment variables for aws_* here
         # because the logic in S3() and rs_copy_table.py does already.
         self.aws_access_key_id = aws_access_key_id

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -81,7 +81,7 @@ class Redshift(RedshiftCreateTable, RedshiftCopyTable, RedshiftTableUtilities, R
         self.s3_temp_bucket = s3_temp_bucket or os.environ.get('S3_TEMP_BUCKET')
         # Set prefix for temp S3 bucket paths that include subfolders
         self.s3_temp_bucket_prefix = None
-        if '/' in self.s3_temp_bucket:
+        if self.s3_temp_bucket and '/' in self.s3_temp_bucket:
             split_temp_bucket_name = self.s3_temp_bucket.split('/', 1)
             self.s3_temp_bucket = split_temp_bucket_name[0]
             self.s3_temp_bucket_prefix = split_temp_bucket_name[1]

--- a/parsons/databases/redshift/rs_copy_table.py
+++ b/parsons/databases/redshift/rs_copy_table.py
@@ -139,7 +139,7 @@ class RedshiftCopyTable(object):
         hashed_name = hash(time.time())
         key = f"{S3_TEMP_KEY_PREFIX}/{hashed_name}.csv.gz"
         if self.s3_temp_bucket_prefix:
-            key = '/' + self.s3_temp_bucket_prefix + '/' + key
+            key = self.s3_temp_bucket_prefix + '/' + key
 
         # Convert table to compressed CSV file, to optimize the transfers to S3 and to
         # Redshift.

--- a/parsons/databases/redshift/rs_copy_table.py
+++ b/parsons/databases/redshift/rs_copy_table.py
@@ -138,6 +138,8 @@ class RedshiftCopyTable(object):
 
         hashed_name = hash(time.time())
         key = f"{S3_TEMP_KEY_PREFIX}/{hashed_name}.csv.gz"
+        if self.s3_temp_bucket_prefix:
+            key = '/' + self.s3_temp_bucket_prefix + '/' + key
 
         # Convert table to compressed CSV file, to optimize the transfers to S3 and to
         # Redshift.


### PR DESCRIPTION
This small change to the Redshift connector will allow users to direct the temporary S3 file storage used for Redshift copy operations to simulated S3 subfolders, rather than just a top-level bucket.