### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ google-auth==2.6.2
 facebook-business==13.0.0
 google-api-python-client==1.7.7
 google-resumable-media==2.3.2
-grpcio==1.45.0
+grpcio==1.51.1
 httplib2==0.19.0
 validate-email==1.3
 paramiko==2.11.0
@@ -21,7 +21,7 @@ joblib==1.2.0
 censusgeocode==0.4.3.post1
 airtable-python-wrapper==0.13.0
 google-cloud-storage==2.2.0
-google-cloud-bigquery==3.0.1
+google-cloud-bigquery==3.4.0
 docutils<0.18,>=0.14
 urllib3==1.26.5
 simplejson==3.16.0


### PR DESCRIPTION
I was getting a segmentation fault when running any and all tests locally. OS: macOS Ventura 13.01. Python version: 3.10.8. See below log:
```
(parsons-ve) kathynguyen@administrators-MacBook-Pro parsons % pytest -rf test/test_shopify.py
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.10.8, pytest-7.1.1, pluggy-1.0.0
rootdir: /Users/kathynguyen/Documents/GitHub/parsons, configfile: pytest.ini
plugins: requests-mock-1.5.2, datadir-1.3.0
collected 4 items                                                                                                                                             
test/test_shopify.py ....                                                                                                                               [100%]
====================================================================== warnings summary =======================================================================
../../../.pyenv/versions/3.10.8/envs/parsons-ve/lib/python3.10/site-packages/joblib/my_exceptions.py:21
  /Users/kathynguyen/.pyenv/versions/3.10.8/envs/parsons-ve/lib/python3.10/site-packages/joblib/my_exceptions.py:21: DeprecationWarning: TransportableException is deprecated and will be removed from joblib in 0.16
    warn("{} is deprecated and will be removed from joblib "
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ 4 passed, 1 warning in 1.29s =================================================================
zsh: segmentation fault  pytest -rf test/test_shopify.py
```

After some digging, it was discovered that the root cause is the `google-cloud-bigquery==3.0.1` requirement. This installs `pyarrow==7.0.0` which caused the segmentation fault. After upgrading to `google-cloud-bigquery==3.4.0`, pyarrow will be updated to `pyarrow==10.0.1`, which will fix the issue. `grpcio` is also required to by updated because of the `google-cloud-bigquery` update