### PR TITLE
Fix BigQuery type map for datetime objects

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -27,13 +27,12 @@ BIGQUERY_TYPE_MAP = {
     "float": "FLOAT",
     "int": "INTEGER",
     "bool": "BOOLEAN",
-    "datetime.datetime": "DATETIME",
-    "datetime.date": "DATE",
-    "datetime.time": "TIME",
+    "datetime": "DATETIME",
+    "date": "DATE",
+    "time": "TIME",
     "dict": "RECORD",
     "NoneType": "STRING",
     "UUID": "STRING",
-    "datetime": "DATETIME",
 }
 
 # Max number of rows that we query at a time, so we can avoid loading huge


### PR DESCRIPTION
Source types ultimately come from `petl.typeset`, which calls `type(v).__name__`. This call does not include source module, but only the type name itself. e.g. `date` and not `datetime.date`