### PR TITLE
Update stale references to parsons.databases.bigquery

### DIFF
--- a/parsons/databases/discover_database.py
+++ b/parsons/databases/discover_database.py
@@ -5,7 +5,7 @@ from parsons.databases.database_connector import DatabaseConnector
 from parsons.databases.redshift import Redshift
 from parsons.databases.mysql import MySQL
 from parsons.databases.postgres import Postgres
-from parsons.databases.bigquery import BigQuery
+from parsons import GoogleBigQuery as BigQuery
 
 
 def discover_database(

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -647,7 +647,7 @@ class ToFrom(object):
             ``None``
         """
 
-        from parsons.databases.bigquery.bigquery import BigQuery
+        from parsons import GoogleBigQuery as BigQuery
 
         bq = BigQuery(app_creds=app_creds, project=project)
         bq.copy(self, table_name=table_name, **kwargs)
@@ -953,7 +953,7 @@ class ToFrom(object):
                 See :ref:`parsons-table` for output options.
         """
 
-        from parsons.databases.bigquery.bigquery import BigQuery
+        from parsons import GoogleBigQuery as BigQuery
 
         bq = BigQuery(app_creds=app_creds, project=project)
 

--- a/test/test_databases/test_discover_database.py
+++ b/test/test_databases/test_discover_database.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from parsons.databases.redshift import Redshift
 from parsons.databases.mysql import MySQL
 from parsons.databases.postgres import Postgres
-from parsons.databases.bigquery import BigQuery
+from parsons import GoogleBigQuery as BigQuery
 from parsons.databases.discover_database import discover_database
 
 


### PR DESCRIPTION
This PR is a minor update to import statements in the `major-release` branch, to point to the updated BigQuery module path in the main`__init__.py` file.

Unit tests for `discover_database` have additionally been updated to reflect the new path.