### PR TITLE
Google BigQuery - Clean Up Autodetect Logic

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -551,6 +551,7 @@ class GoogleBigQuery(DatabaseConnector):
         old_bucket_name, old_blob_name = gcs.split_uri(gcs_uri=gcs_blob_uri)
 
         uncompressed_gcs_uri = None
+
         try:
             logger.debug("Unzipping large file")
             uncompressed_gcs_uri = gcs.unzip_blob(
@@ -1048,13 +1049,14 @@ class GoogleBigQuery(DatabaseConnector):
         if not job_config:
             job_config = bigquery.LoadJobConfig()
 
-        if not job_config.schema and kwargs["schema"]:
-            logger.debug("Using user-supplied schema definition...")
-            job_config.schema = map_column_headers_to_schema_field(kwargs["schema"])
-            job_config.autodetect = False
-        else:
-            logger.debug("Autodetecting schema definition...")
-            job_config.autodetect = True
+        if not job_config.schema:
+            if kwargs["schema"]:
+                logger.debug("Using user-supplied schema definition...")
+                job_config.schema = map_column_headers_to_schema_field(kwargs["schema"])
+                job_config.autodetect = False
+            else:
+                logger.debug("Autodetecting schema definition...")
+                job_config.autodetect = True
 
         if not job_config.create_disposition:
             job_config.create_disposition = bigquery.CreateDisposition.CREATE_IF_NEEDED

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -575,8 +575,8 @@ class GoogleBigQuery(DatabaseConnector):
                 new_bucket_name, new_blob_name = gcs.split_uri(
                     gcs_uri=uncompressed_gcs_uri
                 )
-                gcs.delete_blob(new_bucket_name, new_blob_name)
-                logger.debug("Successfully dropped uncompressed blob")
+                # gcs.delete_blob(new_bucket_name, new_blob_name)
+                # logger.debug("Successfully dropped uncompressed blob")
 
     def copy_s3(
         self,

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -576,8 +576,8 @@ class GoogleBigQuery(DatabaseConnector):
                 new_bucket_name, new_blob_name = gcs.split_uri(
                     gcs_uri=uncompressed_gcs_uri
                 )
-                # gcs.delete_blob(new_bucket_name, new_blob_name)
-                # logger.debug("Successfully dropped uncompressed blob")
+                gcs.delete_blob(new_bucket_name, new_blob_name)
+                logger.debug("Successfully dropped uncompressed blob")
 
     def copy_s3(
         self,


### PR DESCRIPTION
The job config logic was written such that incoming `job_config` objects were set to `autodetect=True` ... we cleaned up the logic that's applied such that an explicitly passed-in schema will take precedence