### PR TITLE
Catch File Extensions in S3 Prefix

### DIFF
--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -158,9 +158,21 @@ class S3(object):
 
         continuation_token = None
 
-        # Confirm that prefix has trailing / if it's provided
-        if prefix and not prefix.endswith("/"):
-            prefix = f"{prefix}/"
+        """
+        Two conditions here...
+
+        * User supplied a prefix
+        * The prefix is a route OR file type
+        * We assume a '.' here specifies a file extension
+
+        If all of these conditions are met then a trailing slash is implicitly
+        added to the prefix
+        """
+
+        if prefix and not prefix.endswith("/") and "." not in prefix:
+            supplied_prefix = prefix
+            prefix = f"{supplied_prefix}/"
+            logger.info(f"BE ADVISED: Prefix {supplied_prefix} updated to {prefix}")
 
         while True:
             args = {"Bucket": bucket}

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -158,8 +158,8 @@ class S3(object):
 
         continuation_token = None
 
-        # Confirm that prefix has trailing /
-        if not prefix.endswith("/"):
+        # Confirm that prefix has trailing / if it's provided
+        if prefix and not prefix.endswith("/"):
             prefix = f"{prefix}/"
 
         while True:

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -176,7 +176,9 @@ class S3(object):
                 error_message = """Unable to list bucket objects!
                 This may be due to a lack of permission on the requested
                 bucket. Double-check that you have sufficient READ permissions
-                on the bucket you've requested"""
+                on the bucket you've requested. If you only have permissions for
+                keys within a specific prefix, make sure you include a trailing '/' in
+                in prefix."""
 
                 logger.error(error_message)
 

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -173,23 +173,14 @@ class S3(object):
                 resp = self.client.list_objects_v2(**args)
 
             except ClientError as e:
-                new_prefix = f"{prefix}/"
+                error_message = """Unable to list bucket objects!
+                This may be due to a lack of permission on the requested
+                bucket. Double-check that you have sufficient READ permissions
+                on the bucket you've requested"""
 
-                logger.error(
-                    f"Failed to return objects ... updating prefix={new_prefix}"
-                )
+                logger.error(error_message)
 
-                args["Prefix"] = new_prefix
-
-                try:
-                    resp = self.client.list_objects_v2(**args)
-
-                except ClientError as e:
-                    logger.error(
-                        "Failed to return objects - check your permissions on this bucket"
-                    )
-
-                    raise e
+                raise e
 
             for key in resp.get("Contents", []):
                 # Match suffix

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -1,5 +1,6 @@
 import re
 import boto3
+from botocore.client import ClientError
 from parsons.utilities import files
 import logging
 import os
@@ -15,7 +16,6 @@ class AWSConnection(object):
         aws_session_token=None,
         use_env_token=True,
     ):
-
         # Order of operations for searching for keys:
         #   1. Look for keys passed as kwargs
         #   2. Look for env variables
@@ -71,7 +71,6 @@ class S3(object):
         aws_session_token=None,
         use_env_token=True,
     ):
-
         self.aws = AWSConnection(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
@@ -159,18 +158,32 @@ class S3(object):
 
         continuation_token = None
 
+        # Confirm that prefix has trailing /
+        if not prefix.endswith("/"):
+            prefix = f"{prefix}/"
+
         while True:
             args = {"Bucket": bucket}
+
             if prefix:
                 args["Prefix"] = prefix
+
             if continuation_token:
                 args["ContinuationToken"] = continuation_token
+
             args.update(kwargs)
 
-            resp = self.client.list_objects_v2(**args)
+            try:
+                resp = self.client.list_objects_v2(**args)
+
+            except ClientError as e:
+                logger.error(
+                    "FAILED TO RETURN OBJECTS! Double-check your permissions in this bucket, and consider providing a prefix"
+                )
+
+                raise e
 
             for key in resp.get("Contents", []):
-
                 # Match suffix
                 if suffix and not key["Key"].endswith(suffix):
                     continue
@@ -201,10 +214,12 @@ class S3(object):
             # If more than 1000 results, continue with token
             if resp.get("NextContinuationToken"):
                 continuation_token = resp["NextContinuationToken"]
+
             else:
                 break
 
         logger.debug(f"Retrieved {len(keys_dict)} keys")
+
         return keys_dict
 
     def key_exists(self, bucket, key):

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -177,8 +177,9 @@ class S3(object):
                 resp = self.client.list_objects_v2(**args)
 
             except ClientError as e:
+                logger.error("FAILED TO RETURN OBJECTS!")
                 logger.error(
-                    "FAILED TO RETURN OBJECTS! Double-check your permissions in this bucket, and consider providing a prefix"
+                    "Check your permissions in this bucket, and consider providing a prefix"
                 )
 
                 raise e


### PR DESCRIPTION
Adding in logic to skip the `prefix -> prefix/` logic here if a file extension is passed in.

Will defer to @KasiaHinkson on what the best solution is here (not sure I totally understand where this is breaking in STW sync)