### PR TITLE
 Fix Salesforce query output

### DIFF
--- a/parsons/salesforce/salesforce.py
+++ b/parsons/salesforce/salesforce.py
@@ -80,9 +80,9 @@ class Salesforce:
             list of dicts with Salesforce data
         """  # noqa: E501,E261
 
-        q = Table(self.client.query_all(soql))
-        logger.info(f"Found {q.num_rows} results")
-        return q
+        q = self.client.query_all(soql)
+        q=json.loads(json.dumps(q))
+        logger.info(f"Found {q['totalSize']} results")
 
     def insert_record(self, object, data_table):
         """

--- a/parsons/salesforce/salesforce.py
+++ b/parsons/salesforce/salesforce.py
@@ -1,6 +1,5 @@
 from simple_salesforce import Salesforce as _Salesforce
 from parsons.utilities import check_env
-from parsons.etl import Table
 import logging
 import json
 
@@ -81,7 +80,7 @@ class Salesforce:
         """  # noqa: E501,E261
 
         q = self.client.query_all(soql)
-        q=json.loads(json.dumps(q))
+        q = json.loads(json.dumps(q))
         logger.info(f"Found {q['totalSize']} results")
         return q
 

--- a/parsons/salesforce/salesforce.py
+++ b/parsons/salesforce/salesforce.py
@@ -83,6 +83,7 @@ class Salesforce:
         q = self.client.query_all(soql)
         q=json.loads(json.dumps(q))
         logger.info(f"Found {q['totalSize']} results")
+        return q
 
     def insert_record(self, object, data_table):
         """

--- a/test/test_salesforce/test_salesforce.py
+++ b/test/test_salesforce/test_salesforce.py
@@ -14,7 +14,7 @@ class TestSalesforce(unittest.TestCase):
         self.sf = Salesforce()
         self.sf._client = mock.MagicMock()
 
-        self.sf._client.query_all.return_value = [{"Id": 1, "value": "FAKE"}]
+        self.sf._client.query_all.return_value = {"totalSize": 1, "done": True, "records": [{"attributes": {"type": "Contact", "url": "/services/data/v38.0/sobjects/Contact/1234567890AaBbC"}, "Id": "1234567890AaBbC"}]}
         self.sf._client.bulk.Contact.insert.return_value = [
             {"success": True, "created": True, "id": "1234567890AaBbC", "errors": []}
         ]
@@ -43,7 +43,7 @@ class TestSalesforce(unittest.TestCase):
         fake_soql = "FAKESOQL"
         response = self.sf.query(fake_soql)
         assert self.sf.client.query_all.called_with(fake_soql)
-        self.assertEqual(response[0]["value"], "FAKE")
+        self.assertEqual(response['records'][0]['Id'], '1234567890AaBbC')
 
     def test_insert(self):
 

--- a/test/test_salesforce/test_salesforce.py
+++ b/test/test_salesforce/test_salesforce.py
@@ -13,8 +13,12 @@ class TestSalesforce(unittest.TestCase):
 
         self.sf = Salesforce()
         self.sf._client = mock.MagicMock()
-
-        self.sf._client.query_all.return_value = {"totalSize": 1, "done": True, "records": [{"attributes": {"type": "Contact", "url": "/services/data/v38.0/sobjects/Contact/1234567890AaBbC"}, "Id": "1234567890AaBbC"}]}
+        self.sf._client.query_all.return_value = {"totalSize": 1, "done": True, "records":
+                                                  [{"attributes": {"type": "Contact",
+                                                                   "url": "/services/data/v38.0/"
+                                                                          + "sobjects/Contact/"
+                                                                          + "1234567890AaBbC"},
+                                                    "Id": "1234567890AaBbC"}]}
         self.sf._client.bulk.Contact.insert.return_value = [
             {"success": True, "created": True, "id": "1234567890AaBbC", "errors": []}
         ]

--- a/test/test_salesforce/test_salesforce.py
+++ b/test/test_salesforce/test_salesforce.py
@@ -6,19 +6,27 @@ from parsons import Salesforce, Table
 
 class TestSalesforce(unittest.TestCase):
     def setUp(self):
-
         os.environ["SALESFORCE_USERNAME"] = "MYFAKEUSERNAME"
         os.environ["SALESFORCE_PASSWORD"] = "MYFAKEPASSWORD"
         os.environ["SALESFORCE_SECURITY_TOKEN"] = "MYFAKESECURITYTOKEN"
 
         self.sf = Salesforce()
         self.sf._client = mock.MagicMock()
-        self.sf._client.query_all.return_value = {"totalSize": 1, "done": True, "records":
-                                                  [{"attributes": {"type": "Contact",
-                                                                   "url": "/services/data/v38.0/"
-                                                                          + "sobjects/Contact/"
-                                                                          + "1234567890AaBbC"},
-                                                    "Id": "1234567890AaBbC"}]}
+        self.sf._client.query_all.return_value = {
+            "totalSize": 1,
+            "done": True,
+            "records": [
+                {
+                    "attributes": {
+                        "type": "Contact",
+                        "url": "/services/data/v38.0/"
+                        + "sobjects/Contact/"
+                        + "1234567890AaBbC",
+                    },
+                    "Id": "1234567890AaBbC",
+                }
+            ],
+        }
         self.sf._client.bulk.Contact.insert.return_value = [
             {"success": True, "created": True, "id": "1234567890AaBbC", "errors": []}
         ]
@@ -34,30 +42,25 @@ class TestSalesforce(unittest.TestCase):
         ]
 
     def test_describe(self):
-
         pass
 
     def test_describe_fields(self):
-
         # TO DO: test this with requests mock instead?
         pass
 
     def test_query(self):
-
         fake_soql = "FAKESOQL"
         response = self.sf.query(fake_soql)
         assert self.sf.client.query_all.called_with(fake_soql)
-        self.assertEqual(response['records'][0]['Id'], '1234567890AaBbC')
+        self.assertEqual(response["records"][0]["Id"], "1234567890AaBbC")
 
     def test_insert(self):
-
         fake_data = Table([{"firstname": "Chrisjen", "lastname": "Avasarala"}])
         response = self.sf.insert_record("Contact", fake_data)
         assert self.sf.client.bulk.Contact.insert.called_with(fake_data)
         assert response[0]["created"]
 
     def test_update(self):
-
         fake_data = Table(
             [
                 {
@@ -72,7 +75,6 @@ class TestSalesforce(unittest.TestCase):
         assert not response[0]["created"]
 
     def test_upsert(self):
-
         fake_data = Table(
             [
                 {
@@ -90,7 +92,6 @@ class TestSalesforce(unittest.TestCase):
         assert response[1]["created"]
 
     def test_delete(self):
-
         fake_data = Table([{"id": "1234567890AaBbC"}])
         response = self.sf.delete_record("Contact", fake_data)
         assert self.sf.client.bulk.Contact.update.called_with(fake_data)


### PR DESCRIPTION
The existing code did not match the method description and did not produce a useful result. Salesforce returns a set of nested dicts, similar to JSON; the new method reformats the nested ordered dicts using the json library, similar to describe_fields.