### PR TITLE
 Don't auto-grab session token if it's not passed in

### DIFF
--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -2,7 +2,6 @@ import re
 import boto3
 from parsons.utilities import files
 import logging
-import os
 
 logger = logging.getLogger(__name__)
 
@@ -21,11 +20,8 @@ class AWSConnection(object):
         # why that's not working.
 
         if aws_access_key_id and aws_secret_access_key:
-            # The AWS session token isn't needed most of the time, so we'll check
-            # for the env variable here instead of requiring it to be passed
-            # whenever the aws_access_key_id and aws_secret_access_key are passed.
-            if aws_session_token is None:
-                aws_session_token = os.getenv('AWS_SESSION_TOKEN')
+            # Trying to grab a session token from the environment variable can break things
+            # when used in concert with Zappa asynchronous processing, so don't force it here.
 
             self.session = boto3.Session(aws_access_key_id=aws_access_key_id,
                                          aws_secret_access_key=aws_secret_access_key,

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -2,15 +2,15 @@ import re
 import boto3
 from parsons.utilities import files
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
 
 class AWSConnection(object):
 
-    def __init__(self, aws_access_key_id=None,
-                 aws_secret_access_key=None,
-                 aws_session_token=None):
+    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None,                
+                    use_env_token=True):
 
         # Order of operations for searching for keys:
         #   1. Look for keys passed as kwargs
@@ -20,8 +20,12 @@ class AWSConnection(object):
         # why that's not working.
 
         if aws_access_key_id and aws_secret_access_key:
-            # Trying to grab a session token from the environment variable can break things
-            # when used in concert with Zappa asynchronous processing, so don't force it here.
+            # The AWS session token isn't needed most of the time, so we'll check
+            # for the env variable here instead of requiring it to be passed
+            # whenever the aws_access_key_id and aws_secret_access_key are passed.
+
+            if aws_session_token is None and use_env_token:
+                aws_session_token = os.getenv('AWS_SESSION_TOKEN')
 
             self.session = boto3.Session(aws_access_key_id=aws_access_key_id,
                                          aws_secret_access_key=aws_secret_access_key,

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -9,8 +9,8 @@ logger = logging.getLogger(__name__)
 
 class AWSConnection(object):
 
-    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None,                
-                    use_env_token=True):
+    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None,
+                 use_env_token=True):
 
         # Order of operations for searching for keys:
         #   1. Look for keys passed as kwargs


### PR DESCRIPTION
It turns out that trying to grab a session token from the environment variable can break things when used in concert with Zappa asynchronous processing - the access key and secret key passed in may not match the temporary token generated for the asynchronous process. Thus, this change requires the token to be passed in, even if it's set as an environment variable. 

As described [here](https://github.com/zappa/Zappa#asynchronous-task-execution), with asynchronous task execution, Zappa spins up a completely separate Lambda instance. The session token is generated as part of that process, and (as far as I can tell) is based on the execution role of the Lambda function.
So when the asynchronous task is running, it has the `aws_session_token` set even though there wasn't one originally. I'm not sure why it isn't just "None".
In any case, the token doesn't match the access key ID and secret access key that I was being passed in, resulting in an InvalidTokenError: `An error occurred (InvalidToken) when calling the PutObject operation: The provided token is malformed or otherwise invalid`. It's not that the token is actually invalid, but it doesn't match the credentials being passed in.

I'd like to be able to force aws_session_token to None even if the environment variable is set.