### PR TITLE
Fix invalid setup.py syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def main():
             "s3": ["boto3"],
             "salesforce": ["simple-salesforce"],
             "sftp": ["paramiko"],
-            "slack": ["slackclient~=1"],
+            "slack": ["slackclient<2"],
             "smtp": ["validate-email"],
             "targetsmart": ["xmltodict"],
             "twilio": ["twilio"],


### PR DESCRIPTION
After c056045d8a4bb76ec11b35958088591a28f74683 was merged, there is an error when running: `pip install git+https://github.com/move-coop/parsons@main#egg=parsons`

```
(test-pywell-ve) kathynguyen@administrators-MacBook-Pro-2 test-pywell % pip install git+https://github.com/move-coop/parsons@main#egg=parsons
Collecting parsons
  Cloning https://github.com/move-coop/parsons (to revision main) to /private/var/folders/d4/td5jnc7d6zd6s1ylg1t74jn40000gp/T/pip-install-2424vdzk/parsons_7b331d3cb8aa43a789e103429d496a28
  Running command git clone --filter=blob:none --quiet https://github.com/move-coop/parsons /private/var/folders/d4/td5jnc7d6zd6s1ylg1t74jn40000gp/T/pip-install-2424vdzk/parsons_7b331d3cb8aa43a789e103429d496a28
  Resolved https://github.com/move-coop/parsons to commit 9e061ba7c314be03025b4fa702cd76a00c50773a
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in parsons setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

This is because `~=` is not valid syntax in `setup.py`. I changed it to `<2`, which is valid.