### PR TITLE
Enhancement: Action Network Connector: Added unpack_statistics param in get_messages method

### DIFF
--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -583,7 +583,7 @@ class ActionNetwork(object):
         return self.api.get_request(f"lists/{list_id}")
 
     # Messages
-    def get_messages(self, limit=None, per_page=25, page=None, filter=None):
+    def get_messages(self, limit=None, per_page=25, page=None, filter=None, unpack_statistics=True):
         """
         `Args:`
             limit:
@@ -595,14 +595,23 @@ class ActionNetwork(object):
            filter:
                The OData query for filtering results. E.g. "modified_date gt '2014-03-25'".
                When None, no filter is applied.
+           unpack_statistics:
+                Whether to unpack the statistics dictionary into the table. Default to True.
 
 
         `Returns:`
-            A  JSON with all the messages related entries
+            A Parsons Table with all the messages related entries
         """
+        # Fetch messages
         if page:
-            return self._get_page("messages", page, per_page, filter)
-        return self._get_entry_list("messages", limit, per_page, filter)
+            return self._get_page("messages", page, per_page)
+        tbl = self._get_entry_list("messages", limit, per_page)
+
+        # Unpack statistics
+        if unpack_statistics:
+            tbl.unpack_dict("statistics", prepend=False)
+
+        return tbl
 
     def get_message(self, message_id):
         """

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -48,7 +48,6 @@ class ActionNetwork(object):
         count = 0
         page = 1
         return_list = []
-        print("get_entry 1")
         while True:
             response = self._get_page(object_name, page, per_page, filter=filter)
             page = page + 1
@@ -60,7 +59,6 @@ class ActionNetwork(object):
             if limit:
                 if count >= limit:
                     return Table(return_list[0:limit])
-            print(response_list)
 
     # Advocacy Campaigns
     def get_advocacy_campaigns(self, limit=None, per_page=25, page=None, filter=None):

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -48,6 +48,7 @@ class ActionNetwork(object):
         count = 0
         page = 1
         return_list = []
+        print("get_entry 1")
         while True:
             response = self._get_page(object_name, page, per_page, filter=filter)
             page = page + 1
@@ -59,6 +60,7 @@ class ActionNetwork(object):
             if limit:
                 if count >= limit:
                     return Table(return_list[0:limit])
+            print(response_list)
 
     # Advocacy Campaigns
     def get_advocacy_campaigns(self, limit=None, per_page=25, page=None, filter=None):
@@ -604,13 +606,11 @@ class ActionNetwork(object):
         """
         # Fetch messages
         if page:
-            return self._get_page("messages", page, per_page)
-        tbl = self._get_entry_list("messages", limit, per_page)
-
+            return self._get_page("messages", page, per_page, filter)
+        return self._get_entry_list("messages", limit, per_page, filter)
         # Unpack statistics
         if unpack_statistics:
-            tbl.unpack_dict("statistics", prepend=False)
-
+            tbl.unpack_dict("statistics", prepend=False, include_original=True)
         return tbl
 
     def get_message(self, message_id):

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -605,7 +605,7 @@ class ActionNetwork(object):
         # Fetch messages
         if page:
             return self._get_page("messages", page, per_page, filter)
-        return self._get_entry_list("messages", limit, per_page, filter)
+        tbl = self._get_entry_list("messages", limit, per_page, filter)
         # Unpack statistics
         if unpack_statistics:
             tbl.unpack_dict("statistics", prepend=False, include_original=True)

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -598,7 +598,7 @@ class ActionNetwork(object):
                The OData query for filtering results. E.g. "modified_date gt '2014-03-25'".
                When None, no filter is applied.
            unpack_statistics:
-                Whether to unpack the statistics dictionary into the table. Default to True.
+                Whether to unpack the statistics dictionary into the table. Default to False.
 
 
         `Returns:`

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -583,7 +583,9 @@ class ActionNetwork(object):
         return self.api.get_request(f"lists/{list_id}")
 
     # Messages
-    def get_messages(self, limit=None, per_page=25, page=None, filter=None, unpack_statistics=False):
+    def get_messages(
+        self, limit=None, per_page=25, page=None, filter=None, unpack_statistics=False
+    ):
         """
         `Args:`
             limit:

--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -583,7 +583,7 @@ class ActionNetwork(object):
         return self.api.get_request(f"lists/{list_id}")
 
     # Messages
-    def get_messages(self, limit=None, per_page=25, page=None, filter=None, unpack_statistics=True):
+    def get_messages(self, limit=None, per_page=25, page=None, filter=None, unpack_statistics=False):
         """
         `Args:`
             limit:

--- a/test/test_action_network/test_action_network.py
+++ b/test/test_action_network/test_action_network.py
@@ -3866,14 +3866,6 @@ class TestActionNetwork(unittest.TestCase):
             self.fake_messages["_embedded"][list(self.fake_messages["_embedded"])[0]],
         )
 
-    @requests_mock.Mocker()
-    def test_get_message(self, m):
-        m.get(f"{self.api_url}/messages/123", text=json.dumps(self.fake_message))
-        assert_matching_tables(
-            self.an.get_message("123"),
-            self.fake_message,
-        )
-
     # Metadata
     @requests_mock.Mocker()
     def test_get_metadata(self, m):

--- a/test/test_action_network/test_action_network.py
+++ b/test/test_action_network/test_action_network.py
@@ -3866,6 +3866,14 @@ class TestActionNetwork(unittest.TestCase):
             self.fake_messages["_embedded"][list(self.fake_messages["_embedded"])[0]],
         )
 
+    @requests_mock.Mocker()
+    def test_get_message(self, m):
+        m.get(f"{self.api_url}/messages/123", text=json.dumps(self.fake_message))
+        assert_matching_tables(
+            self.an.get_message("123"),
+            self.fake_message,
+        )
+
     # Metadata
     @requests_mock.Mocker()
     def test_get_metadata(self, m):


### PR DESCRIPTION
This PR introduces an enhancement to the get_messages method in the action_network.py file. The update includes an optional parameter unpack_statistics which, when set to True, unpacks the statistics dictionary into the returned Parsons Table. This feature provides users with more granular data access, allowing them to directly interact with the statistics related to each message.

The unpack_statistics parameter defaults to False, ensuring backward compatibility for users who do not require this level of detail. When unpack_statistics is True, the method uses the unpack_dict function on the statistics field of the Parsons Table.

This enhancement improves the flexibility and usefulness of the get_messages method, providing users with more control over the data they retrieve.

Please review and provide any feedback.