### PR TITLE
Enhancement: Added get_representatives_by_address method to Google Civic Connector

### DIFF
--- a/docs/google.rst
+++ b/docs/google.rst
@@ -239,7 +239,7 @@ You can also retrieve represntative information such as offices, officals, etc.
 .. code-block:: python
 
    address = '1600 Pennsylvania Avenue, Washington DC'
-   represntatives = google_civic.get_representatives_by_address(address=address)
+   representatives = google_civic.get_representatives_by_address(address=address)
 
 ===
 API

--- a/docs/google.rst
+++ b/docs/google.rst
@@ -234,6 +234,13 @@ Now you can retrieve election information
    election_id = '7000'  # General Election
    google_civic.get_polling_location(election_id=election_id, address=address)
 
+You can also retrieve represntative information such as offices, officals, etc.
+
+.. code-block:: python
+
+   address = '1600 Pennsylvania Avenue, Washington DC'
+   represntatives = google_civic.get_representatives_by_address(address=address)
+
 ===
 API
 ===

--- a/parsons/google/google_civic.py
+++ b/parsons/google/google_civic.py
@@ -116,3 +116,71 @@ class GoogleCivic(object):
         tbl.move_column("polling_address", 2)
 
         return tbl
+
+    def get_representative_info(
+        self, address: str, include_offices=True, levels=None, roles=None
+    ):
+        """
+        Get representative information for a given address.
+        `Args:`
+            address: str
+                A valid US address in a single string.
+            include_offices: bool
+                Whether to return information about offices and officials.
+                If false, only the top-level district information will be returned. (Default: True)
+            levels: list of str
+                A list of office levels to filter by.
+                Only offices that serve at least one of these levels will be returned.
+                Divisions that don't contain a matching office will not be returned.
+                    Acceptable values are:
+                    "administrativeArea1"
+                    "administrativeArea2"
+                    "country"
+                    "international"
+                    "locality"
+                    "regional"
+                    "special"
+                    "subLocality1"
+                    "subLocality2"
+            roles: list of str
+                A list of office roles to filter by.
+                Only offices fulfilling one of these roles will be returned.
+                Divisions that don't contain a matching office will not be returned.
+                    Acceptable values are:
+                    "deputyHeadOfGovernment"
+                    "executiveCouncil"
+                    "governmentOfficer"
+                    "headOfGovernment"
+                    "headOfState"
+                    "highestCourtJudge"
+                    "judge"
+                    "legislatorLowerBody"
+                    "legislatorUpperBody"
+                    "schoolBoard"
+                    "specialPurposeOfficer"
+
+        `Returns:`
+            Parsons Table
+                See :ref:`parsons-table` for output options.
+        """
+
+        if levels is not None and not isinstance(levels, list):
+            raise ValueError("levels must be a list of strings")
+        if roles is not None and not isinstance(roles, list):
+            raise ValueError("roles must be a list of strings")
+
+        url = self.uri + "representatives"
+
+        args = {
+            "address": address,
+            "includeOffices": include_offices,
+            "levels": levels,
+            "roles": roles,
+        }
+
+        response = self.request(url, args=args)
+
+        # Unpack values
+        tbl = Table(response["officials"])
+
+        return tbl

--- a/parsons/google/google_civic.py
+++ b/parsons/google/google_civic.py
@@ -117,11 +117,16 @@ class GoogleCivic(object):
 
         return tbl
 
-    def get_representative_info(
+    def get_representative_info_by_address(
         self, address: str, include_offices=True, levels=None, roles=None
     ):
         """
         Get representative information for a given address.
+        This method returns the raw JSON response from the Google Civic API.
+        It is a complex response that is not easily parsed into a table.
+        Here is the information on how to parse the response:
+        https://developers.google.com/civic-information/docs/v2/representatives/representativeInfoByAddress
+
         `Args:`
             address: str
                 A valid US address in a single string.
@@ -178,9 +183,4 @@ class GoogleCivic(object):
             "roles": roles,
         }
 
-        response = self.request(url, args=args)
-
-        # Unpack values
-        tbl = Table(response["officials"])
-
-        return tbl
+        return self.request(url, args=args)

--- a/parsons/google/google_civic.py
+++ b/parsons/google/google_civic.py
@@ -173,6 +173,8 @@ class GoogleCivic(object):
             raise ValueError("levels must be a list of strings")
         if roles is not None and not isinstance(roles, list):
             raise ValueError("roles must be a list of strings")
+        if address is None or not isinstance(address, str):
+            raise ValueError("address must be a string")
 
         url = self.uri + "representatives"
 
@@ -183,4 +185,10 @@ class GoogleCivic(object):
             "roles": roles,
         }
 
-        return self.request(url, args=args)
+        response = self.request(url, args=args)
+
+        # Raise an error if the address was invalid
+        if "error" in response:
+            raise ValueError(response["error"]["message"])
+
+        return response

--- a/test/test_google/googlecivic_responses.py
+++ b/test/test_google/googlecivic_responses.py
@@ -918,3 +918,587 @@ polling_data = [
         "notes": "",
     },
 ]
+
+representatives_resp = {
+    "normalizedInput": {
+        "line1": "1600 Amphitheatre Parkway",
+        "city": "Mountain View",
+        "state": "CA",
+        "zip": "94043",
+    },
+    "kind": "civicinfo#representativeInfoResponse",
+    "divisions": {
+        "ocd-division/country:us/state:ca/county:santa_clara": {
+            "name": "Santa Clara County",
+            "officeIndices": [14, 15, 16],
+        },
+        "ocd-division/country:us": {"name": "United States", "officeIndices": [0, 1]},
+        "ocd-division/country:us/state:ca/cd:16": {
+            "name": "California's 16th congressional district",
+            "officeIndices": [3],
+        },
+        "ocd-division/country:us/state:ca/place:mountain_view": {
+            "name": "Mountain View city"
+        },
+        "ocd-division/country:us/state:ca/sldl:23": {
+            "name": "California Assembly district 23",
+            "officeIndices": [12],
+        },
+        "ocd-division/country:us/state:ca": {
+            "name": "California",
+            "officeIndices": [2, 4, 5, 6, 7, 8, 9, 10, 11, 13],
+        },
+    },
+    "offices": [
+        {
+            "name": "President of the United States",
+            "divisionId": "ocd-division/country:us",
+            "levels": ["country"],
+            "roles": ["headOfGovernment", "headOfState"],
+            "officialIndices": [0],
+        },
+        {
+            "name": "Vice President of the United States",
+            "divisionId": "ocd-division/country:us",
+            "levels": ["country"],
+            "roles": ["deputyHeadOfGovernment"],
+            "officialIndices": [1],
+        },
+        {
+            "name": "U.S. Senator",
+            "divisionId": "ocd-division/country:us/state:ca",
+            "levels": ["country"],
+            "roles": ["legislatorUpperBody"],
+            "officialIndices": [2, 3],
+        },
+        {
+            "name": "U.S. Representative",
+            "divisionId": "ocd-division/country:us/state:ca/cd:16",
+            "levels": ["country"],
+            "roles": ["legislatorLowerBody"],
+            "officialIndices": [4],
+        },
+        {
+            "name": "Governor of California",
+            "divisionId": "ocd-division/country:us/state:ca",
+            "levels": ["administrativeArea1"],
+            "roles": ["headOfGovernment"],
+            "officialIndices": [5],
+        },
+        {
+            "name": "Lieutenant Governor of California",
+            "divisionId": "ocd-division/country:us/state:ca",
+            "levels": ["administrativeArea1"],
+            "roles": ["deputyHeadOfGovernment"],
+            "officialIndices": [6],
+        },
+        {
+            "name": "CA State Superintendent of Public Instruction",
+            "divisionId": "ocd-division/country:us/state:ca",
+            "levels": ["administrativeArea1"],
+            "roles": ["governmentOfficer"],
+            "officialIndices": [7],
+        },
+        {
+            "name": "CA Secretary of State",
+            "divisionId": "ocd-division/country:us/state:ca",
+            "levels": ["administrativeArea1"],
+            "roles": ["governmentOfficer"],
+            "officialIndices": [8],
+        },
+        {
+            "name": "CA State Insurance Commissioner",
+            "divisionId": "ocd-division/country:us/state:ca",
+            "levels": ["administrativeArea1"],
+            "roles": ["governmentOfficer"],
+            "officialIndices": [9],
+        },
+        {
+            "name": "CA State Treasurer",
+            "divisionId": "ocd-division/country:us/state:ca",
+            "levels": ["administrativeArea1"],
+            "roles": ["governmentOfficer"],
+            "officialIndices": [10],
+        },
+        {
+            "name": "CA State Attorney General",
+            "divisionId": "ocd-division/country:us/state:ca",
+            "levels": ["administrativeArea1"],
+            "roles": ["governmentOfficer"],
+            "officialIndices": [11],
+        },
+        {
+            "name": "CA State Controller",
+            "divisionId": "ocd-division/country:us/state:ca",
+            "levels": ["administrativeArea1"],
+            "roles": ["governmentOfficer"],
+            "officialIndices": [12],
+        },
+        {
+            "name": "CA State Assembly Member",
+            "divisionId": "ocd-division/country:us/state:ca/sldl:23",
+            "levels": ["administrativeArea1"],
+            "roles": ["legislatorLowerBody"],
+            "officialIndices": [13],
+        },
+        {
+            "name": "CA State Supreme Court Justice",
+            "divisionId": "ocd-division/country:us/state:ca",
+            "levels": ["administrativeArea1"],
+            "roles": ["judge"],
+            "officialIndices": [14, 15, 16, 17, 18, 19, 20],
+        },
+        {
+            "name": "Santa Clara County District Attorney",
+            "divisionId": "ocd-division/country:us/state:ca/county:santa_clara",
+            "levels": ["administrativeArea2"],
+            "roles": ["governmentOfficer"],
+            "officialIndices": [21],
+        },
+        {
+            "name": "Santa Clara County Assessor",
+            "divisionId": "ocd-division/country:us/state:ca/county:santa_clara",
+            "levels": ["administrativeArea2"],
+            "roles": ["governmentOfficer"],
+            "officialIndices": [22],
+        },
+        {
+            "name": "Santa Clara County Sheriff",
+            "divisionId": "ocd-division/country:us/state:ca/county:santa_clara",
+            "levels": ["administrativeArea2"],
+            "roles": ["governmentOfficer"],
+            "officialIndices": [23],
+        },
+    ],
+    "officials": [
+        {
+            "name": "Joseph R. Biden",
+            "address": [
+                {
+                    "line1": "1600 Pennsylvania Avenue Northwest",
+                    "city": "Washington",
+                    "state": "DC",
+                    "zip": "20500",
+                }
+            ],
+            "party": "Democratic Party",
+            "phones": ["(202) 456-1111"],
+            "urls": [
+                "https://www.whitehouse.gov/",
+                "https://en.wikipedia.org/wiki/Joe_Biden",
+            ],
+            "channels": [{"type": "Twitter", "id": "potus"}],
+        },
+        {
+            "name": "Kamala D. Harris",
+            "address": [
+                {
+                    "line1": "1600 Pennsylvania Avenue Northwest",
+                    "city": "Washington",
+                    "state": "DC",
+                    "zip": "20500",
+                }
+            ],
+            "party": "Democratic Party",
+            "phones": ["(202) 456-1111"],
+            "urls": [
+                "https://www.whitehouse.gov/",
+                "https://en.wikipedia.org/wiki/Kamala_Harris",
+            ],
+            "channels": [{"type": "Twitter", "id": "VP"}],
+        },
+        {
+            "name": "Alex Padilla",
+            "address": [
+                {"line1": "B03", "city": "Washington", "state": "DC", "zip": "20510"}
+            ],
+            "party": "Democratic Party",
+            "phones": ["(202) 224-3553"],
+            "urls": [
+                "https://www.padilla.senate.gov/",
+                "https://en.wikipedia.org/wiki/Alex_Padilla",
+            ],
+            "channels": [
+                {"type": "Facebook", "id": "SenAlexPadilla"},
+                {"type": "Twitter", "id": "SenAlexPadilla"},
+            ],
+        },
+        {
+            "name": "LaPhonza R. Butler",
+            "party": "Democratic Party",
+            "phones": ["(202) 224-3841"],
+            "urls": ["https://www.butler.senate.gov/"],
+        },
+        {
+            "name": "Anna G. Eshoo",
+            "address": [
+                {
+                    "line1": "272 Cannon House Office Building",
+                    "city": "Washington",
+                    "state": "DC",
+                    "zip": "20515",
+                }
+            ],
+            "party": "Democratic Party",
+            "phones": ["(202) 225-8104"],
+            "urls": [
+                "https://eshoo.house.gov/",
+                "https://en.wikipedia.org/wiki/Anna_Eshoo",
+            ],
+            "channels": [
+                {"type": "Facebook", "id": "RepAnnaEshoo"},
+                {"type": "Twitter", "id": "RepAnnaEshoo"},
+            ],
+        },
+        {
+            "name": "Gavin Newsom",
+            "address": [
+                {
+                    "line1": "1303 10th Street",
+                    "city": "Sacramento",
+                    "state": "CA",
+                    "zip": "95814",
+                }
+            ],
+            "party": "Democratic Party",
+            "phones": ["(916) 445-2841"],
+            "urls": [
+                "https://www.gov.ca.gov/",
+                "https://en.wikipedia.org/wiki/Gavin_Newsom",
+            ],
+            "photoUrl": "http://www.ltg.ca.gov/images/newsimages/i2.png",
+            "channels": [
+                {"type": "Facebook", "id": "CAgovernor"},
+                {"type": "Twitter", "id": "CAgovernor"},
+            ],
+        },
+        {
+            "name": "Eleni Kounalakis",
+            "address": [
+                {
+                    "line1": "1315 10th Street",
+                    "city": "Sacramento",
+                    "state": "CA",
+                    "zip": "95814",
+                }
+            ],
+            "party": "Democratic Party",
+            "phones": ["(916) 445-8994"],
+            "urls": [
+                "https://ltg.ca.gov/",
+                "https://en.wikipedia.org/wiki/Eleni_Kounalakis",
+            ],
+            "channels": [
+                {"type": "Facebook", "id": "EleniKounalakis"},
+                {"type": "Twitter", "id": "CALtGovernor"},
+            ],
+        },
+        {
+            "name": "Tony Thurmond",
+            "address": [
+                {
+                    "line1": "1430 N Street",
+                    "city": "Sacramento",
+                    "state": "CA",
+                    "zip": "95814",
+                }
+            ],
+            "party": "Nonpartisan",
+            "phones": ["(916) 319-0800"],
+            "urls": [
+                "https://www.cde.ca.gov/eo/",
+                "https://en.wikipedia.org/wiki/Tony_Thurmond",
+            ],
+            "channels": [
+                {"type": "Facebook", "id": "CAEducation"},
+                {"type": "Twitter", "id": "CADeptEd"},
+            ],
+        },
+        {
+            "name": "Shirley N. Weber",
+            "address": [
+                {
+                    "line1": "1500 11th Street",
+                    "city": "Sacramento",
+                    "state": "CA",
+                    "zip": "95814",
+                }
+            ],
+            "party": "Democratic Party",
+            "phones": ["(916) 653-6814"],
+            "urls": [
+                "https://www.sos.ca.gov/",
+                "https://en.wikipedia.org/wiki/Shirley_Weber",
+            ],
+            "channels": [
+                {"type": "Facebook", "id": "CaliforniaSOS"},
+                {"type": "Twitter", "id": "CASOSvote"},
+            ],
+        },
+        {
+            "name": "Ricardo Lara",
+            "address": [
+                {
+                    "line1": "300 Capitol Mall",
+                    "city": "Sacramento",
+                    "state": "CA",
+                    "zip": "95814",
+                }
+            ],
+            "party": "Democratic Party",
+            "phones": ["(800) 927-4357"],
+            "urls": [
+                "http://www.insurance.ca.gov/",
+                "https://en.wikipedia.org/wiki/Ricardo_Lara",
+            ],
+            "channels": [
+                {"type": "Facebook", "id": "ICRicardoLara"},
+                {"type": "Twitter", "id": "ICRicardoLara"},
+            ],
+        },
+        {
+            "name": "Fiona Ma",
+            "address": [
+                {
+                    "line1": "915 Capitol Mall",
+                    "city": "Sacramento",
+                    "state": "CA",
+                    "zip": "95814",
+                }
+            ],
+            "party": "Democratic Party",
+            "phones": ["(916) 653-2995"],
+            "urls": [
+                "https://www.treasurer.ca.gov/",
+                "https://en.wikipedia.org/wiki/Fiona_Ma",
+            ],
+            "channels": [
+                {"type": "Facebook", "id": "CaliforniaSTO"},
+                {"type": "Twitter", "id": "CalTreasurer"},
+            ],
+        },
+        {
+            "name": "Rob Bonta",
+            "party": "Democratic Party",
+            "phones": ["(916) 445-9555"],
+            "urls": ["https://oag.ca.gov/", "https://en.wikipedia.org/wiki/Rob_Bonta"],
+            "channels": [
+                {"type": "Facebook", "id": "AGRobBonta"},
+                {"type": "Twitter", "id": "AGRobBonta"},
+            ],
+        },
+        {
+            "name": "Malia M. Cohen",
+            "address": [
+                {
+                    "line1": "300 Capitol Mall",
+                    "city": "Sacramento",
+                    "state": "CA",
+                    "zip": "95814",
+                }
+            ],
+            "party": "Democratic Party",
+            "phones": ["(916) 445-2636"],
+            "urls": [
+                "https://www.sco.ca.gov/index.html",
+                "https://en.wikipedia.org/wiki/Malia_Cohen",
+            ],
+            "channels": [
+                {"type": "Facebook", "id": "CAController"},
+                {"type": "Twitter", "id": "CAController"},
+            ],
+        },
+        {
+            "name": "Marc Berman",
+            "party": "Democratic Party",
+            "phones": ["(916) 319-2023"],
+            "urls": [
+                "https://a23.asmdc.org/",
+                "https://en.wikipedia.org/wiki/Marc_Berman",
+            ],
+            "channels": [
+                {"type": "Facebook", "id": "AsmMarcBerman"},
+                {"type": "Twitter", "id": "AsmMarcBerman"},
+            ],
+        },
+        {
+            "name": "Carol A. Corrigan",
+            "address": [
+                {
+                    "line1": "350 McAllister Street",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "zip": "94102",
+                }
+            ],
+            "party": "Nonpartisan",
+            "phones": ["(415) 865-7000"],
+            "urls": [
+                "https://www.courts.ca.gov/supremecourt.htm",
+                "https://en.wikipedia.org/wiki/Carol_Corrigan",
+            ],
+            "channels": [{"type": "Twitter", "id": "CaSupremeCourt"}],
+        },
+        {
+            "name": "Goodwin H. Liu",
+            "address": [
+                {
+                    "line1": "350 McAllister Street",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "zip": "94102",
+                }
+            ],
+            "party": "Nonpartisan",
+            "phones": ["(415) 865-7000"],
+            "urls": [
+                "https://www.courts.ca.gov/supremecourt.htm",
+                "https://en.wikipedia.org/wiki/Goodwin_Liu",
+            ],
+            "channels": [{"type": "Twitter", "id": "CaSupremeCourt"}],
+        },
+        {
+            "name": "Joshua P. Groban",
+            "address": [
+                {
+                    "line1": "350 McAllister Street",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "zip": "94102",
+                }
+            ],
+            "party": "Nonpartisan",
+            "phones": ["(415) 865-7000"],
+            "urls": [
+                "https://www.courts.ca.gov/supremecourt.htm",
+                "https://en.wikipedia.org/wiki/Joshua_Groban",
+            ],
+            "channels": [{"type": "Twitter", "id": "CaSupremeCourt"}],
+        },
+        {
+            "name": "Kelli Evans",
+            "address": [
+                {
+                    "line1": "350 McAllister Street",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "zip": "94102",
+                }
+            ],
+            "party": "Nonpartisan",
+            "phones": ["(415) 865-7000"],
+            "urls": [
+                "https://www.courts.ca.gov/supremecourt.htm",
+                "https://en.wikipedia.org/wiki/Kelli_Evans",
+            ],
+            "channels": [{"type": "Twitter", "id": "CaSupremeCourt"}],
+        },
+        {
+            "name": "Leondra R. Kruger",
+            "address": [
+                {
+                    "line1": "350 McAllister Street",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "zip": "94102",
+                }
+            ],
+            "party": "Nonpartisan",
+            "phones": ["(415) 865-7000"],
+            "urls": [
+                "https://www.courts.ca.gov/supremecourt.htm",
+                "https://en.wikipedia.org/wiki/Leondra_Kruger",
+            ],
+            "channels": [{"type": "Twitter", "id": "CaSupremeCourt"}],
+        },
+        {
+            "name": "Martin J. Jenkins",
+            "address": [
+                {
+                    "line1": "350 McAllister Street",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "zip": "94102",
+                }
+            ],
+            "party": "Nonpartisan",
+            "phones": ["(415) 865-7000"],
+            "urls": [
+                "https://www.courts.ca.gov/supremecourt.htm",
+                "https://en.wikipedia.org/wiki/Martin_Jenkins",
+            ],
+            "channels": [{"type": "Twitter", "id": "CaSupremeCourt"}],
+        },
+        {
+            "name": "Patricia Guerrero",
+            "address": [
+                {
+                    "line1": "350 McAllister Street",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "zip": "94102",
+                }
+            ],
+            "party": "Nonpartisan",
+            "phones": ["(415) 865-7000"],
+            "urls": [
+                "https://www.courts.ca.gov/supremecourt.htm",
+                "https://en.wikipedia.org/wiki/Patricia_Guerrero_%28judge%29",
+            ],
+            "channels": [{"type": "Twitter", "id": "CaSupremeCourt"}],
+        },
+        {
+            "name": "Jeffrey F. Rosen",
+            "address": [
+                {
+                    "line1": "70 West Hedding Street",
+                    "city": "San Jose",
+                    "state": "CA",
+                    "zip": "95110",
+                }
+            ],
+            "party": "Nonpartisan",
+            "phones": ["(408) 299-7500"],
+            "urls": ["https://countyda.sccgov.org/home"],
+            "emails": ["jrosen@dao.sccgov.org"],
+            "channels": [
+                {"type": "Facebook", "id": "SantaClaraDA"},
+                {"type": "Twitter", "id": "SantaClaraDA"},
+            ],
+        },
+        {
+            "name": "Lawrence E. Stone",
+            "address": [
+                {
+                    "line1": "70 West Hedding Street",
+                    "city": "San Jose",
+                    "state": "CA",
+                    "zip": "95110",
+                }
+            ],
+            "party": "Nonpartisan",
+            "phones": ["(408) 299-5500"],
+            "urls": ["https://www.sccassessor.org/"],
+            "emails": ["assessor@asr.sccgov.org"],
+        },
+        {
+            "name": "Robert Jonsen",
+            "address": [
+                {
+                    "line1": "55 West Younger Avenue",
+                    "city": "San Jose",
+                    "state": "CA",
+                    "zip": "95110",
+                }
+            ],
+            "party": "Nonpartisan",
+            "phones": ["(408) 808-4400"],
+            "urls": ["https://countysheriff.sccgov.org/home"],
+            "emails": ["so.website@shf.sccgov.org"],
+            "channels": [
+                {"type": "Facebook", "id": "santaclarasheriff"},
+                {"type": "Twitter", "id": "SCCoSheriff"},
+            ],
+        },
+    ],
+}

--- a/test/test_google/test_googlecivic.py
+++ b/test/test_google/test_googlecivic.py
@@ -1,7 +1,12 @@
 import unittest
 import requests_mock
 from parsons import Table, GoogleCivic
-from googlecivic_responses import elections_resp, voterinfo_resp, polling_data
+from googlecivic_responses import (
+    elections_resp,
+    voterinfo_resp,
+    polling_data,
+    representatives_resp,
+)
 from test.utils import assert_matching_tables
 
 
@@ -48,3 +53,33 @@ class TestGoogleCivic(unittest.TestCase):
         tbl = self.gc.get_polling_locations(2000, address_tbl)
 
         assert_matching_tables(tbl, expected_tbl)
+
+    @requests_mock.Mocker()
+    def test_get_representative_info_by_address(self, m):
+        m.get(self.gc.uri + "representatives", json=representatives_resp)
+
+        address = "1600 Amphitheatre Parkway, Mountain View, CA"  # replace with a valid address
+        response = self.gc.get_representative_info_by_address(address)
+
+        self.assertIsInstance(response, dict)
+        self.assertIn("offices", response)
+        self.assertIn("officials", response)
+        self.assertIn("divisions", response)
+
+    @requests_mock.Mocker()
+    def test_get_representative_info_by_address_invalid_input(self, m):
+
+        m.get(self.gc.uri + "representatives", json=representatives_resp)
+
+        with self.assertRaises(ValueError):
+            self.gc.get_representative_info_by_address(123)  # Invalid address
+
+        with self.assertRaises(ValueError):
+            self.gc.get_representative_info_by_address(
+                "1600 Amphitheatre Parkway, Mountain View, CA", levels="country"
+            )  # levels should be a list
+
+        with self.assertRaises(ValueError):
+            self.gc.get_representative_info_by_address(
+                "1600 Amphitheatre Parkway, Mountain View, CA", roles="headOfGovernment"
+            )  # roles should be a list

--- a/test/test_google/test_googlecivic.py
+++ b/test/test_google/test_googlecivic.py
@@ -83,3 +83,20 @@ class TestGoogleCivic(unittest.TestCase):
             self.gc.get_representative_info_by_address(
                 "1600 Amphitheatre Parkway, Mountain View, CA", roles="headOfGovernment"
             )  # roles should be a list
+
+    @requests_mock.Mocker()
+    def test_get_representative_info_by_address_different_params(self, m):
+        m.get(self.gc.uri + "representatives", json=representatives_resp)
+
+        address = "1600 Amphitheatre Parkway, Mountain View, CA"
+        response = self.gc.get_representative_info_by_address(
+            address,
+            include_offices=False,
+            levels=["country"],
+            roles=["headOfGovernment"],
+        )
+
+        self.assertIsInstance(response, dict)
+        self.assertIn("offices", response)
+        self.assertIn("officials", response)
+        self.assertIn("divisions", response)


### PR DESCRIPTION
This PR introduces the get_representative_info_by_address method to our Google Civic API wrapper. This method allows users to retrieve representative information for a given US address. The method returns the raw response from the Google Civic API, which includes information about offices, officials, and divisions.

The method accepts the following parameters:

address: A valid US address in a single string.
include_offices: Whether to return information about offices and officials. Defaults to True.
levels: A list of office levels to filter by.
roles: A list of office roles to filter by.
The method performs validation checks on the input parameters and raises a ValueError if the input is not valid. It also checks the API response for errors and raises a ValueError if the address was invalid.

In addition to the new method, this PR also includes:

Comprehensive unit tests for get_representative_info_by_address, covering different parameters, error handling, and different mock responses.

Updates to the documentation to include example usage of get_representative_info_by_address.

This new functionality enhances our Google Civic API wrapper by providing users with a convenient way to retrieve detailed representative information for a given address.