### PR TITLE
Check for empty tables in zoom poll results

### DIFF
--- a/parsons/zoom/zoom.py
+++ b/parsons/zoom/zoom.py
@@ -151,6 +151,8 @@ class Zoom:
         `Returns`:
             Parsons Table
         """
+        if tbl.num_rows == 0:
+            return tbl
 
         # Add surrogate key
         tbl.add_column("poll_taker_id", lambda _: str(uuid.uuid4()))


### PR DESCRIPTION
The new Zoom poll code fails when trying to get results for a meeting/webinar that does not return poll data. This commit checks that there is poll data before trying to apply the table transformations.

```
Traceback (most recent call last):
  File "parsons\parsons\zoom\zoom.py", line 509, in get_meeting_poll_results
    return self.__process_poll_results(tbl=tbl)
  File "parsons\parsons\zoom\zoom.py", line 159, in __process_poll_results
    tbl = tbl.unpack_nested_columns_as_rows(
  File "parsons\parsons\etl\etl.py", line 576, in unpack_nested_columns_as_rows
    ignore_cols.remove(column)
ValueError: list.remove(x): x not in list
```