### PR TITLE
Airtable switch from API key to personal access token

### DIFF
--- a/docs/airtable.rst
+++ b/docs/airtable.rst
@@ -6,7 +6,7 @@ Overview
 ********
 
 The Airtable class allows you to interact with an `Airtable <https://airtable.com/>`_ base. In order to use this class
-you must generate an Airtable API Key which can be found in your Airtable `account settings <https://airtable.com/account>`_.
+you must generate an Airtable personal access token which can be found in your Airtable `settings <https://airtable.com/create/tokens>`_.
 
 .. note::
    Finding The Base Key
@@ -18,20 +18,20 @@ you must generate an Airtable API Key which can be found in your Airtable `accou
 **********
 QuickStart
 **********
-To instantiate the Airtable class, you can either store your Airtable API
-``AIRTABLE_API_KEY`` as an environmental variable or pass in your api key
+To instantiate the Airtable class, you can either store your Airtable personal access token
+``AIRTABLE_PERSONAL_ACCESS_TOKEN`` as an environmental variable or pass in your personal access token
 as an argument. You also need to pass in the base key and table name.
 
 .. code-block:: python
 
    from parsons import Airtable
 
-   # First approach: Use API credentials via environmental variables and pass
+   # First approach: Use personal access token via environmental variable and pass
    # the base key and the table as arguments.
    at = Airtable(base_key, 'table01')
 
-   # Second approach: Pass API credentials, base key and table name as arguments.
-   at = Airtable(base_key, 'table01', api_key='MYFAKEKEY')
+   # Second approach: Pass personal access token, base key and table name as arguments.
+   at = Airtable(base_key, 'table01', personal_access_token='MYFAKETOKEN')
 
 
 You can then call various endpoints:

--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -15,14 +15,17 @@ class Airtable(object):
         table_name: str
             The name of the table in the base. The table name is the equivilant of the sheet name
             in Excel or GoogleDocs.
-        api_key: str
-            The Airtable provided api key. Not required if ``AIRTABLE_API_KEY`` env variable set.
+        personal_access_token: str
+            The Airtable personal access token. Not required if ``AIRTABLE_PERSONAL_ACCESS_TOKEN``
+            env variable set.
     """
 
-    def __init__(self, base_key, table_name, api_key=None):
+    def __init__(self, base_key, table_name, personal_access_token=None):
 
-        self.api_key = check_env.check("AIRTABLE_API_KEY", api_key)
-        self.client = client(base_key, table_name, self.api_key)
+        self.personal_access_token = check_env.check(
+            "AIRTABLE_PERSONAL_ACCESS_TOKEN", personal_access_token
+        )
+        self.client = client(base_key, table_name, self.personal_access_token)
 
     def get_record(self, record_id):
         """

--- a/test/test_airtable/test_airtable.py
+++ b/test/test_airtable/test_airtable.py
@@ -11,7 +11,7 @@ from airtable_responses import (
 )
 
 
-os.environ["AIRTABLE_API_KEY"] = "SOME_KEY"
+os.environ["AIRTABLE_PERSONAL_ACCESS_TOKEN"] = "SOME_TOKEN"
 BASE_KEY = "BASEKEY"
 TABLE_NAME = "TABLENAME"
 


### PR DESCRIPTION
Fixes #788 

The authentication process using Airtable API key vs personal access token is the same. Switching the name from `api_key` to `personal_access_token` to reflect the fact that Airtable will be deprecating API keys and a personal access token should be used instead: https://community.airtable.com/t5/announcements/new-api-capabilities-now-in-ga-and-upcoming-api-keys-deprecation/ba-p/141824