### PR TITLE
Enable email dict to be passed to VAN.upsert_person()

### DIFF
--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -1,4 +1,5 @@
 from parsons.utilities import json_format
+from typing import Union, List, Dict
 import logging
 
 logger = logging.getLogger(__name__)
@@ -197,7 +198,7 @@ class People(object):
         first_name=None,
         last_name=None,
         date_of_birth=None,
-        email=None,
+        email: Union[str, List[Dict[str, Union[str, bool]]], None] = None,
         phone=None,
         phone_type=None,
         street_number=None,
@@ -227,8 +228,10 @@ class People(object):
                 The person's last name
             dob: str
                 ISO 8601 formatted date of birth (e.g. ``1981-02-01``)
-            email: str
-                The person's email address
+            email: Union[str, List[Dict[str, Union[str, bool]]], None]
+                The person's email address or a list of email dicts.
+                e.g. [{'email': 'abcd@gmail.com', 'isSubscribed': False}]
+                See https://docs.everyaction.com/reference/people-common-models#email
             phone: str
                 Phone number of any type (Work, Cell, Home)
             phone_type: str
@@ -298,7 +301,7 @@ class People(object):
         first_name=None,
         last_name=None,
         date_of_birth=None,
-        email=None,
+        email: Union[str, List[Dict[str, Union[str, bool]]], None] = None,
         phone=None,
         phone_type="H",
         street_number=None,
@@ -320,7 +323,14 @@ class People(object):
 
             # Will fail if empty dicts are provided, hence needed to add if exist
             if email:
-                json["emails"] = [{"email": email}]
+                if isinstance(email, str):
+                    json["emails"] = [{"email": email}]
+                elif isinstance(email, list):
+                    json["emails"] = email
+                else:
+                    raise ValueError(
+                        f"Unexpected data type for email argument: {type(email)}"
+                    )
             if phone:  # To Do: Strip out non-integers from phone
                 json["phones"] = [{"phoneNumber": phone, "phoneType": phone_type}]
             if date_of_birth:


### PR DESCRIPTION
This allows for greater configurability of email data when upserting person records in EveryAction. This change is backwards compatible, but allows, for example, setting emails to not be subscribed by default when loading into EveryAction.