### PR TITLE
Specify version of slackclient in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def main():
             "s3": ["boto3"],
             "salesforce": ["simple-salesforce"],
             "sftp": ["paramiko"],
-            "slack": ["slackclient"],
+            "slack": ["slackclient==1.3.0"],
             "smtp": ["validate-email"],
             "targetsmart": ["xmltodict"],
             "twilio": ["twilio"],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def main():
             "s3": ["boto3"],
             "salesforce": ["simple-salesforce"],
             "sftp": ["paramiko"],
-            "slack": ["slackclient==1.3.0"],
+            "slack": ["slackclient~=1"],
             "smtp": ["validate-email"],
             "targetsmart": ["xmltodict"],
             "twilio": ["twilio"],


### PR DESCRIPTION
When running `pip install parsons[slack]`, the latest version of slackclient is installed (2.9.4). The version of slackclient specified in `requirements.txt` is 1.3.0: https://github.com/move-coop/parsons/blob/853b27cb14394daaf113b88718facfde1190a572/requirements.txt#L6

In slackclient 2.9.4, the `slackclient` module has been renamed, causing all references to `parsons/notifications/slack.py` to return the error `ModuleNotFoundError: No module named 'slackclient'`. https://github.com/move-coop/parsons/blob/853b27cb14394daaf113b88718facfde1190a572/parsons/notifications/slack.py#L7

This PR specifies the slackclient version in `setup.py` to be the same version specified in `requirements.txt`.