### PR TITLE
Fix import of google.storage.storage_transfer

### DIFF
--- a/parsons/google/google_cloud_storage.py
+++ b/parsons/google/google_cloud_storage.py
@@ -1,6 +1,5 @@
 import google
 from google.cloud import storage
-from google.cloud import storage_transfer
 from parsons.google.utitities import setup_google_application_credentials
 from parsons.utilities import files
 import datetime
@@ -380,6 +379,8 @@ class GoogleCloudStorage(object):
             )
         if source_path and source_path[-1] != "/":
             raise ValueError("Source path much end in a '/'")
+
+        from google.cloud import storage_transfer
 
         client = storage_transfer.StorageTransferServiceClient()
 


### PR DESCRIPTION
This import can only work after a storage client has already been initialized.

See https://stackoverflow.com/questions/50840511/google-cloud-import-storage-cannot-import-storage