### PR TITLE
Fix nullable column type parsing by BigQuery connector

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1088,7 +1088,18 @@ class GoogleBigQuery(DatabaseConnector):
         fields = []
         for stat in stats:
             petl_types = stat["type"]
-            best_type = "str" if "str" in petl_types else petl_types[0]
+
+            # Prefer 'str' if included
+            # Otherwise choose first type that isn't "NoneType"
+            # Otherwise choose NoneType
+            not_none_petl_types = [i for i in petl_types if i != "NoneType"]
+            if "str" in petl_types:
+                best_type = "str"
+            elif not_none_petl_types:
+                best_type = not_none_petl_types[0]
+            else:
+                best_type = "NoneType"
+
             field_type = self._bigquery_type(best_type)
             field = bigquery.schema.SchemaField(stat["name"], field_type)
             fields.append(field)

--- a/test/test_databases/test_bigquery.py
+++ b/test/test_databases/test_bigquery.py
@@ -354,6 +354,9 @@ class TestGoogleBigQuery(FakeCredentialTest):
 
         self.assertEqual(bq.copy_from_gcs.call_count, 1)
         load_call_args = bq.copy_from_gcs.call_args
+        job_config = bq.copy_from_gcs.call_args[1]["job_config"]
+        column_types = [schema_field.field_type for schema_field in job_config.schema]
+        self.assertEqual(column_types, ["INTEGER", "STRING", "BOOLEAN"])
         self.assertEqual(load_call_args[1]["gcs_blob_uri"], tmp_blob_uri)
         self.assertEqual(load_call_args[1]["table_name"], table_name)
 
@@ -533,7 +536,7 @@ class TestGoogleBigQuery(FakeCredentialTest):
     def default_table(self):
         return Table(
             [
-                {"num": 1, "ltr": "a"},
-                {"num": 2, "ltr": "b"},
+                {"num": 1, "ltr": "a", "boolcol": None},
+                {"num": 2, "ltr": "b", "boolcol": True},
             ]
         )


### PR DESCRIPTION
If a Parsons Table column has values like `[None, None, True, False]`,
the BigQuery connector will infer that the appropriate type for this
column is NoneType, which it will translate into a STRING type.

This change ensures that types returned by petl.typecheck() will
choose the first available type that isnt `NoneType` if that is
available.

Adds a test that checks if the connector is able to successfully parse a column type when nulls are included. First commit here will allow test to run and fail, second commit will make the fix and demonstrate the test succeeds.