### PR TITLE
Fix airtable.insert_records table arg type

### DIFF
--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -158,7 +158,7 @@ class Airtable(object):
             table = table.to_dicts()
         resp = self.client.batch_insert(table, typecast=typecast)
         resp = Table(resp)
-        logger.info(f"{table.num_rows} records inserted.")
+        logger.info(f"{resp.num_rows} records inserted.")
         return resp
 
     def update_record(self, record_id, fields, typecast=False):

--- a/parsons/airtable/airtable.py
+++ b/parsons/airtable/airtable.py
@@ -147,15 +147,17 @@ class Airtable(object):
         order of the columns is irrelevant.
 
         `Args:`
-            table: A Parsons Table
-                Insert a Parsons table
+            table: A Parsons Table or list of dicts
+                Insert a Parsons table or list
             typecast: boolean
                 Automatic data conversion from string values.
         `Returns:`
             List of dictionaries of inserted rows
         """
-
+        if isinstance(table, Table):
+            table = table.to_dicts()
         resp = self.client.batch_insert(table, typecast=typecast)
+        resp = Table(resp)
         logger.info(f"{table.num_rows} records inserted.")
         return resp
 


### PR DESCRIPTION
It seems that `airtable.batch_insert` was used without any conversion to a list from the table arg, and [expects a raw list](https://airtable-python-wrapper.readthedocs.io/en/master/api.html#airtable.Airtable.batch_insert), but this parsons method expects a parsons table. So, either sending a table or list in would cause an error, though sending the list would actually insert the rows into Airtable but throw the error on the final `table.num_rows` log.

This PR allows for either to work!

Errors for reference:

Table source:
```
  File "/root/.pyenv/versions/letters-comments-vetting-ve/lib/python3.9/site-packages/airtable/airtable.py", line 154, in _chunk
    for i in range(0, len(iterable), chunk_size):
TypeError: object of type 'Table' has no len()
```
list source:
```
  File "/root/.pyenv/versions/letters-comments-vetting-ve/lib/python3.9/site-packages/parsons/airtable/airtable.py", line 147, in insert_records
    logger.info(f'{table.num_rows} records inserted.')
AttributeError: 'list' object has no attribute 'num_rows'
```