### PR TITLE
Add utility method to format phone numbers

### DIFF
--- a/parsons/utilities/format_phone_number.py
+++ b/parsons/utilities/format_phone_number.py
@@ -3,15 +3,19 @@ import re
 
 def format_phone_number(phone_number, country_code="1"):
     """
-    Formats a phone number in E.164 format.
+    Formats a phone number in E.164 format, which is the international standard for phone numbers.
+    Example: Converts "555-555-5555" -> "+15555555555"
 
-    Args:
-        phone_number (str): The phone number to be formatted.
-        country_code (str): The country code to be used as a prefix.
+    `Args:`
+        phone_number (str):
+            The phone number to be formatted.
+        country_code (str):
+            The country code to be used as a prefix.
         Defaults to "1" (United States).
 
-    Returns:
-        str: The formatted phone number in E.164 format.
+    `Returns:`
+        str:
+            The formatted phone number in E.164 format.
     """
     # Remove non-numeric characters and leading zeros
     digits = re.sub(r"[^\d]", "", phone_number.lstrip("0"))
@@ -26,8 +30,5 @@ def format_phone_number(phone_number, country_code="1"):
 
     # Format the phone number in E.164 format
     formatted_number = "+" + digits
-
-    # Check if the formatted number is valid
-    # Implement validation logic here
 
     return formatted_number

--- a/parsons/utilities/format_phone_number.py
+++ b/parsons/utilities/format_phone_number.py
@@ -18,7 +18,7 @@ def format_phone_number(phone_number, country_code="1"):
 
     # Check if the phone number is valid
     if len(digits) < 10:
-        raise ValueError("Invalid phone number.")
+        return None
 
     # Handle country code prefix
     if not digits.startswith(country_code):

--- a/parsons/utilities/format_phone_number.py
+++ b/parsons/utilities/format_phone_number.py
@@ -1,0 +1,33 @@
+import re
+
+
+def format_phone_number(phone_number, country_code="1"):
+    """
+    Formats a phone number in E.164 format.
+
+    Args:
+        phone_number (str): The phone number to be formatted.
+        country_code (str): The country code to be used as a prefix.
+        Defaults to "1" (United States).
+
+    Returns:
+        str: The formatted phone number in E.164 format.
+    """
+    # Remove non-numeric characters and leading zeros
+    digits = re.sub(r"[^\d]", "", phone_number.lstrip("0"))
+
+    # Check if the phone number is valid
+    if len(digits) < 10:
+        raise ValueError("Invalid phone number.")
+
+    # Handle country code prefix
+    if not digits.startswith(country_code):
+        digits = country_code + digits
+
+    # Format the phone number in E.164 format
+    formatted_number = "+" + digits
+
+    # Check if the formatted number is valid
+    # Implement validation logic here
+
+    return formatted_number

--- a/test/test_utilities/test_format_phone_number.py
+++ b/test/test_utilities/test_format_phone_number.py
@@ -1,0 +1,35 @@
+import unittest
+from parsons.utilities.format_phone_number import format_phone_number
+
+
+class TestFormatPhoneNumber(unittest.TestCase):
+    def test_format_phone_number_local_us_number(self):
+        phone_number = "555-123-4567"
+        expected_result = "+15551234567"
+        self.assertEqual(
+            format_phone_number(
+                phone_number,
+            ),
+            expected_result,
+        )
+
+    def test_format_phone_number_us_number_with_leading_1(self):
+        phone_number = "15551234567"
+        expected_result = "+15551234567"
+        self.assertEqual(format_phone_number(phone_number), expected_result)
+
+    def test_format_phone_number_international_number(self):
+        phone_number = "+441234567890"
+        expected_result = "+441234567890"
+        self.assertEqual(
+            format_phone_number(phone_number, country_code="44"), expected_result
+        )
+
+    def test_format_phone_number_invalid_length(self):
+        phone_number = "12345"
+        with self.assertRaises(ValueError):
+            format_phone_number(phone_number)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_utilities/test_format_phone_number.py
+++ b/test/test_utilities/test_format_phone_number.py
@@ -27,8 +27,7 @@ class TestFormatPhoneNumber(unittest.TestCase):
 
     def test_format_phone_number_invalid_length(self):
         phone_number = "12345"
-        with self.assertRaises(ValueError):
-            format_phone_number(phone_number)
+        self.assertIsNone(format_phone_number(phone_number))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request adds a new utility method, `format_phone_number`, which formats a phone number in E.164 format. The method takes a phone number as input and an optional country code, and returns the formatted phone number. It removes non-numeric characters and leading zeros, adds the country code prefix if necessary, and formats the number in E.164 format. The pull request also includes unit tests for the `format_phone_number` method to ensure its correctness and handle different scenarios.