### PR TITLE
Implement, test, and document Parsons Table deduplicate method

### DIFF
--- a/docs/table.rst
+++ b/docs/table.rst
@@ -196,6 +196,8 @@ of commonly used methods. The full list can be found in the API section.
       - Divide tables into smaller tables based on row count
     * - :py:meth:`~parsons.etl.etl.ETL.remove_null_rows`
       - Removes rows with null values in specified columns
+    * - :py:meth:`~parsons.etl.etl.ETL.deduplicate`
+      - Removes duplicate rows based on optional key(s), and optionally sorts
 
 
 **Extraction and Reshaping**

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -1159,3 +1159,32 @@ class ETL(object):
         from parsons.etl.table import Table
 
         return Table(getattr(petl, petl_method)(self.table, *args, **kwargs))
+
+    def deduplicate(self, keys=None, sort=False):
+        """
+        Deduplicates table based on an optional ``keys`` argument,
+        which can contain any number of keys or None.
+
+        `Args:`
+            keys: str or list[str] or None
+                keys to deduplicate (and optionally sort) on
+            sort: bool or None
+                Whether petl should sort the data (inverse of petl's `presorted` argument)
+        `Returns`:
+            `Parsons Table` and also updates self
+
+        """
+
+        # petl's `presorted` declarative argument indicates
+        # whether the table is already sorted.
+        # This method's `sort` imperative argument indicates
+        # whether the table is NOT yet sorted.
+        # That is, petl expects presorted=True here to mean the the opposite of
+        # what sort=True means in this method.
+        # we use `presorted=not sort` to convert between these two interpretations
+        deduped = petl.transform.dedup.distinct(
+            self.table, key=keys, presorted=not sort
+        )
+        self.table = deduped
+
+        return deduped

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -1195,4 +1195,4 @@ class ETL(object):
         )
         self.table = deduped
 
-        return deduped
+        return self

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -899,7 +899,7 @@ class TestParsonsTable(unittest.TestCase):
 
     def test_deduplicate(self):
         # Confirm deduplicate works with no keys for one-column duplicates
-        tbl = Table([['a'],[1], [2], [2], [3]])
+        tbl = Table([['a'], [1], [2], [2], [3]])
         tbl_expected = Table([['a'], [1], [2], [3]])
         tbl.deduplicate()
         assert_matching_tables(tbl_expected, tbl)
@@ -990,5 +990,5 @@ class TestParsonsTable(unittest.TestCase):
             [1, 3, 2],
             [2, 3, 4]
         ])
-        tbl.deduplicate(['a','b'])
+        tbl.deduplicate(['a', 'b'])
         assert_matching_tables(tbl_expected, tbl)

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -896,3 +896,99 @@ class TestParsonsTable(unittest.TestCase):
 
         tbl_petl = tbl.use_petl("skipcomments", "#", to_petl=True)
         self.assertIsInstance(tbl_petl, PetlTable)
+
+    def test_deduplicate(self):
+        # Confirm deduplicate works with no keys for one-column duplicates
+        tbl = Table([['a'],[1], [2], [2], [3]])
+        tbl_expected = Table([['a'], [1], [2], [3]])
+        tbl.deduplicate()
+        assert_matching_tables(tbl_expected, tbl)
+
+        # Confirm deduplicate works with no keys for multiple columns
+        tbl = Table([
+            ['a', 'b'],
+            [1, 2],
+            [1, 2],
+            [1, 3],
+            [2, 3]
+        ])
+        tbl_expected = Table([
+            ['a', 'b'],
+            [1, 2],
+            [1, 3],
+            [2, 3],
+        ])
+        tbl.deduplicate()
+        assert_matching_tables(tbl_expected, tbl)
+
+        # Confirm deduplicate works with one key for multiple columns
+        tbl = Table([
+            ['a', 'b'],
+            [1, 3],
+            [1, 2],
+            [1, 2],
+            [2, 3]
+        ])
+        tbl_expected = Table([
+            ['a', 'b'],
+            [1, 3],
+            [2, 3],
+        ])
+        tbl.deduplicate(keys=['a'])
+        assert_matching_tables(tbl_expected, tbl)
+
+        # Confirm sorting deduplicate works with one key for multiple columns
+
+        # Note that petl sorts on the column(s) you're deduping on
+        # Meaning it will ignore the 'b' column below
+        # That is, the first row, [1,3],
+        # would not get moved to after the [1,2]
+        tbl = Table([
+            ['a', 'b'],
+            [2, 3],
+            [1, 3],
+            [1, 2],
+            [1, 2]
+        ])
+        tbl_expected = Table([
+            ['a', 'b'],
+            [1, 3],
+            [2, 3],
+        ])
+        tbl.deduplicate(keys=['a'], sort=True)
+        assert_matching_tables(tbl_expected, tbl)
+
+        # Confirm sorting deduplicate works for two of two columns
+        tbl = Table([
+            ['a', 'b'],
+            [2, 3],
+            [1, 3],
+            [1, 2],
+            [1, 2]
+        ])
+        tbl_expected = Table([
+            ['a', 'b'],
+            [1, 2],
+            [1, 3],
+            [2, 3],
+        ])
+        tbl.deduplicate(keys=['a', 'b'], sort=True)
+        assert_matching_tables(tbl_expected, tbl)
+
+        # Confirm deduplicate works for multiple keys
+        tbl = Table([
+            ['a', 'b', 'c'],
+            [1, 2, 3],
+            [1, 2, 3],
+            [1, 2, 4],
+            [1, 3, 2],
+            [2, 3, 4]
+        ])
+        tbl_expected = Table([
+            ['a', 'b', 'c'],
+            [1, 2, 3],
+            [1, 3, 2],
+            [2, 3, 4]
+        ])
+        tbl.deduplicate(['a','b'])
+        assert_matching_tables(tbl_expected, tbl)

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -899,42 +899,34 @@ class TestParsonsTable(unittest.TestCase):
 
     def test_deduplicate(self):
         # Confirm deduplicate works with no keys for one-column duplicates
-        tbl = Table([['a'], [1], [2], [2], [3]])
-        tbl_expected = Table([['a'], [1], [2], [3]])
+        tbl = Table([["a"], [1], [2], [2], [3]])
+        tbl_expected = Table([["a"], [1], [2], [3]])
         tbl.deduplicate()
         assert_matching_tables(tbl_expected, tbl)
 
         # Confirm deduplicate works with no keys for multiple columns
-        tbl = Table([
-            ['a', 'b'],
-            [1, 2],
-            [1, 2],
-            [1, 3],
-            [2, 3]
-        ])
-        tbl_expected = Table([
-            ['a', 'b'],
-            [1, 2],
-            [1, 3],
-            [2, 3],
-        ])
+        tbl = Table([["a", "b"], [1, 2], [1, 2], [1, 3], [2, 3]])
+        tbl_expected = Table(
+            [
+                ["a", "b"],
+                [1, 2],
+                [1, 3],
+                [2, 3],
+            ]
+        )
         tbl.deduplicate()
         assert_matching_tables(tbl_expected, tbl)
 
         # Confirm deduplicate works with one key for multiple columns
-        tbl = Table([
-            ['a', 'b'],
-            [1, 3],
-            [1, 2],
-            [1, 2],
-            [2, 3]
-        ])
-        tbl_expected = Table([
-            ['a', 'b'],
-            [1, 3],
-            [2, 3],
-        ])
-        tbl.deduplicate(keys=['a'])
+        tbl = Table([["a", "b"], [1, 3], [1, 2], [1, 2], [2, 3]])
+        tbl_expected = Table(
+            [
+                ["a", "b"],
+                [1, 3],
+                [2, 3],
+            ]
+        )
+        tbl.deduplicate(keys=["a"])
         assert_matching_tables(tbl_expected, tbl)
 
         # Confirm sorting deduplicate works with one key for multiple columns
@@ -943,52 +935,34 @@ class TestParsonsTable(unittest.TestCase):
         # Meaning it will ignore the 'b' column below
         # That is, the first row, [1,3],
         # would not get moved to after the [1,2]
-        tbl = Table([
-            ['a', 'b'],
-            [2, 3],
-            [1, 3],
-            [1, 2],
-            [1, 2]
-        ])
-        tbl_expected = Table([
-            ['a', 'b'],
-            [1, 3],
-            [2, 3],
-        ])
-        tbl.deduplicate(keys=['a'], sort=True)
+        tbl = Table([["a", "b"], [2, 3], [1, 3], [1, 2], [1, 2]])
+        tbl_expected = Table(
+            [
+                ["a", "b"],
+                [1, 3],
+                [2, 3],
+            ]
+        )
+        tbl.deduplicate(keys=["a"], sort=True)
         assert_matching_tables(tbl_expected, tbl)
 
         # Confirm sorting deduplicate works for two of two columns
-        tbl = Table([
-            ['a', 'b'],
-            [2, 3],
-            [1, 3],
-            [1, 2],
-            [1, 2]
-        ])
-        tbl_expected = Table([
-            ['a', 'b'],
-            [1, 2],
-            [1, 3],
-            [2, 3],
-        ])
-        tbl.deduplicate(keys=['a', 'b'], sort=True)
+        tbl = Table([["a", "b"], [2, 3], [1, 3], [1, 2], [1, 2]])
+        tbl_expected = Table(
+            [
+                ["a", "b"],
+                [1, 2],
+                [1, 3],
+                [2, 3],
+            ]
+        )
+        tbl.deduplicate(keys=["a", "b"], sort=True)
         assert_matching_tables(tbl_expected, tbl)
 
         # Confirm deduplicate works for multiple keys
-        tbl = Table([
-            ['a', 'b', 'c'],
-            [1, 2, 3],
-            [1, 2, 3],
-            [1, 2, 4],
-            [1, 3, 2],
-            [2, 3, 4]
-        ])
-        tbl_expected = Table([
-            ['a', 'b', 'c'],
-            [1, 2, 3],
-            [1, 3, 2],
-            [2, 3, 4]
-        ])
-        tbl.deduplicate(['a', 'b'])
+        tbl = Table(
+            [["a", "b", "c"], [1, 2, 3], [1, 2, 3], [1, 2, 4], [1, 3, 2], [2, 3, 4]]
+        )
+        tbl_expected = Table([["a", "b", "c"], [1, 2, 3], [1, 3, 2], [2, 3, 4]])
+        tbl.deduplicate(["a", "b"])
         assert_matching_tables(tbl_expected, tbl)

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -946,7 +946,7 @@ class TestParsonsTable(unittest.TestCase):
                 [2, 3],
             ]
         )
-        tbl.deduplicate(keys=["a"], sort=True)
+        tbl.deduplicate(keys=["a"], presorted=False)
         assert_matching_tables(tbl_expected, tbl)
 
         # Confirm sorting deduplicate works for two of two columns
@@ -959,7 +959,7 @@ class TestParsonsTable(unittest.TestCase):
                 [2, 3],
             ]
         )
-        tbl.deduplicate(keys=["a", "b"], sort=True)
+        tbl.deduplicate(keys=["a", "b"], presorted=False)
         assert_matching_tables(tbl_expected, tbl)
 
         # Confirm deduplicate works for multiple keys


### PR DESCRIPTION
This PR resolves #820.

# Summary of changes:

`parsons/etl/etl.py`: adds a `deduplicate` method which optionally accepts a key or list of keys to deduplicate on, and an optional flag to indicate whether the method should first sort the table.
`docs/table.rst`: adds deduplicate method to Table documentation.
`test/test_etl.py`: adds several deduplicate unit tests for various scenarios involving zero, one, or multiple keys on both sorted and unsorted tables.

This method is essentially a wrapper around the built-in [petl.transform.dedup.distinct](https://petl.readthedocs.io/en/stable/transform.html#petl.transform.dedup.distinct) method and extends the functionality natively to the Parsons Table class. This solution also heavily references the implementation provided in the original issue by @shaunagm!

## One sticky point on terminology
As suggested in the original issue, this method accepts an optional `sort` parameter to instruct petl (imperatively) whether to first sort the table. However, this is more or less the opposite definition used internally by the petl library. In petl, the same argument is called `presorted` which (declaratively) describes a table as either presorted or not presorted &mdash; if it's not presorted, petl sorts it.

It's a small detail, but anyone who is used to the petl definition may be confused by this. A `sort=True` value (meaning, "this table is not yet sorted, sort it for me") is the exact opposite of a `presorted=True` value in petl (meaning, "this table is sorted, don't sort it"). In the code, this is represented by an explicit inversion (`presorted=not sort`) on line 1186 when it's passed into petl's method. I've also included a comment explaining this for anyone who might be confused by the definitions.

For one, I totally agree that "sort" makes more sense here to instruct the deduplicate method to sort the array, but I'm newer to the community and wanted to note here that it might run against what someone might expect if they're used to interacting with petl and Parsons Tables directly.

Happy to adjust any of the above!