### PR TITLE
Action Builder Deactivate & Reactivate Connections

### DIFF
--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -425,11 +425,11 @@ class ActionBuilder(object):
         from_identifier,
         connection_identifier=None,
         to_identifier=None,
-        campaign=None
+        campaign=None,
     ):
         """
         Deactivate an existing connection record in Action Builder between two existing entity
-        records. Only one connection record is allowed per pair of entities, so this can be done 
+        records. Only one connection record is allowed per pair of entities, so this can be done
         by supplying the ID for the connection record, or for the two connected entity records.
         `Args:`
             from_identifier: str
@@ -438,7 +438,7 @@ class ActionBuilder(object):
                 Optional. The unique identifier for an entity or connection record being updated.
                 If omitted, `to_identifier` must be provided.
             to_identifier: str
-                Optional. The second entity with a connection to `from_entity`. If omitted, 
+                Optional. The second entity with a connection to `from_entity`. If omitted,
                 `connection_identifier` must be provided.
             campaign: str
                 Optional. The 36-character "interact ID" of the campaign whose data is to be
@@ -449,27 +449,23 @@ class ActionBuilder(object):
 
         # Check that either connection or second entity identifier are provided
         if {connection_identifier, to_identifier} == {None}:
-            raise ValueError("Must provide a connection ID or an ID for the second entity")
+            raise ValueError(
+                "Must provide a connection ID or an ID for the second entity"
+            )
 
         campaign = self._campaign_check(campaign)
 
         url = f"campaigns/{campaign}/people/{from_identifier}/connections"
 
-        data = {
-            "connection": {
-                "inactive": True
-            }
-        }
+        data = {"connection": {"inactive": True}}
 
         # Prioritize connection ID to avoid potential confusion if to_identifier is also provided
         # to_identifier entity could have duplicates, connection ID is more specific
         if connection_identifier:
-
-            url += f'/{connection_identifier}'
+            url += f"/{connection_identifier}"
             return self.api.put_request(url=url, data=json.dumps(data))
 
         # If no connection ID then there must be a to_identifier not to have errored by now
         else:
-
-            data['connection']['person_id'] = to_identifier
+            data["connection"]["person_id"] = to_identifier
             return self.api.post_request(url=url, data=json.dumps(data))

--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -471,5 +471,5 @@ class ActionBuilder(object):
         # If no connection ID then there must be a to_identifier not to have errored by now
         else:
 
-            data['person_id'] = to_identifier
+            data['connection']['person_id'] = to_identifier
             return self.api.post_request(url=url, data=json.dumps(data))

--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -371,11 +371,7 @@ class ActionBuilder(object):
         )
 
     def upsert_connection(
-        self,
-        identifiers,
-        tag_data=None,
-        campaign=None,
-        reactivate=True
+        self, identifiers, tag_data=None, campaign=None, reactivate=True
     ):
         """
         Load or update a connection record in Action Builder between two existing entity records.
@@ -474,7 +470,6 @@ class ActionBuilder(object):
         # Prioritize connection ID to avoid potential confusion if to_identifier is also provided
         # to_identifier entity could have duplicates, connection ID is more specific
         if connection_identifier:
-
             url += f"/{connection_identifier}"
 
             # Despite the documentation, PUT requests don't require the outer "connection" key

--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -421,7 +421,11 @@ class ActionBuilder(object):
         return self.api.post_request(url=url, data=json.dumps(data))
 
     def deactivate_connection(
-        self, from_identifier, connection_identifier=None, to_identifier=None
+        self,
+        from_identifier,
+        connection_identifier=None,
+        to_identifier=None,
+        campaign=None
     ):
         """
         Deactivate an existing connection record in Action Builder between two existing entity
@@ -436,6 +440,9 @@ class ActionBuilder(object):
             to_identifier: str
                 Optional. The second entity with a connection to `from_entity`. If omitted, 
                 `connection_identifier` must be provided.
+            campaign: str
+                Optional. The 36-character "interact ID" of the campaign whose data is to be
+                retrieved or edited. Not necessary if supplied when instantiating the class.
         `Returns:`
             Dict containing Action Builder connection data.
         """

--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -370,7 +370,13 @@ class ActionBuilder(object):
             f"campaigns/{campaign}/{endpoint.format(tag_id)}/{tagging_id}"
         )
 
-    def upsert_connection(self, identifiers, tag_data=None, campaign=None):
+    def upsert_connection(
+        self,
+        identifiers,
+        tag_data=None,
+        campaign=None,
+        reactivate=True
+    ):
         """
         Load or update a connection record in Action Builder between two existing entity records.
         Only one connection record is allowed per pair of entities, so if the connection already
@@ -387,6 +393,9 @@ class ActionBuilder(object):
             campaign: str
                 Optional. The 36-character "interact ID" of the campaign whose data is to be
                 retrieved or edited. Not necessary if supplied when instantiating the class.
+            reactivate: bool
+                Optional. Whether or not to set the `inactive` flag on a given Connection to False
+                if the Connection exists and has `inactive` set to True. True by default.
         `Returns:`
             Dict containing Action Builder connection data.
         """  # noqa: E501
@@ -408,6 +417,9 @@ class ActionBuilder(object):
                 "person_id": identifiers[1]
             }
         }
+
+        if reactivate:
+            data["connection"]["inactive"] = False
 
         if tag_data:
             if isinstance(tag_data, dict):

--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -447,7 +447,7 @@ class ActionBuilder(object):
             Dict containing Action Builder connection data.
         """
 
-        # Check that there are exactly two identifiers and that campaign is provided first
+        # Check that either connection or second entity identifier are provided
         if {connection_identifier, to_identifier} == {None}:
             raise ValueError("Must provide a connection ID or an ID for the second entity")
 

--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -448,7 +448,7 @@ class ActionBuilder(object):
         """
 
         # Check that there are exactly two identifiers and that campaign is provided first
-        if {identifier, to_identifier} == {None}:
+        if {connection_identifier, to_identifier} == {None}:
             raise ValueError("Must provide a connection ID or an ID for the second entity")
 
         campaign = self._campaign_check(campaign)

--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -466,10 +466,10 @@ class ActionBuilder(object):
         if connection_identifier:
 
             url += f'/{connection_identifier}'
-            return self.api.post_request(url=url, data=json.dumps(data))
+            return self.api.put_request(url=url, data=json.dumps(data))
 
         # If no connection ID then there must be a to_identifier not to have errored by now
         else:
 
             data['person_id'] = to_identifier
-            return self.api.put_request(url=url, data=json.dumps(data))
+            return self.api.post_request(url=url, data=json.dumps(data))

--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -419,3 +419,50 @@ class ActionBuilder(object):
             data["add_tags"] = tag_data
 
         return self.api.post_request(url=url, data=json.dumps(data))
+
+    def deactivate_connection(
+        self, from_identifier, connection_identifier=None, to_identifier=None
+    ):
+        """
+        Deactivate an existing connection record in Action Builder between two existing entity
+        records. Only one connection record is allowed per pair of entities, so this can be done 
+        by supplying the ID for the connection record, or for the two connected entity records.
+        `Args:`
+            from_identifier: str
+                Unique identifier for one of the two entities with a connection.
+            connection_identifier: str
+                Optional. The unique identifier for an entity or connection record being updated.
+                If omitted, `to_identifier` must be provided.
+            to_identifier: str
+                Optional. The second entity with a connection to `from_entity`. If omitted, 
+                `connection_identifier` must be provided.
+        `Returns:`
+            Dict containing Action Builder connection data.
+        """
+
+        # Check that there are exactly two identifiers and that campaign is provided first
+        if {identifier, to_identifier} == {None}:
+            raise ValueError("Must provide a connection ID or an ID for the second entity")
+
+        campaign = self._campaign_check(campaign)
+
+        url = f"campaigns/{campaign}/people/{from_identifier}/connections"
+
+        data = {
+            "connection": {
+                "inactive": True
+            }
+        }
+
+        # Prioritize connection ID to avoid potential confusion if to_identifier is also provided
+        # to_identifier entity could have duplicates, connection ID is more specific
+        if connection_identifier:
+
+            url += f'/{connection_identifier}'
+            return self.api.post_request(url=url, data=json.dumps(data))
+
+        # If no connection ID then there must be a to_identifier not to have errored by now
+        else:
+
+            data['person_id'] = to_identifier
+            return self.api.put_request(url=url, data=json.dumps(data))

--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -462,7 +462,12 @@ class ActionBuilder(object):
         # Prioritize connection ID to avoid potential confusion if to_identifier is also provided
         # to_identifier entity could have duplicates, connection ID is more specific
         if connection_identifier:
+
             url += f"/{connection_identifier}"
+
+            # Despite the documentation, PUT requests don't require the outer "connection" key
+            data = data["connection"]
+
             return self.api.put_request(url=url, data=json.dumps(data))
 
         # If no connection ID then there must be a to_identifier not to have errored by now

--- a/test/test_action_builder/test_action_builder.py
+++ b/test/test_action_builder/test_action_builder.py
@@ -213,7 +213,11 @@ class TestActionBuilder(unittest.TestCase):
             "message": "Tag has been removed from Taggable Logbook"
         }
 
-        self.fake_connection = {"person_id": "fake-entity-id-2"}
+        # self.fake_connection = {"person_id": "fake-entity-id-2"}
+        self.fake_connection = {
+            "person_id": "fake-entity-id-2",
+            "identifiers": ["action_builder:fake-connection-id"]
+        }
 
     @requests_mock.Mocker()
     def test_get_page(self, m):
@@ -395,4 +399,22 @@ class TestActionBuilder(unittest.TestCase):
         connect_response = self.bldr.upsert_connection(
             [self.fake_entity_id, "fake-entity-id-2"]
         )
-        self.assertEqual(connect_response, self.fake_connection)
+        self.assertEqual(
+            connect_response,
+            {k:v for k,v in self.fake_connection.items() if k != 'identifiers'}
+        )
+
+    @requests_mock.Mocker()
+    def test_deactivate_connection_post(self, m):
+        m.post(
+            f"{self.api_url}/people/{self.fake_entity_id}/connections",
+            json=self.connect_callback,
+        )
+        connect_response = self.bldr.deactivate_connection(
+            self.fake_entity_id, to_identifier = "fake-entity-id-2"
+        )
+        self.assertEqual(
+            connect_response,
+            {**{k:v for k,v in self.fake_connection.items() if k != 'identifiers'},
+             **{"inactive": True}}
+        )

--- a/test/test_action_builder/test_action_builder.py
+++ b/test/test_action_builder/test_action_builder.py
@@ -387,7 +387,10 @@ class TestActionBuilder(unittest.TestCase):
         # Internal method for returning constructed connection data to test
 
         post_data = request.json()
-        connection_data = post_data["connection"]
+        connection_data = post_data
+
+        if request.method != 'PUT':
+            connection_data = post_data["connection"]
 
         url_pieces = [x for x in request.url.split("/") if x]
 

--- a/test/test_action_builder/test_action_builder.py
+++ b/test/test_action_builder/test_action_builder.py
@@ -216,7 +216,7 @@ class TestActionBuilder(unittest.TestCase):
         # self.fake_connection = {"person_id": "fake-entity-id-2"}
         self.fake_connection = {
             "person_id": "fake-entity-id-2",
-            "identifiers": ["action_builder:fake-connection-id"]
+            "identifiers": ["action_builder:fake-connection-id"],
         }
 
     @requests_mock.Mocker()
@@ -389,11 +389,11 @@ class TestActionBuilder(unittest.TestCase):
         post_data = request.json()
         connection_data = post_data["connection"]
 
-        url_pieces = [x for x in request.url.split('/') if x]
-        
+        url_pieces = [x for x in request.url.split("/") if x]
+
         # Grab ID if connections is penultimate in url path
-        if url_pieces.index('connections') == len(url_pieces) - 2:
-            connection_data['identifiers'] = [f'action_builder:{url_pieces[-1]}']
+        if url_pieces.index("connections") == len(url_pieces) - 2:
+            connection_data["identifiers"] = [f"action_builder:{url_pieces[-1]}"]
         return connection_data
 
     @requests_mock.Mocker()
@@ -407,7 +407,7 @@ class TestActionBuilder(unittest.TestCase):
         )
         self.assertEqual(
             connect_response,
-            {k:v for k,v in self.fake_connection.items() if k != 'identifiers'}
+            {k: v for k, v in self.fake_connection.items() if k != "identifiers"},
         )
 
     @requests_mock.Mocker()
@@ -417,12 +417,14 @@ class TestActionBuilder(unittest.TestCase):
             json=self.connect_callback,
         )
         connect_response = self.bldr.deactivate_connection(
-            self.fake_entity_id, to_identifier = "fake-entity-id-2"
+            self.fake_entity_id, to_identifier="fake-entity-id-2"
         )
         self.assertEqual(
             connect_response,
-            {**{k:v for k,v in self.fake_connection.items() if k != 'identifiers'},
-             **{"inactive": True}}
+            {
+                **{k: v for k, v in self.fake_connection.items() if k != "identifiers"},
+                **{"inactive": True},
+            },
         )
 
     @requests_mock.Mocker()
@@ -434,10 +436,12 @@ class TestActionBuilder(unittest.TestCase):
             json=self.connect_callback,
         )
         connect_response = self.bldr.deactivate_connection(
-            self.fake_entity_id, connection_identifier = "fake-connection-id"
+            self.fake_entity_id, connection_identifier="fake-connection-id"
         )
         self.assertEqual(
             connect_response,
-            {**{k:v for k,v in self.fake_connection.items() if k != 'person_id'},
-             **{"inactive": True}}
+            {
+                **{k: v for k, v in self.fake_connection.items() if k != "person_id"},
+                **{"inactive": True},
+            },
         )

--- a/test/test_action_builder/test_action_builder.py
+++ b/test/test_action_builder/test_action_builder.py
@@ -389,7 +389,7 @@ class TestActionBuilder(unittest.TestCase):
         post_data = request.json()
         connection_data = post_data
 
-        if request.method != 'PUT':
+        if request.method != "PUT":
             connection_data = post_data["connection"]
 
         url_pieces = [x for x in request.url.split("/") if x]
@@ -410,7 +410,10 @@ class TestActionBuilder(unittest.TestCase):
         )
         self.assertEqual(
             connect_response,
-            {k: v for k, v in self.fake_connection.items() if k != "identifiers"},
+            {
+                **{k: v for k, v in self.fake_connection.items() if k != "identifiers"},
+                **{"inactive": False},
+            },
         )
 
     @requests_mock.Mocker()


### PR DESCRIPTION
Connection records in Action Builder cannot be deleted. Instead, there's an "Inactive" flag that determines whether they appear in the UI or not on either of the two Entity records they connect. This PR introduces a new method, `deactivate_connection()`, which deactivates an existing Connection. 

The method requires the "interact ID" for one of the two Entities as a positional argument. One of two additional (keyword) arguments is required to make the change: either the interact ID for the other Entity (POST request to the connection helper endpoint), or the interact ID of the connection itself (PUT request to the specific connection endpoint).

This PR also updates the existing `upsert_connection()` method to include by default an explicit `False` value for the `inactive` flag when upserting Connection data, under the assumption that upserting to a given Connection implies that the user wants that Connection to be active. The `reactivate` argument can be set to `False` to prevent this and make changes to inactive Connections _without_ reactivating them.

Tests were written and adapted for these additions and changes, and are running successfully. Furthermore, these changes were successful in live tests done by defining the two methods locally and overriding the Class definitions before instantiation.

A good future PR might be to adapt the existing `upsert_connection()` method to accept the Connection ID as an optional keyword arg, to trigger a PUT request directly to the specific Connection endpoint. Argument validation could be updated such that a single-item list (or even a string) could be accepted for the positional `identifiers` arg if the Connection ID is provided.