### PR TITLE
#741 : Deprecate Slack chat.postMessage `as_user` argument and allow for new authorship arguments

### DIFF
--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -131,7 +131,8 @@ class Slack(object):
             payload["thread_ts"] = parent_message_id
         return requests.post(webhook, json=payload)
 
-    def message_channel(self, channel, text, as_user=False, parent_message_id=None):
+    def message_channel(self, channel, text, as_user=False, parent_message_id=None, username=None,
+                        icon_url=None, icon_emoji=None):
         """
         Send a message to a Slack channel
 
@@ -142,20 +143,30 @@ class Slack(object):
             text: str
                 Text of the message to send.
             as_user: str
-                This is a deprecated argument.
-                Pass true to post the message as the authenticated user,
-                instead of as a bot. Defaults to false. See
-                https://api.slack.com/methods/chat.postMessage#authorship for
+                This is a deprecated argument. Use optional username, icon_url, and icon_emoji
+                args to customize the user posting the message.
+                See https://api.slack.com/methods/chat.postMessage#authorship for
                 more information about Slack authorship.
             parent_message_id: str
                 The `ts` value of the parent message. If used, this will thread the message.
+            username: str
+                The username associated with the message post. If none set, user defaults to slack's
+                rules on message authentication.
+            icon_url: str
+                Url link to user image associated with message. If none set, user image defaults to
+                slack's rules on message authentication.
+            icon_emoji: str
+                colon shortcode for slack emoji to be used alongside user message.
+
+
         `Returns:`
             `dict`:
                 A response json
         """
         if as_user:
             warnings.warn(
-                "as_user is a deprecated argument on message_channel()",
+                "as_user is a deprecated argument on message_channel(). \
+                For message user customization, use the username, icon_url, and icon_emoji arguments.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -164,6 +175,9 @@ class Slack(object):
             channel=channel,
             text=text,
             thread_ts=parent_message_id,
+            username=username,
+            icon_emoji=icon_emoji,
+            icon_url=icon_url,
         )
 
         if not resp["ok"]:

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -148,7 +148,7 @@ class Slack(object):
                 more information about legacy authorship
             parent_message_id: str
                 The `ts` value of the parent message. If used, this will thread the message.
-            \**kwargs: kwargs
+            **kwargs: kwargs
                 Additional arguments for chat.postMessage API call. See documentation
                 <https://api.slack.com/methods/chat.postMessage>` for more info.
 

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -161,6 +161,13 @@ class Slack(object):
                 DeprecationWarning,
                 stacklevel=2,
             )
+        if "thread_ts" in kwargs:
+            warnings.warn(
+                "thread_ts argument on message_channel() will be ignored. Use parent_message_id.",
+                Warning,
+                stacklevel=2,
+            )
+            kwargs.pop("thread_ts", None)
 
         resp = self.client.api_call(
             "chat.postMessage",

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -138,14 +138,14 @@ class Slack(object):
                 an `im` (aka 1-1 message).
             text: str
                 Text of the message to send.
-            as_user: str
-                This is a deprecated argument. Use optional username, icon_url, and icon_emoji
-                args to customize the attributes of the user posting the message.
-                See https://api.slack.com/methods/chat.postMessage#legacy_authorship for
-                more information about legacy authorship
             parent_message_id: str
                 The `ts` value of the parent message. If used, this will thread the message.
             **kwargs: kwargs
+                as_user: str
+                    This is a deprecated argument. Use optional username, icon_url, and icon_emoji
+                    args to customize the attributes of the user posting the message.
+                    See https://api.slack.com/methods/chat.postMessage#legacy_authorship for
+                    more information about legacy authorship
                 Additional arguments for chat.postMessage API call. See documentation
                 <https://api.slack.com/methods/chat.postMessage>` for more info.
 

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -155,7 +155,7 @@ class Slack(object):
                 A response json
         """
 
-        if kwargs.get("as_user", None) is not None:
+        if "as_user" in kwargs:
             warnings.warn(
                 "as_user is a deprecated argument on message_channel().",
                 DeprecationWarning,

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -131,8 +131,7 @@ class Slack(object):
             payload["thread_ts"] = parent_message_id
         return requests.post(webhook, json=payload)
 
-    def message_channel(self, channel, text, as_user=False, parent_message_id=None, username=None,
-                        icon_url=None, icon_emoji=None):
+    def message_channel(self, channel, text, as_user=False, parent_message_id=None, **kwargs):
         """
         Send a message to a Slack channel
 
@@ -144,22 +143,14 @@ class Slack(object):
                 Text of the message to send.
             as_user: str
                 This is a deprecated argument. Use optional username, icon_url, and icon_emoji
-                args to customize the user posting the message.
-                See https://api.slack.com/methods/chat.postMessage#authorship for
-                more information about Slack authorship.
+                args to customize the attributes of the user posting the message.
+                See https://api.slack.com/methods/chat.postMessage#legacy_authorship for
+                more information about legacy authorship
             parent_message_id: str
                 The `ts` value of the parent message. If used, this will thread the message.
-            username: str
-                The username associated with the message post. If none set, user defaults to slack's
-                rules on message authentication. This setting will be ignored if authenticated user does
-                not have `chat:write.customize` permission.
-            icon_url: str
-                Url link to user image associated with message. If none set, user image defaults to
-                slack's rules on message authentication. This setting will be ignored if authenticated user does
-                not have `chat:write.customize` permission.
-            icon_emoji: str
-                colon shortcode for slack emoji to be used alongside user message. This setting will be ignored
-                if authenticated user does not have `chat:write.customize` permission.
+            \**kwargs: kwargs
+                Additional arguments for chat.postMessage API call. See documentation
+                <https://api.slack.com/methods/chat.postMessage>` for more info.
 
 
         `Returns:`
@@ -168,8 +159,7 @@ class Slack(object):
         """
         if as_user:
             warnings.warn(
-                "as_user is a deprecated argument on message_channel(). \
-                For message user customization, use the username, icon_url, and icon_emoji arguments.",
+                "as_user is a deprecated argument on message_channel().",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -178,9 +168,7 @@ class Slack(object):
             channel=channel,
             text=text,
             thread_ts=parent_message_id,
-            username=username,
-            icon_emoji=icon_emoji,
-            icon_url=icon_url,
+            **kwargs,
         )
 
         if not resp["ok"]:

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -1,5 +1,6 @@
 import os
 import time
+import warnings
 
 from parsons.etl.table import Table
 from parsons.utilities.check_env import check
@@ -141,6 +142,7 @@ class Slack(object):
             text: str
                 Text of the message to send.
             as_user: str
+                This is a deprecated argument.
                 Pass true to post the message as the authenticated user,
                 instead of as a bot. Defaults to false. See
                 https://api.slack.com/methods/chat.postMessage#authorship for
@@ -151,11 +153,16 @@ class Slack(object):
             `dict`:
                 A response json
         """
+        if as_user:
+            warnings.warn(
+                "as_user is a deprecated argument on message_channel()",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         resp = self.client.api_call(
             "chat.postMessage",
             channel=channel,
             text=text,
-            as_user=as_user,
             thread_ts=parent_message_id,
         )
 
@@ -165,7 +172,7 @@ class Slack(object):
                 time.sleep(int(resp["headers"]["Retry-After"]))
 
                 resp = self.client.api_call(
-                    "chat.postMessage", channel=channel, text=text, as_user=as_user
+                    "chat.postMessage", channel=channel, text=text
                 )
 
             raise SlackClientError(resp["error"])

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -179,7 +179,7 @@ class Slack(object):
                 time.sleep(int(resp["headers"]["Retry-After"]))
 
                 resp = self.client.api_call(
-                    "chat.postMessage", channel=channel, text=text
+                    "chat.postMessage", channel=channel, text=text, **kwargs
                 )
 
             resp.pop('headers', None)

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -151,12 +151,15 @@ class Slack(object):
                 The `ts` value of the parent message. If used, this will thread the message.
             username: str
                 The username associated with the message post. If none set, user defaults to slack's
-                rules on message authentication.
+                rules on message authentication. This setting will be ignored if authenticated user does
+                not have `chat:write.customize` permission.
             icon_url: str
                 Url link to user image associated with message. If none set, user image defaults to
-                slack's rules on message authentication.
+                slack's rules on message authentication. This setting will be ignored if authenticated user does
+                not have `chat:write.customize` permission.
             icon_emoji: str
-                colon shortcode for slack emoji to be used alongside user message.
+                colon shortcode for slack emoji to be used alongside user message. This setting will be ignored
+                if authenticated user does not have `chat:write.customize` permission.
 
 
         `Returns:`

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -131,7 +131,7 @@ class Slack(object):
             payload["thread_ts"] = parent_message_id
         return requests.post(webhook, json=payload)
 
-    def message_channel(self, channel, text, as_user=False, parent_message_id=None, **kwargs):
+    def message_channel(self, channel, text, parent_message_id=None, **kwargs):
         """
         Send a message to a Slack channel
 
@@ -157,12 +157,14 @@ class Slack(object):
             `dict`:
                 A response json
         """
-        if as_user:
+
+        if kwargs.get('as_user', None) is not None:
             warnings.warn(
                 "as_user is a deprecated argument on message_channel().",
                 DeprecationWarning,
                 stacklevel=2,
             )
+
         resp = self.client.api_call(
             "chat.postMessage",
             channel=channel,

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -180,7 +180,9 @@ class Slack(object):
                     "chat.postMessage", channel=channel, text=text
                 )
 
-            raise SlackClientError(resp["error"])
+            resp.pop('headers', None)
+
+            raise SlackClientError(resp)
 
         return resp
 

--- a/parsons/notifications/slack.py
+++ b/parsons/notifications/slack.py
@@ -13,9 +13,7 @@ import requests
 
 class Slack(object):
     def __init__(self, api_key=None):
-
         if api_key is None:
-
             try:
                 self.api_key = os.environ["SLACK_API_TOKEN"]
 
@@ -26,7 +24,6 @@ class Slack(object):
                 )
 
         else:
-
             self.api_key = api_key
 
         self.client = SlackClient(self.api_key)
@@ -158,7 +155,7 @@ class Slack(object):
                 A response json
         """
 
-        if kwargs.get('as_user', None) is not None:
+        if kwargs.get("as_user", None) is not None:
             warnings.warn(
                 "as_user is a deprecated argument on message_channel().",
                 DeprecationWarning,
@@ -174,7 +171,6 @@ class Slack(object):
         )
 
         if not resp["ok"]:
-
             if resp["error"] == "ratelimited":
                 time.sleep(int(resp["headers"]["Retry-After"]))
 
@@ -182,7 +178,7 @@ class Slack(object):
                     "chat.postMessage", channel=channel, text=text, **kwargs
                 )
 
-            resp.pop('headers', None)
+            resp.pop("headers", None)
 
             raise SlackClientError(resp)
 
@@ -237,7 +233,6 @@ class Slack(object):
             )
 
             if not resp["ok"]:
-
                 if resp["error"] == "ratelimited":
                     time.sleep(int(resp["headers"]["Retry-After"]))
 
@@ -266,7 +261,6 @@ class Slack(object):
             resp = self.client.api_call(endpoint, cursor=cursor, limit=LIMIT, **kwargs)
 
             if not resp["ok"]:
-
                 if resp["error"] == "ratelimited":
                     time.sleep(int(resp["headers"]["Retry-After"]))
                     continue

--- a/useful_resources/sample_code/civis_job_status_slack_alert.py
+++ b/useful_resources/sample_code/civis_job_status_slack_alert.py
@@ -140,7 +140,7 @@ def main():
     message = f"*{project_name} Status*\n{line_items}"
     logger.info(f"Posting message to Slack channel {SLACK_CHANNEL}")
     # Post message
-    slack.message_channel(SLACK_CHANNEL, message, as_user=True)
+    slack.message_channel(SLACK_CHANNEL, message)
     logger.info("Slack message posted")
 
 


### PR DESCRIPTION
Addresses #741 

This PR adds a deprecation warning for usage of the `as_user` argument in calls to `chat.postMessage`, allows the user to see failed Slack API `deprecated_argument` responses, and facilitates usage of the new Slack authorship customization arguments `username`, `icon_url`, and `icon_emoji` using optional keyword arguments (See: https://api.slack.com/methods/chat.postMessage#authorship)

`as_user` will still be passed on to the slack request and will still fail if the user passes in `as_user=False`, but the user should see more information in the failed response now.