### PR TITLE
NewMode - Add bulk `targets` endpoint

### DIFF
--- a/parsons/newmode/newmode.py
+++ b/parsons/newmode/newmode.py
@@ -165,6 +165,27 @@ class Newmode:
             logging.warning("Empty target returned")
             return None
 
+    def get_targets(self, params={}):
+        """
+        Get all targets
+
+        Args:
+            params dict:
+                Extra paramaters sent to New/Mode library
+
+        Returns:
+            Target information
+        """
+
+        targets = self.client.getTargets(params=params)
+
+        if targets:
+            return self.convert_to_table(targets)
+
+        else:
+            logging.warning("No targets returned")
+            return None
+
     def get_campaigns(self, params={}):
         """
         Get existing campaigns.


### PR DESCRIPTION
This PR adds an additional `GET` request to the NewMode client that allows ALL targets to be queried and returned as a table. The addition of this function will give Parsons users flexibility in their API requests to NewMode, as they may be interested in exploring target data broadly and across outreaches.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204935310402358