### PR TITLE
Enable parameterization of bigquery queries

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -176,38 +176,6 @@ class GoogleBigQuery(DatabaseConnector):
 
         return self._client
 
-    @contextmanager
-    def connection(self):
-        """
-        Generate a BigQuery connection.
-        The connection is set up as a python "context manager", so it will be closed
-        automatically when the connection goes out of scope. Note that the BigQuery
-        API uses jobs to run database operations and, as such, simply has a no-op for
-        a "commit" function. If you would like to manage transactions, please use
-        multi-statement queries as [outlined here](https://cloud.google.com/bigquery/docs/transactions)
-        or utilize the `query_with_transaction` method on this class.
-
-        When using the connection, make sure to put it in a ``with`` block (necessary for
-        any context manager):
-        ``with bq.connection() as conn:``
-
-        `Returns:`
-            Google BigQuery ``connection`` object
-        """
-        conn = self._dbapi.connect(self.client)
-        try:
-            yield conn
-        finally:
-            conn.close()
-
-    @contextmanager
-    def cursor(self, connection):
-        cur = connection.cursor()
-        try:
-            yield cur
-        finally:
-            cur.close()
-
     def query(
         self,
         sql: str,

--- a/parsons/google/google_cloud_storage.py
+++ b/parsons/google/google_cloud_storage.py
@@ -1,6 +1,5 @@
 import google
 from google.cloud import storage
-from google.cloud import storage_transfer
 from parsons.google.utitities import setup_google_application_credentials
 from parsons.utilities import files
 import datetime
@@ -380,6 +379,8 @@ class GoogleCloudStorage(object):
             )
         if source_path and source_path[-1] != "/":
             raise ValueError("Source path much end in a '/'")
+
+        from google.cloud import storage_transfer
 
         client = storage_transfer.StorageTransferServiceClient()
 

--- a/test/test_google/test_google_bigquery.py
+++ b/test/test_google/test_google_bigquery.py
@@ -1,0 +1,261 @@
+import json
+import os
+import unittest.mock as mock
+
+from google.cloud import bigquery
+from google.cloud import exceptions
+
+from parsons import GoogleBigQuery, Table
+from parsons.google.google_cloud_storage import GoogleCloudStorage
+from test.test_google.test_utilities import FakeCredentialTest
+
+
+class FakeClient:
+    """A Fake Storage Client used for monkey-patching."""
+
+    def __init__(self, project=None):
+        self.project = project
+
+
+class FakeGoogleCloudStorage(GoogleCloudStorage):
+    """A Fake GoogleCloudStorage object used to test setting up credentials."""
+
+    @mock.patch("google.cloud.storage.Client", FakeClient)
+    def __init__(self):
+        super().__init__(None, None)
+
+    def upload_table(
+        self, table, bucket_name, blob_name, data_type="csv", default_acl=None
+    ):
+        pass
+
+    def delete_blob(self, bucket_name, blob_name):
+        pass
+
+
+class TestGoogleBigQuery(FakeCredentialTest):
+    def setUp(self):
+        super().setUp()
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = self.cred_path
+        self.tmp_gcs_bucket = "tmp"
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        del os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+
+    def test_query(self):
+        query_string = "select * from table"
+
+        # Pass the mock class into our GoogleBigQuery constructor
+        bq = self._build_mock_client_for_querying([{"one": 1, "two": 2}])
+
+        # Run a query against our parsons GoogleBigQuery class
+        result = bq.query(query_string)
+
+        # Check our return value
+        self.assertEqual(result.num_rows, 1)
+        self.assertEqual(result.columns, ["one", "two"])
+        self.assertEqual(result[0], {"one": 1, "two": 2})
+
+    def test_query__no_results(self):
+        query_string = "select * from table"
+
+        # Pass the mock class into our GoogleBigQuery constructor
+        bq = self._build_mock_client_for_querying([])
+
+        # Run a query against our parsons GoogleBigQuery class
+        result = bq.query(query_string)
+
+        # Check our return value
+        self.assertEqual(result, None)
+
+    def test_copy(self):
+        # setup dependencies / inputs
+        tmp_blob_uri = "gs://tmp/file"
+
+        # set up object under test
+        gcs_client = self._build_mock_cloud_storage_client(tmp_blob_uri)
+        tbl = self.default_table
+        bq = self._build_mock_client_for_copying(table_exists=False)
+
+        # call the method being tested
+        bq.copy(
+            tbl,
+            "dataset.table",
+            tmp_gcs_bucket=self.tmp_gcs_bucket,
+            gcs_client=gcs_client,
+        )
+
+        # check that the method did the right things
+        self.assertEqual(gcs_client.upload_table.call_count, 1)
+        upload_call_args = gcs_client.upload_table.call_args
+        self.assertEqual(upload_call_args[0][0], tbl)
+        self.assertEqual(upload_call_args[0][1], self.tmp_gcs_bucket)
+        tmp_blob_name = upload_call_args[0][2]
+
+        self.assertEqual(bq.client.load_table_from_uri.call_count, 1)
+        load_call_args = bq.client.load_table_from_uri.call_args
+        self.assertEqual(load_call_args[0][0], tmp_blob_uri)
+
+        job_config = load_call_args[1]["job_config"]
+        self.assertEqual(
+            job_config.write_disposition, bigquery.WriteDisposition.WRITE_EMPTY
+        )
+
+        # make sure we cleaned up the temp file
+        self.assertEqual(gcs_client.delete_blob.call_count, 1)
+        delete_call_args = gcs_client.delete_blob.call_args
+        self.assertEqual(delete_call_args[0][0], self.tmp_gcs_bucket)
+        self.assertEqual(delete_call_args[0][1], tmp_blob_name)
+
+    def test_copy__if_exists_truncate(self):
+        gcs_client = self._build_mock_cloud_storage_client()
+        # set up object under test
+        bq = self._build_mock_client_for_copying()
+
+        # call the method being tested
+        bq.copy(
+            self.default_table,
+            "dataset.table",
+            tmp_gcs_bucket=self.tmp_gcs_bucket,
+            if_exists="truncate",
+            gcs_client=gcs_client,
+        )
+
+        # check that the method did the right things
+        call_args = bq.client.load_table_from_uri.call_args
+        job_config = call_args[1]["job_config"]
+        self.assertEqual(
+            job_config.write_disposition, bigquery.WriteDisposition.WRITE_TRUNCATE
+        )
+
+        # make sure we cleaned up the temp file
+        self.assertEqual(gcs_client.delete_blob.call_count, 1)
+
+    def test_copy__if_exists_append(self):
+        gcs_client = self._build_mock_cloud_storage_client()
+        # set up object under test
+        bq = self._build_mock_client_for_copying()
+
+        # call the method being tested
+        bq.copy(
+            self.default_table,
+            "dataset.table",
+            tmp_gcs_bucket=self.tmp_gcs_bucket,
+            if_exists="append",
+            gcs_client=gcs_client,
+        )
+
+        # check that the method did the right things
+        call_args = bq.client.load_table_from_uri.call_args
+        job_config = call_args[1]["job_config"]
+        self.assertEqual(
+            job_config.write_disposition, bigquery.WriteDisposition.WRITE_APPEND
+        )
+
+        # make sure we cleaned up the temp file
+        self.assertEqual(gcs_client.delete_blob.call_count, 1)
+
+    def test_copy__if_exists_fail(self):
+        # set up object under test
+        bq = self._build_mock_client_for_copying()
+
+        # call the method being tested
+        with self.assertRaises(Exception):
+            bq.copy(
+                self.default_table,
+                "dataset.table",
+                tmp_gcs_bucket=self.tmp_gcs_bucket,
+                gcs_client=self._build_mock_cloud_storage_client(),
+            )
+
+    def test_copy__if_exists_drop(self):
+        gcs_client = self._build_mock_cloud_storage_client()
+        # set up object under test
+        bq = self._build_mock_client_for_copying()
+
+        # call the method being tested
+        bq.copy(
+            self.default_table,
+            "dataset.table",
+            tmp_gcs_bucket=self.tmp_gcs_bucket,
+            if_exists="drop",
+            gcs_client=gcs_client,
+        )
+
+        # check that we tried to delete the table
+        self.assertEqual(bq.client.delete_table.call_count, 1)
+
+        # make sure we cleaned up the temp file
+        self.assertEqual(gcs_client.delete_blob.call_count, 1)
+
+    def test_copy__bad_if_exists(self):
+        gcs_client = self._build_mock_cloud_storage_client()
+
+        # set up object under test
+        bq = self._build_mock_client_for_copying()
+
+        # call the method being tested
+        with self.assertRaises(ValueError):
+            bq.copy(
+                self.default_table,
+                "dataset.table",
+                tmp_gcs_bucket=self.tmp_gcs_bucket,
+                if_exists="foo",
+                gcs_client=gcs_client,
+            )
+
+    def test_copy__credentials_are_correctly_set(self):
+        tbl = self.default_table
+        bq = self._build_mock_client_for_copying(table_exists=False)
+
+        # Pass in our fake GCS Client.
+        bq.copy(
+            tbl,
+            "dataset.table",
+            tmp_gcs_bucket=self.tmp_gcs_bucket,
+            gcs_client=FakeGoogleCloudStorage(),
+        )
+
+        actual = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+
+        with open(actual, "r") as factual:
+            with open(self.cred_path, "r") as fexpected:
+                actual_str = factual.read()
+                self.assertEqual(actual_str, fexpected.read())
+                self.assertEqual(self.cred_contents, json.loads(actual_str))
+
+    def _build_mock_client_for_querying(self, results):
+        # Create a mock that will play the role of the query response
+        query_response = mock.MagicMock()
+        query_response.result.return_value = results
+
+        # Create a mock that will play the role of our GoogleBigQuery client
+        client = mock.MagicMock()
+        client.query.return_value = query_response
+
+        bq = GoogleBigQuery()
+        bq._client = client
+        return bq
+
+    def _build_mock_client_for_copying(self, table_exists=True):
+        bq_client = mock.MagicMock()
+        if not table_exists:
+            bq_client.get_table.side_effect = exceptions.NotFound("not found")
+        bq = GoogleBigQuery()
+        bq._client = bq_client
+        return bq
+
+    def _build_mock_cloud_storage_client(self, tmp_blob_uri=""):
+        gcs_client = mock.MagicMock()
+        gcs_client.upload_table.return_value = tmp_blob_uri
+        return gcs_client
+
+    @property
+    def default_table(self):
+        return Table(
+            [
+                {"num": 1, "ltr": "a"},
+                {"num": 2, "ltr": "b"},
+            ]
+        )


### PR DESCRIPTION
Addresses https://github.com/move-coop/parsons/issues/929

Documentation on BigQuery query parameterization was wrong, but also with the existing implementation of the query method, parameterization was not possible.

Updates are made to enable parameterization of queries using the bigquery client, and documentation is updated to reflect correct usage.

BigQuery python query parameterization requires the use of client.query() rather than a more generic database connection & cursor.

See documentation here: https://cloud.google.com/bigquery/docs/parameterized-queries

This PR replaces #931 to make these updates on top of the major-release branch version of the bigquery client, rather than main.

TODO:
- [ ] Tests on google_bigquery module will need to be fixed, but they were already broken on the major-release branch so require some work there first