### PR TITLE
Enable use of "extension" argument to Redshift unload

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -705,6 +705,7 @@ class Redshift(
         allow_overwrite=True,
         parallel=True,
         max_file_size="6.2 GB",
+        extension=None,
         aws_region=None,
         aws_access_key_id=None,
         aws_secret_access_key=None,
@@ -750,6 +751,8 @@ class Redshift(
         max_file_size: str
             The maximum size of files UNLOAD creates in Amazon S3. Specify a decimal value between
             5 MB and 6.2 GB.
+        extension: str
+            This extension will be added to the end of file names loaded to S3
         region: str
             The AWS Region where the target Amazon S3 bucket is located. REGION is required for
             UNLOAD to an Amazon S3 bucket that is not in the same AWS Region as the Amazon Redshift
@@ -789,6 +792,8 @@ class Redshift(
             statement += "ESCAPE \n"
         if allow_overwrite:
             statement += "ALLOWOVERWRITE \n"
+        if extension:
+            statement += f"EXTENSION '{extension}' \n"
         if aws_region:
             statement += f"REGION {aws_region} \n"
 


### PR DESCRIPTION
Extension is a helpful argument. This PR makes it possible to use the extension argument on Redshift.unload()

I have a workflow where I unload  SQL query to S3, and then make the resulting file available to download. It's great if that file already has a proper extension and I don't need to rename the file in S3 first. Currently all Redshift.unload() files have an extension of .gz if the file is compressed or simply ends with `000` if not.