### PR TITLE
Remove hardcoded version number from conf.py and correct repo link in setup.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ author = "The Movement Cooperative"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "0.5"
+release = ""
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ def main():
         version="1.0.0",
         author="The Movement Cooperative",
         author_email="info@movementcooperative.org",
-        url="https://github.com/movementcoop/parsons",
+        url="https://github.com/move-coop/parsons",
         keywords=["PROGRESSIVE", "API", "ETL"],
         packages=find_packages(),
         install_requires=install_requires,


### PR DESCRIPTION
The hardcoded version "0.5" currently gets automatically populated in the title of [the Parsons docs site](https://move-coop.github.io/parsons/html/stable/index.html), no matter which release of the package is selected. This change clears the value entirely.

Additionally, the setup script for the package currently references an old location of the repository, which is corrected in this PR. There may be follow-up necessary to fix the same link [on PyPI](https://pypi.org/project/parsons/) - I'm not sure if that information populates directly from what's provided in setup.py upon the occasion of a new release.