### PR TITLE
Miscellaneous fixes to BigQuery connector

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -27,13 +27,12 @@ BIGQUERY_TYPE_MAP = {
     "float": "FLOAT",
     "int": "INTEGER",
     "bool": "BOOLEAN",
-    "datetime.datetime": "DATETIME",
-    "datetime.date": "DATE",
-    "datetime.time": "TIME",
+    "datetime": "DATETIME",
+    "date": "DATE",
+    "time": "TIME",
     "dict": "RECORD",
     "NoneType": "STRING",
     "UUID": "STRING",
-    "datetime": "DATETIME",
 }
 
 # Max number of rows that we query at a time, so we can avoid loading huge

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1109,7 +1109,18 @@ class GoogleBigQuery(DatabaseConnector):
         fields = []
         for stat in stats:
             petl_types = stat["type"]
-            best_type = "str" if "str" in petl_types else petl_types[0]
+
+            # Prefer 'str' if included
+            # Otherwise choose first type that isn't "NoneType"
+            # Otherwise choose NoneType
+            not_none_petl_types = [i for i in petl_types if i != "NoneType"]
+            if "str" in petl_types:
+                best_type = "str"
+            elif not_none_petl_types:
+                best_type = not_none_petl_types[0]
+            else:
+                best_type = "NoneType"
+
             field_type = self._bigquery_type(best_type)
             field = bigquery.schema.SchemaField(stat["name"], field_type)
             fields.append(field)

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -775,8 +775,9 @@ class GoogleBigQuery(DatabaseConnector):
         """
         tmp_gcs_bucket = check_env.check("GCS_TEMP_BUCKET", tmp_gcs_bucket)
 
-        # if not job_config:
-        job_config = bigquery.LoadJobConfig()
+        if not job_config:
+            job_config = bigquery.LoadJobConfig()
+
         if not job_config.schema:
             job_config.schema = self._generate_schema_from_parsons_table(tbl)
 

--- a/test/test_databases/test_bigquery.py
+++ b/test/test_databases/test_bigquery.py
@@ -397,6 +397,8 @@ class TestGoogleBigQuery(FakeCredentialTest):
         bq.copy_from_gcs = mock.MagicMock()
         table_name = "dataset.table"
         if_exists = "append"
+        bq.client.get_table = lambda _: mock.MagicMock()
+        bq.client.get_table.return_value = None
 
         # call the method being tested
         bq.copy(

--- a/test/test_databases/test_bigquery.py
+++ b/test/test_databases/test_bigquery.py
@@ -354,6 +354,9 @@ class TestGoogleBigQuery(FakeCredentialTest):
 
         self.assertEqual(bq.copy_from_gcs.call_count, 1)
         load_call_args = bq.copy_from_gcs.call_args
+        job_config = bq.copy_from_gcs.call_args[1]["job_config"]
+        column_types = [schema_field.field_type for schema_field in job_config.schema]
+        self.assertEqual(column_types, ["INTEGER", "STRING", "BOOLEAN"])
         self.assertEqual(load_call_args[1]["gcs_blob_uri"], tmp_blob_uri)
         self.assertEqual(load_call_args[1]["table_name"], table_name)
 
@@ -533,7 +536,7 @@ class TestGoogleBigQuery(FakeCredentialTest):
     def default_table(self):
         return Table(
             [
-                {"num": 1, "ltr": "a"},
-                {"num": 2, "ltr": "b"},
+                {"num": 1, "ltr": "a", "boolcol": None},
+                {"num": 2, "ltr": "b", "boolcol": True},
             ]
         )

--- a/test/test_databases/test_bigquery.py
+++ b/test/test_databases/test_bigquery.py
@@ -396,9 +396,7 @@ class TestGoogleBigQuery(FakeCredentialTest):
         bq = self._build_mock_client_for_copying(table_exists=False)
         bq.copy_from_gcs = mock.MagicMock()
         table_name = "dataset.table"
-        if_exists = "append"
-        bq.client.get_table = lambda _: mock.MagicMock()
-        bq.client.get_table.return_value = None
+        if_exists = "drop"
 
         # call the method being tested
         bq.copy(


### PR DESCRIPTION
The BigQuery.copy() method does not seem to work for a variety of situations, fixes are made here as I encounter these issues and resolve them.

# Fixed BigQuery type map

Source types ultimately come from `petl.typeset`, which calls
`type(v).__name__`. This call does not include source module, but only
the type name itself. e.g. `date` and not `datetime.date`

# Prefer not NoneType when inferring schema for Table load to BigQuery 

If a Parsons Table column has values like `[None, None, True, False]`,
the BigQuery connector will infer that the appropriate type for this
column is NoneType, which it will translate into a STRING type.

This change ensures that types returned by petl.typecheck() will
choose the first available type that isn't 'NoneType' if that is
available.

# Fix commented out row to use job_config passed as argument to BigQuery.copy()

It looks like this line was accidentally commented out

# Parse python datetime objects for BigQuery as datetime or timestamp

Python datetime objects may represent timestamps or datetimes in
BigQuery, depending on whether they do or do not have a timezone
attached.

Before this change, a parsons Table that included datetimes with
timestamps would fail to load to BigQuery because BigQuery
would reject datetime strings with timezone information as the
"datetime" data type.

# Only generate schema for BigQuery when table does not already exist

Always passing a schema to BigQuery is not necessary, and introduces
situations for provided schema to mismatch actual schema.

When table already exists in BigQuery, fetch the schema from BigQuery