### PR TITLE
use requests library

### DIFF
--- a/parsons/scytl/scytl.py
+++ b/parsons/scytl/scytl.py
@@ -1,9 +1,6 @@
-import urllib
 import zipfile
 import csv
 import requests
-import urllib.error
-import urllib.request
 import xml.etree.ElementTree as ET
 import typing as t
 from datetime import datetime
@@ -142,10 +139,9 @@ class Scytl:
         """
 
         with BytesIO() as zipdata:
-            with urllib.request.urlopen(zipfile_url) as remote:
-                data = remote.read()
-                zipdata.write(data)
-                zipdata.flush()
+            res = requests.get(zipfile_url)
+            zipdata.write(r.content)
+            zipdata.flush()
 
             zf = zipfile.ZipFile(zipdata)
 
@@ -635,7 +631,7 @@ class Scytl:
             try:
                 county_data = self._parse_file_from_zip_url(detail_xml_url, 'detail.xml')
 
-            except urllib.error.HTTPError:
+            except requests.exceptions.RequestException:
                 try:
                     summary_data = self._fetch_and_parse_summary_results(
                         f"{self.state}/{county_name}",
@@ -644,7 +640,7 @@ class Scytl:
                         county_name
                     )
 
-                except urllib.error.HTTPError:
+                except requests.exceptions.RequestException:
                     missing_counties.append(county_name)
 
                 else:

--- a/parsons/scytl/scytl.py
+++ b/parsons/scytl/scytl.py
@@ -137,12 +137,10 @@ class Scytl:
             bytes
             The unzipped file as bytes
         """
+        
+        res = requests.get(zipfile_url)
 
-        with BytesIO() as zipdata:
-            res = requests.get(zipfile_url)
-            zipdata.write(res.content)
-            zipdata.flush()
-
+        with BytesIO(res.content) as zipdata:
             zf = zipfile.ZipFile(zipdata)
 
             with zf.open(file_name) as input:

--- a/parsons/scytl/scytl.py
+++ b/parsons/scytl/scytl.py
@@ -138,9 +138,9 @@ class Scytl:
             The unzipped file as bytes
         """
         
-        res = requests.get(zipfile_url)
+        res = requests.get(zipfile_url, stream=True)
 
-        with BytesIO(res.content) as zipdata:
+        with BytesIO(res.raw) as zipdata:
             zf = zipfile.ZipFile(zipdata)
 
             with zf.open(file_name) as input:

--- a/parsons/scytl/scytl.py
+++ b/parsons/scytl/scytl.py
@@ -140,7 +140,11 @@ class Scytl:
         
         res = requests.get(zipfile_url, stream=True)
 
-        with BytesIO(res.raw) as zipdata:
+        with BytesIO() as zipdata:
+            for chunk in res.iter_content(chunk_size=8192): 
+                zipdata.write(chunk)
+                
+            zipdata.flush()
             zf = zipfile.ZipFile(zipdata)
 
             with zf.open(file_name) as input:

--- a/parsons/scytl/scytl.py
+++ b/parsons/scytl/scytl.py
@@ -140,7 +140,7 @@ class Scytl:
 
         with BytesIO() as zipdata:
             res = requests.get(zipfile_url)
-            zipdata.write(r.content)
+            zipdata.write(res.content)
             zipdata.flush()
 
             zf = zipfile.ZipFile(zipdata)


### PR DESCRIPTION
@shaunagm 

When we merged to main, the outgoing requests started failing with a "Forbidden" response, even though it worked both locally and in the pull request.

Let's see if migrating to the requests library improves the situation.