### PR TITLE
add client_options with default scopes to client

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -141,6 +141,10 @@ class GoogleBigQuery(DatabaseConnector):
             then will use the default inferred environment.
         location: str
             Default geographic location for tables
+        client_options: dict
+            A dictionary containing any requested client options. Defaults to the required
+            scopes for making API calls against External tables stored in Google Drive.
+            Can be set to None if these permissions are not desired
     """
 
     def __init__(
@@ -156,13 +160,6 @@ class GoogleBigQuery(DatabaseConnector):
             ]
         },
     ):
-        """
-        Args:
-            client_options: dict
-            A dictionary containing any requested client options. Defaults to the required
-            scopes for making API calls against External tables stored in Google Drive.
-            Can be set to None if these permissions are not desired
-        """
         self.app_creds = app_creds
 
         setup_google_application_credentials(app_creds)

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -143,13 +143,26 @@ class GoogleBigQuery(DatabaseConnector):
             Default geographic location for tables
     """
 
-    def __init__(self, app_creds=None, project=None, location=None):
+    def __init__(
+        self,
+        app_creds=None,
+        project=None,
+        location=None,
+        client_options: dict = {
+            "scopes": [
+                "https://www.googleapis.com/auth/drive",
+                "https://www.googleapis.com/auth/bigquery",
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+        }
+    ):
         self.app_creds = app_creds
 
         setup_google_application_credentials(app_creds)
 
         self.project = project
         self.location = location
+        self.client_options = client_options
 
         # We will not create the client until we need to use it, since creating the client
         # without valid GOOGLE_APPLICATION_CREDENTIALS raises an exception.
@@ -161,16 +174,7 @@ class GoogleBigQuery(DatabaseConnector):
         self.dialect = "bigquery"
 
     @property
-    def client(
-        self,
-        client_options: dict = {
-            "scopes": [
-                "https://www.googleapis.com/auth/drive",
-                "https://www.googleapis.com/auth/bigquery",
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-        },
-    ):
+    def client(self):
         """
         Get the Google BigQuery client to use for making queries.
 
@@ -188,7 +192,7 @@ class GoogleBigQuery(DatabaseConnector):
             self._client = bigquery.Client(
                 project=self.project,
                 location=self.location,
-                client_options=client_options,
+                client_options=self.client_options,
             )
 
         return self._client

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -161,16 +161,35 @@ class GoogleBigQuery(DatabaseConnector):
         self.dialect = "bigquery"
 
     @property
-    def client(self):
+    def client(
+        self,
+        client_options: dict = {
+            "scopes": [
+                "https://www.googleapis.com/auth/drive",
+                "https://www.googleapis.com/auth/bigquery",
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+        },
+    ):
         """
         Get the Google BigQuery client to use for making queries.
+
+        Args:
+        client_options: dict
+            A dictionary containing any requested client options. Defaults to the required
+            scopes for making API calls against External tables stored in Google Drive.
+            Can be set to None if these permissions are not desired
 
         `Returns:`
             `google.cloud.bigquery.client.Client`
         """
         if not self._client:
             # Create a BigQuery client to use to make the query
-            self._client = bigquery.Client(project=self.project, location=self.location)
+            self._client = bigquery.Client(
+                project=self.project,
+                location=self.location,
+                client_options=client_options,
+            )
 
         return self._client
 

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -154,8 +154,15 @@ class GoogleBigQuery(DatabaseConnector):
                 "https://www.googleapis.com/auth/bigquery",
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
-        }
+        },
     ):
+        """
+        Args:
+            client_options: dict
+            A dictionary containing any requested client options. Defaults to the required
+            scopes for making API calls against External tables stored in Google Drive.
+            Can be set to None if these permissions are not desired
+        """
         self.app_creds = app_creds
 
         setup_google_application_credentials(app_creds)
@@ -177,12 +184,6 @@ class GoogleBigQuery(DatabaseConnector):
     def client(self):
         """
         Get the Google BigQuery client to use for making queries.
-
-        Args:
-        client_options: dict
-            A dictionary containing any requested client options. Defaults to the required
-            scopes for making API calls against External tables stored in Google Drive.
-            Can be set to None if these permissions are not desired
 
         `Returns:`
             `google.cloud.bigquery.client.Client`


### PR DESCRIPTION
Add a client_options parameter to the client function, including default scopes. These scopes are necessary to allow querying of external tables stored in Google Drive. The formatting should make it possible to pass in other client options as required.