### PR TITLE
Enhancement: Parsons Table: added rename_columns for multiple cols

### DIFF
--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -80,7 +80,13 @@ class ETL(object):
 
         `Args:`
             column_map: dict
-                A dictionary of columns and new names
+                A dictionary of columns and new names.
+                The key is the old name and the value is the new name.
+
+                Example dictionary:
+                {'old_name': 'new_name',
+                'old_name2': 'new_name2'}
+
         `Returns:`
             `Parsons Table` and also updates self
         """

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -73,7 +73,7 @@ class ETL(object):
         self.table = petl.rename(self.table, column_name, new_column_name)
 
         return self
-    
+
     def rename_columns(self, column_map):
         """
         Rename multiple columns

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -73,6 +73,29 @@ class ETL(object):
         self.table = petl.rename(self.table, column_name, new_column_name)
 
         return self
+    
+    def rename_columns(self, column_map):
+        """
+        Rename multiple columns
+
+        `Args:`
+            column_map: dict
+                A dictionary of columns and new names
+        `Returns:`
+            `Parsons Table` and also updates self
+        """
+
+        # Check if old column name exists and new column name does not exist
+        for old_name, new_name in column_map.items():
+            if old_name not in self.table.columns():
+                raise KeyError(f"Column name {old_name} does not exist")
+            if new_name in self.table.columns():
+                raise ValueError(f"Column name {new_name} already exists")
+
+        # Uses the underlying petl method
+        self.table = petl.rename(self.table, column_map)
+
+        return self
 
     def fill_column(self, column_name, fill_value):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ airtable-python-wrapper==0.13.0
 google-cloud-storage==2.2.0
 google-cloud-bigquery==3.4.0
 docutils<0.18,>=0.14
-urllib3==1.26.5
+urllib3==1.26.17
 simplejson==3.16.0
 twilio==8.2.1
 simple-salesforce==1.11.6

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -323,6 +323,34 @@ class TestParsonsTable(unittest.TestCase):
         # Test that we can't rename to a column that already exists
         self.assertRaises(ValueError, self.tbl.rename_column, "last", "first")
 
+    def test_rename_columns(self):
+        # Test renaming columns with a valid column_map
+        column_map = {"first": "firstname", "last": "lastname"}
+        self.tbl.rename_columns(column_map)
+        self.assertEqual(self.tbl.columns, ["firstname", "lastname"])
+
+    def test_rename_columns_partial(self):
+        # Test renaming only some columns
+        column_map = {"first": "firstname"}
+        self.tbl.rename_columns(column_map)
+        self.assertEqual(self.tbl.columns, ["firstname", "last"])
+
+    def test_rename_columns_nonexistent(self):
+        # Test renaming a column that doesn't exist
+        column_map = {"nonexistent": "newname"}
+        self.assertRaises(KeyError, self.tbl.rename_columns, column_map)
+
+    def test_rename_columns_empty(self):
+        # Test renaming with an empty column_map
+        column_map = {}
+        self.tbl.rename_columns(column_map)
+        self.assertEqual(self.tbl.columns, ["first", "last"])
+
+    def test_rename_columns_duplicate(self):
+        # Test renaming to a column name that already exists
+        column_map = {"first": "last"}
+        self.assertRaises(ValueError, self.tbl.rename_columns, column_map)
+
     def test_fill_column(self):
         # Test that the column is filled
         tbl = Table(self.lst)


### PR DESCRIPTION
This pull request introduces a new method, rename_columns, to the ETL process. This method allows for the renaming of multiple columns at once in a Parsons Table.

The rename_columns method takes a dictionary as an argument (column_map), where the keys represent the current column names and the values represent the new column names. The method checks if the old column name exists and if the new column name does not already exist in the table. If these conditions are met, the method uses the underlying petl.rename function to perform the renaming operation.

The method returns the updated Parsons Table and also updates the self.table attribute of the class instance.

Unit tests have been added to ensure the rename_columns method works as expected and handles edge cases appropriately. These tests cover scenarios such as renaming columns with a valid column map, renaming only some columns, and attempting to rename a column that does not exist or to a name that already exists.

This enhancement provides a more efficient way to rename multiple columns, improving the flexibility and usability of the ETL process.