### PR TITLE
Redshift.copy() can use AWS Session Token as part of auth variables

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -488,6 +488,8 @@ class Redshift(
         alter_table_cascade=False,
         aws_access_key_id=None,
         aws_secret_access_key=None,
+        aws_session_token=None,
+        use_env_token=False,
         iam_role=None,
         cleanup_s3_file=True,
         template_table=None,
@@ -586,6 +588,9 @@ class Redshift(
             aws_secret_access_key:
                 An AWS secret access key granted to the bucket where the file is located. Not
                 required if keys are stored as environmental variables.
+            aws_session_token:
+                An AWS session token granted to the bucket where the file is located. Not
+                required if keys are stored as environmental variables.
             iam_role: str
                 An AWS IAM Role ARN string; an alternative credential for the COPY command
                 from Redshift to S3. The IAM role must have been assigned to the Redshift
@@ -653,6 +658,8 @@ class Redshift(
                 tbl,
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
+                use_env_token=use_env_token,
                 csv_encoding=csv_encoding,
             )
 
@@ -674,6 +681,7 @@ class Redshift(
                     "specifycols": cols,
                     "aws_access_key_id": aws_access_key_id,
                     "aws_secret_access_key": aws_secret_access_key,
+                    "aws_session_token": aws_session_token,
                     "compression": "gzip",
                     "bucket_region": temp_bucket_region,
                 }

--- a/test/test_redshift.py
+++ b/test/test_redshift.py
@@ -1,9 +1,9 @@
-from parsons import Redshift, S3, Table
-from test.utils import assert_matching_tables
-import unittest
 import os
 import re
-from test.utils import validate_list
+import unittest
+from test.utils import assert_matching_tables, validate_list
+
+from parsons import S3, Redshift, Table
 from testfixtures import LogCapture
 
 # The name of the schema and will be temporarily created for the tests
@@ -199,6 +199,29 @@ class TestRedshift(unittest.TestCase):
         # Reset env vars
         os.environ["AWS_ACCESS_KEY_ID"] = prior_aws_access_key_id
         os.environ["AWS_SECRET_ACCESS_KEY"] = prior_aws_secret_access_key
+
+    def test_get_creds_kwargs_with_token(self):
+
+        # Test passing kwargs
+        creds = self.rs.get_creds("kwarg_key", "kwarg_secret_key", "kwarg_token")
+        expected = """credentials 'aws_access_key_id=kwarg_key;aws_secret_access_key=kwarg_secret_key;token=kwarg_token'\n"""  # noqa: E501
+        self.assertEqual(creds, expected)
+
+        # Test grabbing from environmental variables
+        prior_aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID", "")
+        prior_aws_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+        prior_aws_session_token = os.environ.get("AWS_SESSION_TOKEN", "")
+        os.environ["AWS_ACCESS_KEY_ID"] = "env_key"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "env_secret_key"
+        os.environ["AWS_SESSION_TOKEN"] = "env_token"
+        creds = self.rs.get_creds(None, None)
+        expected = """credentials 'aws_access_key_id=env_key;aws_secret_access_key=env_secret_key;token=env_token'\n"""  # noqa: E501
+        self.assertEqual(creds, expected)
+
+        # Reset env vars
+        os.environ["AWS_ACCESS_KEY_ID"] = prior_aws_access_key_id
+        os.environ["AWS_SECRET_ACCESS_KEY"] = prior_aws_secret_access_key
+        os.environ["AWS_SESSION_TOKEN"] = prior_aws_session_token
 
     def scrub_copy_tokens(self, s):
 


### PR DESCRIPTION
A session token is sometimes a necessary component of AWS auth
credentials alongside an access key and secret key. This commit
enables a session token to be passed in the same ways that the other
credentials are passed:

- directly as part of copy_args
- through environmental variables

A test is added at `test/test_redshift.py::TestRedshift::test_get_creds_kwargs_with_token` to validate this behavior.
