### PR TITLE
Update Code of Conduct contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,11 +55,11 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at justin@movementcooperative.org. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported by contacting hr@movementcooperative.org. All complaints will be reviewed 
+and investigated and will result in a response that is deemed necessary and 
+appropriate to the circumstances. The project team is obligated to maintain 
+confidentiality with regard to the reporter of an incident. Further details 
+of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other


### PR DESCRIPTION
This looks like a bigger change than it is because I moved some linebreaks around to preserve matching line lengths. I just replaced "the project team at justin@movementcooperative.org" with "hr@movementcooperative.org".