### PR TITLE
Re-apply revert that got lost in major-release branch

### DIFF
--- a/parsons/action_network/action_network.py
+++ b/parsons/action_network/action_network.py
@@ -764,7 +764,6 @@ class ActionNetwork(object):
         mobile_number=None,
         mobile_status="subscribed",
         background_processing=False,
-        identifiers=None,
         **kwargs,
     ):
         """
@@ -823,16 +822,6 @@ class ActionNetwork(object):
                 an immediate success, with an empty JSON body, and send your request to the
                 background queue for eventual processing.
                 https://actionnetwork.org/docs/v2/#background-processing
-            identifiers:
-                List of strings to be used as globally unique
-                identifiers. Can be useful for matching contacts back
-                to other platforms and systems. If the identifier
-                provided is not globally unique in ActionNetwork, it will
-                simply be ignored and not added to the object. Action Network
-                also creates its own identifier for each new resouce.
-                https://actionnetwork.org/docs/v2/#resources
-                e.g.: ["foreign_system:1", "other_system:12345abcd"]
-
             **kwargs:
                 Any additional fields to store about the person. Action Network allows
                 any custom field.
@@ -897,8 +886,7 @@ class ActionNetwork(object):
             data["person"]["postal_addresses"] = postal_addresses
         if tags is not None:
             data["add_tags"] = tags
-        if identifiers:
-            data["person"]["identifiers"] = identifiers
+
         data["person"]["custom_fields"] = {**kwargs}
         url = f"{self.api_url}/people"
         if background_processing:


### PR DESCRIPTION
For some reason #876 got lost in the major-release branch. Somehow the reverted commit got included in #873 and the reversion wasn't included when the main branch was merged into major-release with ee4ec8b9872288cce20a2ac2c58bc1379fe39672. This PR duplicates #876 to once again revert 77ead6079ee03c399bbc83314351bc719ed457c3