### PR TITLE
Action Builder Entity Record Insert Name Key Hotfix

### DIFF
--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -188,11 +188,12 @@ class ActionBuilder(object):
             Dict containing Action Builder entity data.
         """  # noqa: E501
 
+        name_keys = ("name", "action_builder:name", "given_name")
         error = "Must provide data with name or given_name when inserting new record"
         if not isinstance(data, dict):
             raise ValueError(error)
         name_check = [
-            key for key in data.get("person", {}) if key in ("name", "given_name")
+            key for key in data.get("person", {}) if key in name_keys
         ]
         if not name_check:
             raise ValueError(error)

--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -192,9 +192,7 @@ class ActionBuilder(object):
         error = "Must provide data with name or given_name when inserting new record"
         if not isinstance(data, dict):
             raise ValueError(error)
-        name_check = [
-            key for key in data.get("person", {}) if key in name_keys
-        ]
+        name_check = [key for key in data.get("person", {}) if key in name_keys]
         if not name_check:
             raise ValueError(error)
 


### PR DESCRIPTION
Action Builder's API is not consistent about what key you need in your data for the name of the entity. For People (and other Entities configured like them) you need at least a `given_name` key. Other Entity types can be configured just to take a single name. These used to be insertable with the `name` key, but now seem to require `action_builder:name`. Rather than trying to force that prefix to be added, I'm just making sure all three keys pass the error handling in `insert_entity_record()`.