### PR TITLE
#816 Airtable.get_records() fields argument can be either str or list

### DIFF
--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -94,6 +94,8 @@ class Airtable(object):
                 See :ref:`parsons-table` for output options.
         """
 
+        if isinstance(fields, str):
+            fields = [fields]
         # Raises an error if sort is None type. Thus, only adding if populated.
         kwargs = {
             "fields": fields,
@@ -101,6 +103,7 @@ class Airtable(object):
             "view": view,
             "formula": formula,
         }
+
         if sort:
             kwargs["sort"] = sort
 

--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -103,7 +103,6 @@ class Airtable(object):
             "view": view,
             "formula": formula,
         }
-
         if sort:
             kwargs["sort"] = sort
 

--- a/test/test_airtable/test_airtable.py
+++ b/test/test_airtable/test_airtable.py
@@ -100,6 +100,16 @@ class TestAirtable(unittest.TestCase):
         assert airtable_res.columns == ["id", "createdTime", "Name", "SecondColumn"]
 
     @requests_mock.Mocker()
+    def test_get_records_with_single_field(self, m):
+        m.get(self.base_uri, json=records_response_with_more_columns)
+
+        fields = "Name"
+
+        airtable_res = self.at.get_records(fields, sample_size=1)
+
+        assert airtable_res.columns == ["id", "createdTime", "Name"]
+
+    @requests_mock.Mocker()
     def test_insert_record(self, m):
 
         m.post(self.base_uri, json=insert_response)


### PR DESCRIPTION
Fixes #816 and adds test replicating the issue when passing a single field into the `fields` argument as a string