### PR TITLE
Enable __len__ dunder method for parsons Table

### DIFF
--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -108,6 +108,9 @@ class Table(ETL, ToFrom):
         """
         return petl.nrows(self.table)
 
+    def __len__(self):
+        return self.num_rows
+
     @property
     def data(self):
         """


### PR DESCRIPTION
This enables the pythonic use of len(Table) rather than needing to use the idiosyncratic Table.num_rows. len(Table) calls Table.num_rows