### PR TITLE
DatabaseConnector Interface to Major Release

### DIFF
--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -47,6 +47,7 @@ for module_path, connector_name in (
     ("parsons.controlshift.controlshift", "Controlshift"),
     ("parsons.copper.copper", "Copper"),
     ("parsons.crowdtangle.crowdtangle", "CrowdTangle"),
+    ("parsons.databases.database_connector", "DatabaseConnector"),
     ("parsons.databases.db_sync", "DBSync"),
     ("parsons.databases.mysql.mysql", "MySQL"),
     ("parsons.databases.postgres.postgres", "Postgres"),

--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -48,6 +48,7 @@ for module_path, connector_name in (
     ("parsons.copper.copper", "Copper"),
     ("parsons.crowdtangle.crowdtangle", "CrowdTangle"),
     ("parsons.databases.database_connector", "DatabaseConnector"),
+    ("parsons.databases.discover_database", "DiscoverDatabase"),
     ("parsons.databases.db_sync", "DBSync"),
     ("parsons.databases.mysql.mysql", "MySQL"),
     ("parsons.databases.postgres.postgres", "Postgres"),

--- a/parsons/__init__.py
+++ b/parsons/__init__.py
@@ -48,7 +48,7 @@ for module_path, connector_name in (
     ("parsons.copper.copper", "Copper"),
     ("parsons.crowdtangle.crowdtangle", "CrowdTangle"),
     ("parsons.databases.database_connector", "DatabaseConnector"),
-    ("parsons.databases.discover_database", "DiscoverDatabase"),
+    ("parsons.databases.discover_database", "discover_database"),
     ("parsons.databases.db_sync", "DBSync"),
     ("parsons.databases.mysql.mysql", "MySQL"),
     ("parsons.databases.postgres.postgres", "Postgres"),

--- a/parsons/databases/database_connector.py
+++ b/parsons/databases/database_connector.py
@@ -65,7 +65,7 @@ class DatabaseConnector(ABC):
             if_exists (str):
                 If the table already exists, either ``fail``, ``append``, ``drop``
                 or ``truncate`` the table.
-            strict_length (bool, optional): 
+            strict_length (bool, optional):
                 Whether or not to tightly fit the length of the table columns to the length
                 of the data in ``tbl``; if ``padding`` is specified, this argument is ignored.
                 Defaults to True.

--- a/parsons/databases/database_connector.py
+++ b/parsons/databases/database_connector.py
@@ -9,8 +9,63 @@ class DatabaseConnector(ABC):
     This class should be used in functions instead of the specific database connector classes
     when the functions don't rely on database-specific functionality.
 
-    It ensures that any class that inherits from it implements the `table_exists`, `copy`, and
-    `query` methods, which are common operations when working with databases.
+    It ensures that any class that inherits from it implements the methods that are uniform
+    operations when working with databases.
+
+    Should you use `DatabaseConnector` instead of `Redshift`/`BigQuery`/etc?
+
+    Overall this class is mostly useful for code in the Parsons library, not code using it.
+    There could be some exceptions. In general though, if you are writing a script to do a task
+    like moving data out of an API service and into a data warehouse, you probably do not need
+    to use DatabaseConnector. You can probably just use the Parsons class that directly corresponds
+    with the database that you use.
+
+    Here are more examples of situations where you may or may not need to use DatabaseConnector:
+
+        1. You do not use type annotations, or you don't know what "type annotations" are - No
+
+            If you do not use type annotations for your code, then you do not need to think about
+            `DatabaseConnector` when writing your code. This is the most common case. If none
+            of the cases below apply to you, then you probably don't need it.
+
+            In this simple example, we are not using type annotations in our code. We don't need
+            to think about exactly what class is being passed in. Python will figure it out.
+
+            ```python
+            def my_database_function(db):
+                    some_data = get_some_data()
+                    db.copy("some_table", some_data)
+
+            # These will all just work:
+            my_database_function(Redshift())
+            my_database_function(MySQL())
+            my_database_functon(BigQuery())
+            ```
+
+        2. You only use one database in your work - No
+
+            This is where most people will fall. Usually code is not intended to run on
+            multiple databases without modification. For example, if you are working for
+            an organization that uses Amazon Redshift as your data warehouse, you do not
+            need to use `DatabaseConnector` to write ETL scripts to load data into your
+            Redshift. It is rare that organizations switch databases. In the cases where
+            that does occur, usually more work is required to migrate your environment and
+            your vendor-specific SQL than would be saved by using `DatabaseConnector`.
+
+        3. You are writing a sample script or a tutorial - Yes
+
+            If you are using Parsons to write a sample script or tutorial, you should use
+            `DatabaseConnector`! If you use `DatabaseConnector` type annotations and the
+            `discover_database` function, then your sample code will run on any system.
+            This makes it much easier for new programmers to get your code working on
+            their system.
+
+        4. Utility code inside Parsons or other libraries - Yes
+
+            If you are writing a utility script inside Parsons or another library meant
+            for broad distribution, you should probably use `DatabaseConnector` type
+            annotations. This will ensure that your library code will be usable by the
+            widest possible set of users, not just users on one specific database.
 
     Note:
         The Python type system (as of 3.10.6) will not stop you from breaking the type contract

--- a/parsons/databases/database_connector.py
+++ b/parsons/databases/database_connector.py
@@ -1,0 +1,112 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+from parsons.etl.table import Table
+
+
+class DatabaseConnector(ABC):
+    """
+    An abstract base class that provides a uniform interface for all Parsons database connectors.
+    This class should be used in functions instead of the specific database connector classes
+    when the functions don't rely on database-specific functionality.
+
+    It ensures that any class that inherits from it implements the `table_exists`, `copy`, and
+    `query` methods, which are common operations when working with databases.
+
+    Note:
+        The Python type system (as of 3.10.6) will not stop you from breaking the type contract
+        of method signatures when implementing a subclass. It is up to the author of a database
+        connector to ensure that it satisfies this interface. Be careful to, for example, not
+        change the types of the parameters or leave out optional parameters that are specified
+        in the interface.
+
+        Any such inconsistencies can cause unexpected runtime errors that will not be caught by
+        the type checker.
+
+        It is possible to safely add additional features, such as new methods or extra **optional**
+        parameters to specified methods. In general adding new methods is safe, but adding optional
+        parameters to methods specified in the interface should be considered bad practice, because
+        it could result in unexpected behavior.
+
+    Example usage:
+
+    .. code-block:: python
+
+        def my_function(db: DatabaseConnector, data: Table):
+            # Your code here, using the db object
+
+        # Pass an instance of a class that inherits from DatabaseConnector, e.g. Redshift
+        my_function(some_db_instance, some_data)
+
+    """
+
+    @abstractmethod
+    def table_exists(self, table_name: str) -> bool:
+        """ Check if a table or view exists in the database.
+
+        `Args:`
+            table_name: str
+                The table name and schema (e.g. ``myschema.mytable``).
+
+        `Returns:`
+            boolean
+                ``True`` if the table exists and ``False`` if it does not.
+        """
+        pass
+
+    @abstractmethod
+    def copy(self, tbl: Table, table_name: str, if_exists: str, strict_length=True):
+        """ Copy a :ref:`parsons-table` to the database.
+
+        `Args`:
+            tbl (Table):
+                Table containing the data to save.
+            table_name (str):
+                The destination table name (ex. ``my_schema.my_table``).
+            if_exists (str):
+                If the table already exists, either ``fail``, ``append``, ``drop``
+                or ``truncate`` the table.
+            strict_length (bool, optional): 
+                Whether or not to tightly fit the length of the table columns to the length
+                of the data in ``tbl``; if ``padding`` is specified, this argument is ignored.
+                Defaults to True.
+        """
+        pass
+
+    @abstractmethod
+    def query(self, sql: str, parameters: Optional[list] = None) -> Optional[Table]:
+        """ Execute a query against the database. Will return ``None`` if the query returns empty.
+
+        To include python variables in your query, it is recommended to pass them as parameters,
+        following the `psycopg style
+          <http://initd.org/psycopg/docs/usage.html#passing-parameters-to-sql-queries>`.
+        Using the ``parameters`` argument ensures that values are escaped properly, and avoids SQL
+        injection attacks.
+
+        **Parameter Examples**
+
+        .. code-block:: python
+
+            # Note that the name contains a quote, which could break your query if not escaped
+            # properly.
+            name = "Beatrice O'Brady"
+            sql = "SELECT * FROM my_table WHERE name = %s"
+            db.query(sql, parameters=[name])
+
+        .. code-block:: python
+
+            names = ["Allen Smith", "Beatrice O'Brady", "Cathy Thompson"]
+            placeholders = ', '.join('%s' for item in names)
+            sql = f"SELECT * FROM my_table WHERE name IN ({placeholders})"
+            db.query(sql, parameters=names)
+
+        `Args:`
+            sql: str
+                A valid SQL statement
+            parameters: Optional[list]
+                A list of python variables to be converted into SQL values in your query
+
+        `Returns:`
+            Parsons Table
+                See :ref:`parsons-table` for output options.
+        """
+        pass

--- a/parsons/databases/database_connector.py
+++ b/parsons/databases/database_connector.py
@@ -54,7 +54,7 @@ class DatabaseConnector(ABC):
         pass
 
     @abstractmethod
-    def copy(self, tbl: Table, table_name: str, if_exists: str, strict_length=True):
+    def copy(self, tbl: Table, table_name: str, if_exists: str):
         """ Copy a :ref:`parsons-table` to the database.
 
         `Args`:
@@ -65,9 +65,6 @@ class DatabaseConnector(ABC):
             if_exists (str):
                 If the table already exists, either ``fail``, ``append``, ``drop``
                 or ``truncate`` the table.
-            strict_length (bool, optional):
-                Whether or not to tightly fit the length of the table columns to the length
-                of the data in ``tbl``. Defaults to True.
         """
         pass
 

--- a/parsons/databases/database_connector.py
+++ b/parsons/databases/database_connector.py
@@ -80,9 +80,10 @@ class DatabaseConnector(ABC):
 
         If you go the second route, you can add a stub method like this:
 
-            ```python
-            def new_method(self, arg1, arg2):
-                raise NotImplementedError("Method not implemented for this database connector.")
+            .. code-block:: python
+
+                def new_method(self, arg1, arg2):
+                    raise NotImplementedError("Method not implemented for this database connector.")
             ```
 
         This communicates clearly to users that the method does not exist for certain connectors.

--- a/parsons/databases/database_connector.py
+++ b/parsons/databases/database_connector.py
@@ -67,6 +67,32 @@ class DatabaseConnector(ABC):
             annotations. This will ensure that your library code will be usable by the
             widest possible set of users, not just users on one specific database.
 
+    Developer Notes:
+        This class is an Abstract Base Class (ABC). It's designed to ensure that all classes
+        inheriting from it implement certain methods, enforcing a consistent interface across
+        database connectors.
+
+        If you need to add a new method to the database connectors, there are three options:
+        1. Add the method to this ABC and implement it for all databases.
+        2. Add the method to this ABC and implement it for some databases while adding stubs for
+           others.
+        3. Implement the method on a specific database connector without touching the ABC.
+
+        If you go the second route, you can add a stub method like this:
+
+            ```python
+            def new_method(self, arg1, arg2):
+                raise NotImplementedError("Method not implemented for this database connector.")
+            ```
+
+        This communicates clearly to users that the method does not exist for certain connectors.
+
+        If you go the third route, remember that you're responsible for making sure your new
+        method matches the existing methods in other database connectors. For example, if you're
+        adding a method that already exists in another connector, like Redshift, you need to ensure
+        your new method behaves the same way and has the same parameters with the same types in the
+        same order. See the note below for more detail.
+
     Note:
         The Python type system (as of 3.10.6) will not stop you from breaking the type contract
         of method signatures when implementing a subclass. It is up to the author of a database
@@ -77,7 +103,7 @@ class DatabaseConnector(ABC):
         Any such inconsistencies can cause unexpected runtime errors that will not be caught by
         the type checker.
 
-        It is possible to safely add additional features, such as new methods or extra **optional**
+        It is safe to add additional features to subclasses, such as new methods or extra *optional*
         parameters to specified methods. In general adding new methods is safe, but adding optional
         parameters to methods specified in the interface should be considered bad practice, because
         it could result in unexpected behavior.

--- a/parsons/databases/database_connector.py
+++ b/parsons/databases/database_connector.py
@@ -67,8 +67,7 @@ class DatabaseConnector(ABC):
                 or ``truncate`` the table.
             strict_length (bool, optional):
                 Whether or not to tightly fit the length of the table columns to the length
-                of the data in ``tbl``; if ``padding`` is specified, this argument is ignored.
-                Defaults to True.
+                of the data in ``tbl``. Defaults to True.
         """
         pass
 

--- a/parsons/databases/database_connector.py
+++ b/parsons/databases/database_connector.py
@@ -41,7 +41,7 @@ class DatabaseConnector(ABC):
 
     @abstractmethod
     def table_exists(self, table_name: str) -> bool:
-        """ Check if a table or view exists in the database.
+        """Check if a table or view exists in the database.
 
         `Args:`
             table_name: str
@@ -55,7 +55,7 @@ class DatabaseConnector(ABC):
 
     @abstractmethod
     def copy(self, tbl: Table, table_name: str, if_exists: str):
-        """ Copy a :ref:`parsons-table` to the database.
+        """Copy a :ref:`parsons-table` to the database.
 
         `Args`:
             tbl (Table):
@@ -70,7 +70,7 @@ class DatabaseConnector(ABC):
 
     @abstractmethod
     def query(self, sql: str, parameters: Optional[list] = None) -> Optional[Table]:
-        """ Execute a query against the database. Will return ``None`` if the query returns empty.
+        """Execute a query against the database. Will return ``None`` if the query returns empty.
 
         To include python variables in your query, it is recommended to pass them as parameters,
         following the `psycopg style

--- a/parsons/databases/discover_database.py
+++ b/parsons/databases/discover_database.py
@@ -8,7 +8,7 @@ from parsons.google.google_bigquery import GoogleBigQuery
 
 
 def discover_database() -> DatabaseConnector:
-    """ Create an appropriate ``DatabaseConnector`` based on environmental variables.
+    """Create an appropriate ``DatabaseConnector`` based on environmental variables.
 
     Will search the environmental variables for the proper credentials for the
     Redshift, MySQL, Postgres, and BigQuery connectors. See the documentation

--- a/parsons/databases/discover_database.py
+++ b/parsons/databases/discover_database.py
@@ -1,0 +1,35 @@
+import os
+
+from parsons.databases.database_connector import DatabaseConnector
+from parsons.databases.redshift import Redshift
+from parsons.databases.mysql import MySQL
+from parsons.databases.postgres import Postgres
+from parsons.google.google_bigquery import GoogleBigQuery
+
+
+def discover_database() -> DatabaseConnector:
+    """ Create an appropriate ``DatabaseConnector`` based on environmental variables.
+
+    Will search the environmental variables for the proper credentials for the
+    Redshift, MySQL, Postgres, and BigQuery connectors. See the documentation
+    for the connectors to variables required to initialize them.
+
+    If no suitable configuration is found, will raise an error.
+
+    Note that the variables to be searched for are hard-coded in this function,
+    since they are unlikely to change. If that is done, for some reason, or a
+    new database connector is added, ``discover_database`` should be updated
+
+    Returns:
+        DatabaseConnector: The database connector configured in the environment.
+    """
+    if os.getenv("REDSHIFT_PASSWORD"):
+        return Redshift()
+    elif os.getenv("MYSQL_PASSWORD"):
+        return MySQL()
+    elif os.getenv("PGPASSWORD"):
+        return Postgres()
+    elif os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
+        return GoogleBigQuery()
+
+    raise EnvironmentError("Could not find any database configuration.")

--- a/parsons/databases/discover_database.py
+++ b/parsons/databases/discover_database.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional, Union, Type, List
 
 from parsons.databases.database_connector import DatabaseConnector
 from parsons.databases.redshift import Redshift
@@ -7,7 +8,11 @@ from parsons.databases.postgres import Postgres
 from parsons.google.google_bigquery import GoogleBigQuery
 
 
-def discover_database() -> DatabaseConnector:
+def discover_database(
+    default_connector: Optional[
+        Union[Type[DatabaseConnector], List[Type[DatabaseConnector]]]
+    ] = None
+) -> DatabaseConnector:
     """Create an appropriate ``DatabaseConnector`` based on environmental variables.
 
     Will search the environmental variables for the proper credentials for the
@@ -16,20 +21,59 @@ def discover_database() -> DatabaseConnector:
 
     If no suitable configuration is found, will raise an error.
 
+    If multiple suitable configurations are found, will raise an error unless
+    a default connector class or list of classes is provided.
+
     Note that the variables to be searched for are hard-coded in this function,
     since they are unlikely to change. If that is done, for some reason, or a
     new database connector is added, ``discover_database`` should be updated
 
+    Args:
+        default_connector: Optional, single Class or list of Classes inheriting from
+        DatabaseConnector to be used as default in case multiple database configurations
+        are detected.
+
     Returns:
         DatabaseConnector: The database connector configured in the environment.
     """
-    if os.getenv("REDSHIFT_PASSWORD"):
-        return Redshift()
-    elif os.getenv("MYSQL_PASSWORD"):
-        return MySQL()
-    elif os.getenv("PGPASSWORD"):
-        return Postgres()
-    elif os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
-        return GoogleBigQuery()
+    connectors = {
+        "Redshift": Redshift,
+        "MySQL": MySQL,
+        "Postgres": Postgres,
+        "GoogleBigQuery": GoogleBigQuery,
+    }
 
-    raise EnvironmentError("Could not find any database configuration.")
+    password_vars = {
+        "Redshift": "REDSHIFT_PASSWORD",
+        "MySQL": "MYSQL_PASSWORD",
+        "Postgres": "PGPASSWORD",
+        "GoogleBigQuery": "GOOGLE_APPLICATION_CREDENTIALS",
+    }
+
+    detected = [name for name in connectors.keys() if os.getenv(password_vars[name])]
+
+    if len(detected) > 1:
+        if default_connector is None:
+            raise EnvironmentError(
+                f"Multiple database configurations detected: {detected}."
+                " Please specify a default connector."
+            )
+
+        if isinstance(default_connector, list):
+            for connector in default_connector:
+                if connector.__name__ in detected:
+                    return connector()
+            raise EnvironmentError(
+                f"None of the default connectors {default_connector} were detected."
+            )
+        elif default_connector.__name__ in detected:
+            return default_connector()
+        else:
+            raise EnvironmentError(
+                f"Default connector {default_connector} not detected. Detected: {detected}."
+            )
+
+    elif detected:
+        return connectors[detected[0]]()
+    else:
+        raise EnvironmentError("Could not find any database configuration.")

--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -307,7 +307,7 @@ class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
         else:
             return True
 
-    def table_exists(self, table_name: str):
+    def table_exists(self, table_name: str) -> bool:
         """
         Check if a table or view exists in the database.
 

--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -152,7 +152,6 @@ class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
                 See :ref:`parsons-table` for output options.
         """
         with self.cursor(connection) as cursor:
-
             # The python connector can only execute a single sql statement, so we will
             # break up each statement and execute them separately.
             for s in sql.strip().split(";"):
@@ -199,7 +198,7 @@ class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
         table_name: str,
         if_exists: str = "fail",
         chunk_size: int = 1000,
-        strict_length: bool = True
+        strict_length: bool = True,
     ):
         """
         Copy a :ref:`parsons-table` to the database.
@@ -231,7 +230,6 @@ class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
             return None
 
         with self.connection() as connection:
-
             # Create table if not exists
             if self._create_table_precheck(connection, table_name, if_exists):
                 sql = self.create_statement(
@@ -288,7 +286,6 @@ class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
 
         # If the table exists, evaluate the if_exists argument for next steps.
         if self.table_exists(table_name):
-
             if if_exists == "fail":
                 raise ValueError("Table already exists.")
 

--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -198,8 +198,8 @@ class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
         tbl: Table,
         table_name: str,
         if_exists: str = "fail",
-        strict_length: bool = True,
-        chunk_size: int = 1000
+        chunk_size: int = 1000,
+        strict_length: bool = True
     ):
         """
         Copy a :ref:`parsons-table` to the database.
@@ -217,13 +217,13 @@ class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
             if_exists: str
                 If the table already exists, either ``fail``, ``append``, ``drop``
                 or ``truncate`` the table.
+            chunk_size: int
+                The number of rows to insert per query.
             strict_length: bool
                 If the database table needs to be created, strict_length determines whether
                 the created table's column sizes will be sized to exactly fit the current data,
                 or if their size will be rounded up to account for future values being larger
                 then the current dataset. defaults to ``True``
-            chunk_size: int
-                The number of rows to insert per query.
         """
 
         if tbl.num_rows == 0:

--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -7,6 +7,7 @@ from parsons.utilities import files
 import pickle
 import logging
 import os
+from parsons.databases.database_connector import DatabaseConnector
 from parsons.databases.table import BaseTable
 from parsons.databases.mysql.create_table import MySQLCreateTable
 from parsons.databases.alchemy import Alchemy
@@ -19,7 +20,7 @@ QUERY_BATCH_SIZE = 100000
 logger = logging.getLogger(__name__)
 
 
-class MySQL(MySQLCreateTable, Alchemy):
+class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
     """
     Connect to a MySQL database.
 
@@ -193,7 +194,12 @@ class MySQL(MySQLCreateTable, Alchemy):
                 return final_tbl
 
     def copy(
-        self, tbl, table_name, if_exists="fail", chunk_size=1000, strict_length=True
+        self,
+        tbl: Table,
+        table_name: str,
+        if_exists: str = "fail",
+        strict_length: bool = True,
+        chunk_size: int = 1000
     ):
         """
         Copy a :ref:`parsons-table` to the database.
@@ -211,13 +217,13 @@ class MySQL(MySQLCreateTable, Alchemy):
             if_exists: str
                 If the table already exists, either ``fail``, ``append``, ``drop``
                 or ``truncate`` the table.
-            chunk_size: int
-                The number of rows to insert per query.
             strict_length: bool
                 If the database table needs to be created, strict_length determines whether
                 the created table's column sizes will be sized to exactly fit the current data,
                 or if their size will be rounded up to account for future values being larger
                 then the current dataset. defaults to ``True``
+            chunk_size: int
+                The number of rows to insert per query.
         """
 
         if tbl.num_rows == 0:
@@ -301,7 +307,7 @@ class MySQL(MySQLCreateTable, Alchemy):
         else:
             return True
 
-    def table_exists(self, table_name):
+    def table_exists(self, table_name: str):
         """
         Check if a table or view exists in the database.
 

--- a/parsons/databases/postgres/postgres.py
+++ b/parsons/databases/postgres/postgres.py
@@ -10,7 +10,7 @@ import os
 logger = logging.getLogger(__name__)
 
 
-class Postgres(DatabaseConnector, PostgresCore, Alchemy):
+class Postgres(PostgresCore, Alchemy, DatabaseConnector):
     """
     A Postgres class to connect to database. Credentials can be passed from a ``.pgpass`` file
     stored in your home directory or with environmental variables.

--- a/parsons/databases/postgres/postgres.py
+++ b/parsons/databases/postgres/postgres.py
@@ -59,7 +59,7 @@ class Postgres(PostgresCore, Alchemy, DatabaseConnector):
         tbl: Table,
         table_name: str,
         if_exists: str = "fail",
-        strict_length: bool = True,
+        strict_length: bool = False,
     ):
         """
         Copy a :ref:`parsons-table` to Postgres.
@@ -76,7 +76,7 @@ class Postgres(PostgresCore, Alchemy, DatabaseConnector):
                 If the database table needs to be created, strict_length determines whether
                 the created table's column sizes will be sized to exactly fit the current data,
                 or if their size will be rounded up to account for future values being larger
-                then the current dataset. Defaults to ``True``.
+                then the current dataset. Defaults to ``False``.
         """
 
         with self.connection() as connection:

--- a/parsons/databases/postgres/postgres.py
+++ b/parsons/databases/postgres/postgres.py
@@ -1,6 +1,8 @@
 from parsons.databases.postgres.postgres_core import PostgresCore
 from parsons.databases.table import BaseTable
 from parsons.databases.alchemy import Alchemy
+from parsons.databases.database_connector import DatabaseConnector
+from parsons.etl.table import Table
 import logging
 import os
 
@@ -8,7 +10,7 @@ import os
 logger = logging.getLogger(__name__)
 
 
-class Postgres(PostgresCore, Alchemy):
+class Postgres(DatabaseConnector, PostgresCore, Alchemy):
     """
     A Postgres class to connect to database. Credentials can be passed from a ``.pgpass`` file
     stored in your home directory or with environmental variables.
@@ -52,7 +54,13 @@ class Postgres(PostgresCore, Alchemy):
         self.timeout = timeout
         self.dialect = "postgres"
 
-    def copy(self, tbl, table_name, if_exists="fail", strict_length=False):
+    def copy(
+        self,
+        tbl: Table,
+        table_name: str,
+        if_exists: str = "fail",
+        strict_length: bool = True
+    ):
         """
         Copy a :ref:`parsons-table` to Postgres.
 
@@ -68,7 +76,7 @@ class Postgres(PostgresCore, Alchemy):
                 If the database table needs to be created, strict_length determines whether
                 the created table's column sizes will be sized to exactly fit the current data,
                 or if their size will be rounded up to account for future values being larger
-                then the current dataset
+                then the current dataset. Defaults to ``True``.
         """
 
         with self.connection() as connection:

--- a/parsons/databases/postgres/postgres.py
+++ b/parsons/databases/postgres/postgres.py
@@ -59,7 +59,7 @@ class Postgres(PostgresCore, Alchemy, DatabaseConnector):
         tbl: Table,
         table_name: str,
         if_exists: str = "fail",
-        strict_length: bool = True
+        strict_length: bool = True,
     ):
         """
         Copy a :ref:`parsons-table` to Postgres.
@@ -80,10 +80,8 @@ class Postgres(PostgresCore, Alchemy, DatabaseConnector):
         """
 
         with self.connection() as connection:
-
             # Auto-generate table
             if self._create_table_precheck(connection, table_name, if_exists):
-
                 # Create the table
                 # To Do: Pass in the advanced configuration parameters.
                 sql = self.create_statement(

--- a/parsons/databases/postgres/postgres_core.py
+++ b/parsons/databases/postgres/postgres_core.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from typing import Optional
 import psycopg2
 import psycopg2.extras
 from parsons.etl.table import Table
@@ -61,7 +62,7 @@ class PostgresCore(PostgresCreateStatement):
         finally:
             cur.close()
 
-    def query(self, sql, parameters=None):
+    def query(self, sql: str, parameters: Optional[list] = None) -> Optional[Table]:
         """
         Execute a query against the database. Will return ``None`` if the query returns zero rows.
 
@@ -207,7 +208,7 @@ class PostgresCore(PostgresCreateStatement):
         else:
             return True
 
-    def table_exists(self, table_name, view=True):
+    def table_exists(self, table_name: str, view: bool = True) -> bool:
         """
         Check if a table or view exists in the database.
 
@@ -215,7 +216,7 @@ class PostgresCore(PostgresCreateStatement):
             table_name: str
                 The table name and schema (e.g. ``myschema.mytable``).
             view: boolean
-                Check to see if a view exists by the same name
+                Check to see if a view exists by the same name. Defaults to ``True``.
 
         `Returns:`
             boolean

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -33,7 +33,7 @@ class Redshift(
     RedshiftTableUtilities,
     RedshiftSchema,
     Alchemy,
-    DatabaseConnector
+    DatabaseConnector,
 ):
     """
     A Redshift class to connect to database.

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1,3 +1,4 @@
+from typing import List, Optional
 from parsons.etl.table import Table
 from parsons.databases.redshift.rs_copy_table import RedshiftCopyTable
 from parsons.databases.redshift.rs_create_table import RedshiftCreateTable
@@ -6,6 +7,7 @@ from parsons.databases.redshift.rs_schema import RedshiftSchema
 from parsons.databases.table import BaseTable
 from parsons.databases.alchemy import Alchemy
 from parsons.utilities import files, sql_helpers
+from parsons.databases.database_connector import DatabaseConnector
 import psycopg2
 import psycopg2.extras
 import os
@@ -26,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class Redshift(
+    DatabaseConnector,
     RedshiftCreateTable,
     RedshiftCopyTable,
     RedshiftTableUtilities,
@@ -152,7 +155,7 @@ class Redshift(
         finally:
             cur.close()
 
-    def query(self, sql, parameters=None):
+    def query(self, sql: str, parameters: Optional[list] = None) -> Optional[Table]:
         """
         Execute a query against the Redshift database. Will return ``None``
         if the query returns zero rows.
@@ -461,36 +464,36 @@ class Redshift(
 
     def copy(
         self,
-        tbl,
-        table_name,
-        if_exists="fail",
-        max_errors=0,
-        distkey=None,
-        sortkey=None,
-        padding=None,
-        statupdate=None,
-        compupdate=None,
-        acceptanydate=True,
-        emptyasnull=True,
-        blanksasnull=True,
-        nullas=None,
-        acceptinvchars=True,
-        dateformat="auto",
-        timeformat="auto",
-        varchar_max=None,
-        truncatecolumns=False,
-        columntypes=None,
-        specifycols=None,
-        alter_table=False,
-        alter_table_cascade=False,
-        aws_access_key_id=None,
-        aws_secret_access_key=None,
-        iam_role=None,
-        cleanup_s3_file=True,
-        template_table=None,
-        temp_bucket_region=None,
-        strict_length=True,
-        csv_encoding="utf-8",
+        tbl: Table,
+        table_name: str,
+        if_exists: str = "fail",
+        strict_length: bool = True,
+        max_errors: int = 0,
+        distkey: Optional[str] = None,
+        sortkey: Optional[str] = None,
+        padding: Optional[float] = None,
+        statupdate: Optional[bool] = None,
+        compupdate: Optional[bool] = None,
+        acceptanydate: bool = True,
+        emptyasnull: bool = True,
+        blanksasnull: bool = True,
+        nullas: Optional[str] = None,
+        acceptinvchars: bool = True,
+        dateformat: str = "auto",
+        timeformat: str = "auto",
+        varchar_max: Optional[List[str]] = None,
+        truncatecolumns: bool = False,
+        columntypes: Optional[dict] = None,
+        specifycols: Optional[bool] = None,
+        alter_table: bool = False,
+        alter_table_cascade: bool = False,
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        iam_role: Optional[str] = None,  # Unused - Should we remove?
+        cleanup_s3_file: bool = True,
+        template_table: Optional[str] = None,
+        temp_bucket_region: Optional[str] = None,
+        csv_encoding: str = "utf-8",
     ):
         """
         Copy a :ref:`parsons-table` to Redshift.
@@ -503,6 +506,9 @@ class Redshift(
             if_exists: str
                 If the table already exists, either ``fail``, ``append``, ``drop``
                 or ``truncate`` the table.
+            strict_length: bool
+                Whether or not to tightly fit the length of the table columns to the length
+                of the data in ``tbl``; if ``padding`` is specified, this argument is ignored.
             max_errors: int
                 The maximum number of rows that can error and be skipped before
                 the job fails.
@@ -513,9 +519,6 @@ class Redshift(
             padding: float
                 A percentage padding to add to varchar columns if creating a new table. This is
                 helpful to add a buffer for future copies in which the data might be wider.
-            varchar_max: list
-                A list of columns in which to set the width of the varchar column to 65,535
-                characters.
             statupate: boolean
                 Governs automatic computation and refresh of optimizer statistics at the end
                 of a successful COPY command. If ``True`` explicitly sets ``statupate`` to on, if
@@ -553,6 +556,9 @@ class Redshift(
                 Set the date format. Defaults to ``auto``.
             timeformat: str
                 Set the time format. Defaults to ``auto``.
+            varchar_max: list
+                A list of columns in which to set the width of the varchar column to 65,535
+                characters.
             truncatecolumns: boolean
                 If the table already exists, truncates data in columns to the appropriate number
                 of characters so that it fits the column specification. Applies only to columns
@@ -598,9 +604,6 @@ class Redshift(
                 The AWS region that the temp bucket (specified by the TEMP_S3_BUCKET environment
                 variable) is located in. This should be provided if the Redshift cluster is located
                 in a different region from the temp bucket.
-            strict_length: bool
-                Whether or not to tightly fit the length of the table columns to the length
-                of the data in ``tbl``; if ``padding`` is specified, this argument is ignored
             csv_ecoding: str
                 String encoding to use when writing the temporary CSV file that is uploaded to S3.
                 Defaults to 'utf-8'.

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -28,12 +28,12 @@ logger = logging.getLogger(__name__)
 
 
 class Redshift(
-    DatabaseConnector,
     RedshiftCreateTable,
     RedshiftCopyTable,
     RedshiftTableUtilities,
     RedshiftSchema,
     Alchemy,
+    DatabaseConnector
 ):
     """
     A Redshift class to connect to database.

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -467,7 +467,6 @@ class Redshift(
         tbl: Table,
         table_name: str,
         if_exists: str = "fail",
-        strict_length: bool = True,
         max_errors: int = 0,
         distkey: Optional[str] = None,
         sortkey: Optional[str] = None,
@@ -493,6 +492,7 @@ class Redshift(
         cleanup_s3_file: bool = True,
         template_table: Optional[str] = None,
         temp_bucket_region: Optional[str] = None,
+        strict_length: bool = True,
         csv_encoding: str = "utf-8",
     ):
         """
@@ -506,9 +506,6 @@ class Redshift(
             if_exists: str
                 If the table already exists, either ``fail``, ``append``, ``drop``
                 or ``truncate`` the table.
-            strict_length: bool
-                Whether or not to tightly fit the length of the table columns to the length
-                of the data in ``tbl``; if ``padding`` is specified, this argument is ignored.
             max_errors: int
                 The maximum number of rows that can error and be skipped before
                 the job fails.
@@ -604,6 +601,9 @@ class Redshift(
                 The AWS region that the temp bucket (specified by the TEMP_S3_BUCKET environment
                 variable) is located in. This should be provided if the Redshift cluster is located
                 in a different region from the temp bucket.
+            strict_length: bool
+                Whether or not to tightly fit the length of the table columns to the length
+                of the data in ``tbl``; if ``padding`` is specified, this argument is ignored.
             csv_ecoding: str
                 String encoding to use when writing the temporary CSV file that is uploaded to S3.
                 Defaults to 'utf-8'.

--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -9,7 +9,7 @@ class RedshiftTableUtilities(object):
     def __init__(self):
         pass
 
-    def table_exists(self, table_name, view=True):
+    def table_exists(self, table_name: str, view: bool = True) -> bool:
         """
         Check if a table or view exists in the database.
 

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -4,6 +4,7 @@ import uuid
 
 from google.cloud import bigquery
 from google.cloud.bigquery import dbapi
+from google.cloud.bigquery.job import LoadJobConfig
 from google.cloud import exceptions
 import petl
 
@@ -102,14 +103,11 @@ class GoogleBigQuery(DatabaseConnector):
 
         self.dialect = "bigquery"
 
-    # TODO: Implement `strict_length`
-    # TODO: Find ref for `LoadJobConfig` to import
     def copy(
         self,
         tbl: Table,
         table_name: str,
         if_exists: str = "fail",
-        strict_length: bool = True,
         tmp_gcs_bucket: Optional[str] = None,
         gcs_client: Optional[GoogleCloudStorage] = None,
         job_config: Optional[LoadJobConfig] = None,
@@ -126,10 +124,6 @@ class GoogleBigQuery(DatabaseConnector):
             if_exists: str
                 If the table already exists, either ``fail``, ``append``, ``drop``
                 or ``truncate`` the table.
-            strict_length (bool, optional): 
-                Whether or not to tightly fit the length of the table columns to the length
-                of the data in ``tbl``; if ``padding`` is specified, this argument is ignored.
-                Defaults to True.
             tmp_gcs_bucket: str
                 The name of the Google Cloud Storage bucket to use to stage the data to load
                 into BigQuery. Required if `GCS_TEMP_BUCKET` is not specified.

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -170,9 +170,7 @@ class GoogleBigQuery(DatabaseConnector):
 
         gcs_client = gcs_client or GoogleCloudStorage()
         temp_blob_name = f"{uuid.uuid4()}.csv"
-        temp_blob_uri = gcs_client.upload_table(
-            tbl, tmp_gcs_bucket, temp_blob_name
-        )
+        temp_blob_uri = gcs_client.upload_table(tbl, tmp_gcs_bucket, temp_blob_name)
 
         # load CSV from Cloud Storage into BigQuery
         table_ref = get_table_ref(self.client, table_name)
@@ -198,7 +196,9 @@ class GoogleBigQuery(DatabaseConnector):
         table_ref = get_table_ref(self.client, table_name)
         self.client.delete_table(table_ref)
 
-    def query(self, sql: str, parameters: Optional[Union[list, dict]] = None) -> Optional[Table]:
+    def query(
+        self, sql: str, parameters: Optional[Union[list, dict]] = None
+    ) -> Optional[Table]:
         """
         Run a BigQuery query and return the results as a Parsons table.
 

--- a/test/test_databases/test_discover_database.py
+++ b/test/test_databases/test_discover_database.py
@@ -34,6 +34,30 @@ class TestDiscoverDatabase(unittest.TestCase):
     @patch.object(MySQL, "__init__", return_value=None)
     @patch.object(Redshift, "__init__", return_value=None)
     @patch("os.getenv")
+    def test_single_database_detected_with_other_default(self, mock_getenv, *_):
+        mock_getenv.side_effect = (
+            lambda var: "password" if var == "REDSHIFT_PASSWORD" else None
+        )
+        self.assertIsInstance(discover_database(default_connector=Postgres), Redshift)
+
+    @patch.object(GoogleBigQuery, "__init__", return_value=None)
+    @patch.object(Postgres, "__init__", return_value=None)
+    @patch.object(MySQL, "__init__", return_value=None)
+    @patch.object(Redshift, "__init__", return_value=None)
+    @patch("os.getenv")
+    def test_single_database_detected_with_other_default_list(self, mock_getenv, *_):
+        mock_getenv.side_effect = (
+            lambda var: "password" if var == "REDSHIFT_PASSWORD" else None
+        )
+        self.assertIsInstance(
+            discover_database(default_connector=[Postgres, MySQL]), Redshift
+        )
+
+    @patch.object(GoogleBigQuery, "__init__", return_value=None)
+    @patch.object(Postgres, "__init__", return_value=None)
+    @patch.object(MySQL, "__init__", return_value=None)
+    @patch.object(Redshift, "__init__", return_value=None)
+    @patch("os.getenv")
     def test_multiple_databases_no_default(self, mock_getenv, *_):
         mock_getenv.return_value = "password"
         with self.assertRaises(EnvironmentError):

--- a/test/test_databases/test_discover_database.py
+++ b/test/test_databases/test_discover_database.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest.mock import patch
+from parsons.databases.database_connector import DatabaseConnector
+from parsons.databases.redshift import Redshift
+from parsons.databases.mysql import MySQL
+from parsons.databases.postgres import Postgres
+from parsons.google.google_bigquery import GoogleBigQuery
+from parsons.databases.discover_database import discover_database
+
+
+class TestDiscoverDatabase(unittest.TestCase):
+    @patch("os.getenv")
+    def test_no_database_detected(self, mock_getenv):
+        mock_getenv.return_value = None
+        with self.assertRaises(EnvironmentError):
+            discover_database()
+
+    @patch("os.getenv")
+    def test_single_database_detected(self, mock_getenv):
+        mock_getenv.side_effect = lambda var: var == "REDSHIFT_PASSWORD"
+        self.assertIsInstance(discover_database(), Redshift)
+
+    @patch("os.getenv")
+    def test_multiple_databases_no_default(self, mock_getenv):
+        mock_getenv.return_value = True
+        with self.assertRaises(EnvironmentError):
+            discover_database()
+
+    @patch("os.getenv")
+    def test_multiple_databases_with_default(self, mock_getenv):
+        mock_getenv.return_value = True
+        self.assertIsInstance(discover_database(default_connector=Redshift), Redshift)
+
+    @patch("os.getenv")
+    def test_multiple_databases_with_default_list(self, mock_getenv):
+        mock_getenv.return_value = True
+        self.assertIsInstance(
+            discover_database(default_connector=[MySQL, Redshift]), Redshift
+        )
+
+    @patch("os.getenv")
+    def test_multiple_databases_invalid_default(self, mock_getenv):
+        mock_getenv.return_value = True
+        with self.assertRaises(EnvironmentError):
+            discover_database(default_connector=DatabaseConnector)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_databases/test_discover_database.py
+++ b/test/test_databases/test_discover_database.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import patch
-from parsons.databases.database_connector import DatabaseConnector
 from parsons.databases.redshift import Redshift
 from parsons.databases.mysql import MySQL
 from parsons.databases.postgres import Postgres
@@ -9,40 +8,84 @@ from parsons.databases.discover_database import discover_database
 
 
 class TestDiscoverDatabase(unittest.TestCase):
+    @patch.object(GoogleBigQuery, "__init__", return_value=None)
+    @patch.object(Postgres, "__init__", return_value=None)
+    @patch.object(MySQL, "__init__", return_value=None)
+    @patch.object(Redshift, "__init__", return_value=None)
     @patch("os.getenv")
-    def test_no_database_detected(self, mock_getenv):
+    def test_no_database_detected(self, mock_getenv, *_):
         mock_getenv.return_value = None
         with self.assertRaises(EnvironmentError):
             discover_database()
 
+    @patch.object(GoogleBigQuery, "__init__", return_value=None)
+    @patch.object(Postgres, "__init__", return_value=None)
+    @patch.object(MySQL, "__init__", return_value=None)
+    @patch.object(Redshift, "__init__", return_value=None)
     @patch("os.getenv")
-    def test_single_database_detected(self, mock_getenv):
-        mock_getenv.side_effect = lambda var: var == "REDSHIFT_PASSWORD"
+    def test_single_database_detected(self, mock_getenv, *_):
+        mock_getenv.side_effect = (
+            lambda var: "password" if var == "REDSHIFT_PASSWORD" else None
+        )
         self.assertIsInstance(discover_database(), Redshift)
 
+    @patch.object(GoogleBigQuery, "__init__", return_value=None)
+    @patch.object(Postgres, "__init__", return_value=None)
+    @patch.object(MySQL, "__init__", return_value=None)
+    @patch.object(Redshift, "__init__", return_value=None)
     @patch("os.getenv")
-    def test_multiple_databases_no_default(self, mock_getenv):
-        mock_getenv.return_value = True
+    def test_multiple_databases_no_default(self, mock_getenv, *_):
+        mock_getenv.return_value = "password"
         with self.assertRaises(EnvironmentError):
             discover_database()
 
+    @patch.object(GoogleBigQuery, "__init__", return_value=None)
+    @patch.object(Postgres, "__init__", return_value=None)
+    @patch.object(MySQL, "__init__", return_value=None)
+    @patch.object(Redshift, "__init__", return_value=None)
     @patch("os.getenv")
-    def test_multiple_databases_with_default(self, mock_getenv):
-        mock_getenv.return_value = True
+    def test_multiple_databases_with_default(self, mock_getenv, *_):
+        mock_getenv.return_value = "password"
         self.assertIsInstance(discover_database(default_connector=Redshift), Redshift)
 
+    @patch.object(GoogleBigQuery, "__init__", return_value=None)
+    @patch.object(Postgres, "__init__", return_value=None)
+    @patch.object(MySQL, "__init__", return_value=None)
+    @patch.object(Redshift, "__init__", return_value=None)
     @patch("os.getenv")
-    def test_multiple_databases_with_default_list(self, mock_getenv):
-        mock_getenv.return_value = True
+    def test_multiple_databases_with_default_list(self, mock_getenv, *_):
+        mock_getenv.return_value = "password"
         self.assertIsInstance(
-            discover_database(default_connector=[MySQL, Redshift]), Redshift
+            discover_database(default_connector=[MySQL, Redshift]), MySQL
         )
 
+    @patch.object(GoogleBigQuery, "__init__", return_value=None)
+    @patch.object(Postgres, "__init__", return_value=None)
+    @patch.object(MySQL, "__init__", return_value=None)
+    @patch.object(Redshift, "__init__", return_value=None)
     @patch("os.getenv")
-    def test_multiple_databases_invalid_default(self, mock_getenv):
-        mock_getenv.return_value = True
+    def test_multiple_databases_invalid_default(self, mock_getenv, *_):
+        mock_getenv.side_effect = (
+            lambda var: "password"
+            if var == "REDSHIFT_PASSWORD" or var == "MYSQL_PASSWORD"
+            else None
+        )
         with self.assertRaises(EnvironmentError):
-            discover_database(default_connector=DatabaseConnector)
+            discover_database(default_connector=Postgres)
+
+    @patch.object(GoogleBigQuery, "__init__", return_value=None)
+    @patch.object(Postgres, "__init__", return_value=None)
+    @patch.object(MySQL, "__init__", return_value=None)
+    @patch.object(Redshift, "__init__", return_value=None)
+    @patch("os.getenv")
+    def test_multiple_databases_invalid_default_list(self, mock_getenv, *_):
+        mock_getenv.side_effect = (
+            lambda var: "password"
+            if var == "REDSHIFT_PASSWORD" or var == "MYSQL_PASSWORD"
+            else None
+        )
+        with self.assertRaises(EnvironmentError):
+            discover_database(default_connector=[Postgres, GoogleBigQuery])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[Here is a spreadsheet with the analysis I did of current feature parity between the four database connectors](https://docs.google.com/spreadsheets/d/1_jbhYk7lRCGwbwA00WKjJK9Ne0Zku_g_C3SuPx0m5-k/edit#gid=0).

Currently there are three methods they share in common that I think are worth representing in the interface:

- table_exists
- query
- copy

Of those, the main difference between the functionality is copy , where Redshift has a ton of extra functionality that the others do not have.

This PR creates the interface ABC, DatabaseConnector, and add the nifty discover_database function. I also do a little cleanup on the existing connectors, mostly adding type hints. These are very useful to make sure that the connector classes align properly with the interface and each other.

The only breaking change is switching the default value of strict_length in the Postgres connector from False to True, to align with the Redshift & MySQL connectors.

This PR only attempts to create the interface "as is", documenting the existing behavior shared by the database connectors (apart from the one Postgres default value). Once DatabaseConnector is merged in, we can plan out how we want to address the feature parity.