### PR TITLE
Fix assert_matching_tables

### DIFF
--- a/test/test_google/test_google_admin.py
+++ b/test/test_google/test_google_admin.py
@@ -18,7 +18,7 @@ class TestGoogleAdmin(unittest.TestCase):
     mock_all_groups = Table([
         {'email': 'fakeemail4@fakedomain.com', 'id': 1},
         {'email': 'fakeemail5@fakedomain.com', 'id': 2},
-        {'email': 'fakeemail6@fakedomain.com', 'id': 2}
+        {'email': 'fakeemail6@fakedomain.com', 'id': 3}
     ])
 
     def setUp(self):

--- a/test/utils.py
+++ b/test/utils.py
@@ -38,4 +38,4 @@ def assert_matching_tables(table1, table2, ignore_headers=False):
 
     for r1, r2 in zip(data1, data2):
         # Cast both rows to lists, in case they are different types of collections
-        assert list(r1) == list(r2)
+        assert list(r1.items()) == list(r2.items())


### PR DESCRIPTION
In `utils.py`, when comparing `assert list(r1) == list(r2)`, this only compares if the headers of `r1` and `r2` are equal, when it should be comparing if the entire contents of both tables are equal.

This is why the `test_google_admin.py` test was passing even though it had a typo and should have failed. This typo is also fixed in this PR