### PR TITLE
Enable passing `identifiers` to ActionNetwork `upsert_person()`

### DIFF
--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -156,7 +156,11 @@ class ActionNetwork(object):
                 background queue for eventual processing.
                 https://actionnetwork.org/docs/v2/#background-processing
             identifiers:
-                list of strings to be used as globally unique identifiers
+                list of strings to be used as globally unique identifiers.
+                e.g.: [
+                   "action_network:d3e27e15-e5b5-4707-be96-8bc359462133",
+                   "foreign_system:1"
+                ]
             **kwargs:
                 Any additional fields to store about the person. Action Network allows
                 any custom field.

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -100,6 +100,7 @@ class ActionNetwork(object):
         mobile_number=None,
         mobile_status="subscribed",
         background_processing=False,
+        identifiers=None,
         **kwargs,
     ):
         """
@@ -153,6 +154,8 @@ class ActionNetwork(object):
                 an immediate success, with an empty JSON body, and send your request to the
                 background queue for eventual processing.
                 https://actionnetwork.org/docs/v2/#background-processing
+            identifiers:
+                list of strings to be used as globally unique identifiers
             **kwargs:
                 Any additional fields to store about the person. Action Network allows
                 any custom field.
@@ -217,7 +220,8 @@ class ActionNetwork(object):
             data["person"]["postal_addresses"] = postal_addresses
         if tags is not None:
             data["add_tags"] = tags
-
+        if identifiers:
+            data["person"]["identifiers"] = identifiers
         data["person"]["custom_fields"] = {**kwargs}
         url = f"{self.api_url}/people"
         if background_processing:

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -156,11 +156,15 @@ class ActionNetwork(object):
                 background queue for eventual processing.
                 https://actionnetwork.org/docs/v2/#background-processing
             identifiers:
-                list of strings to be used as globally unique identifiers.
-                e.g.: [
-                   "action_network:d3e27e15-e5b5-4707-be96-8bc359462133",
-                   "foreign_system:1"
-                ]
+                List of strings to be used as globally unique
+                identifiers. Can be useful for matching contacts back
+                to other platforms and systems. If the identifier
+                provided is not globally unique in ActionNetwork, it will
+                simply be ignored and not added to the object. Action Network
+                also creates its own identifier for each new resouce.
+                https://actionnetwork.org/docs/v2/#resources
+                e.g.: ["foreign_system:1", "other_system:12345abcd"]
+
             **kwargs:
                 Any additional fields to store about the person. Action Network allows
                 any custom field.

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -325,21 +325,15 @@ class ActionNetwork(object):
         logger.info(f"Person {entry_id} successfully updated")
         return response
 
-    def get_tags(self, limit=None, per_page=25, page=None):
+    def get_tags(self, limit=None):
         """
         `Args:`
             limit:
                 The number of entries to return. When None, returns all entries.
-            per_page
-                The number of entries per page to return. 25 maximum.
-            page
-                Which page of results to return
         `Returns:`
             A list of JSONs of tags in Action Network.
         """
-        if page:
-            self.get_page("tags", page, per_page)
-        return self._get_entry_list("tags", limit, per_page)
+        return self._get_entry_list("tags", limit)
 
     def get_tag(self, tag_id):
         """

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import warnings
 
 from parsons import Table
 from parsons.utilities import check_env
@@ -325,14 +326,22 @@ class ActionNetwork(object):
         logger.info(f"Person {entry_id} successfully updated")
         return response
 
-    def get_tags(self, limit=None):
+    def get_tags(self, limit=None, per_page=None):
         """
         `Args:`
             limit:
                 The number of entries to return. When None, returns all entries.
+            per_page:
+                This is a deprecated argument.
         `Returns:`
             A list of JSONs of tags in Action Network.
         """
+        if per_page:
+            warnings.warn(
+                "per_page is a deprecated argument on get_tags()",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self._get_entry_list("tags", limit)
 
     def get_tag(self, tag_id):


### PR DESCRIPTION
`identifiers` is a useful method when upserting a person, for either matching to an existing contact or creating a new contact.

The `**kwargs` keyword arguments on upsert_person() are passed as custom fields and so excludes the ability to add identifiers as additional keyword arguments without adding this functionality.

Small code readability improvements are also made to the `get_tags()` method in this PR by removing code that didn't do anything.