### PR TITLE
Bump python-dateutil from v2.8.1 to v2.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ suds-py3==1.3.4.0
 newmode==0.1.6
 mysql-connector-python==8.0.18
 braintree==4.0.0
-python-dateutil==2.8.1
+python-dateutil==2.8.2
 azure-storage-blob==12.3.2
 PyGitHub==1.51
 surveygizmo==1.2.3


### PR DESCRIPTION
Pandas requires python-dateutil 2.8.2 since at least pandas v2.0.0, with pandas v3.0.0 coming soon.
It would be helpful to be able to be able to use parsons with pandas.