### PR TITLE
Fixed GitHub connector API docs

### DIFF
--- a/parsons/github/github.py
+++ b/parsons/github/github.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def _wrap_method(decorator, method):
+    @wraps(method)
     def _wrapper(self, *args, **kwargs):
         bound_method = partial(method.__get__(self, type(self)))
         return decorator(bound_method)(*args, **kwargs)


### PR DESCRIPTION
Even though `_wrap_method` is not _explicitly_ used as a decorator with the @ syntax, `decorate_methods` uses it in [functionally the same way](https://github.com/move-coop/parsons/blob/4775b5dfbcf5560a7dc2a617ed7847e41abdf450/parsons/github/github.py#L31). So adding `@wraps` to the inner function of `_wrap_method` seems to do the trick to propagate the docstrings.

I built the docs locally and it seems to work:
![image](https://user-images.githubusercontent.com/923682/192277128-fccc7000-68b2-498a-8ed3-f7e9060dfc86.png)


I also ran all the unit tests and nothing seems to have broken. 

Closes #742. 