### PR TITLE
BigQuery returns empty Table on query with no rows returned

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1,22 +1,21 @@
-import pickle
-from typing import Optional, Union, List
-import uuid
-import logging
 import datetime
+import logging
+import pickle
 import random
+import uuid
+from contextlib import contextmanager
+from typing import List, Optional, Union
 
-from google.cloud import bigquery
+import petl
+from google.cloud import bigquery, exceptions
 from google.cloud.bigquery import dbapi
 from google.cloud.bigquery.job import LoadJobConfig
-from google.cloud import exceptions
-import petl
-from contextlib import contextmanager
 
-from parsons.databases.table import BaseTable
 from parsons.databases.database_connector import DatabaseConnector
+from parsons.databases.table import BaseTable
 from parsons.etl import Table
-from parsons.google.utitities import setup_google_application_credentials
 from parsons.google.google_cloud_storage import GoogleCloudStorage
+from parsons.google.utitities import setup_google_application_credentials
 from parsons.utilities import check_env
 from parsons.utilities.files import create_temp_file
 
@@ -1179,7 +1178,7 @@ class GoogleBigQuery(DatabaseConnector):
         with open(temp_filename, "wb") as temp_file:
             header = [i[0] for i in cursor.description]
             pickle.dump(header, temp_file)
-            
+
             while True:
                 batch = cursor.fetchmany(QUERY_BATCH_SIZE)
                 if len(batch) == 0:

--- a/test/test_databases/test_bigquery.py
+++ b/test/test_databases/test_bigquery.py
@@ -72,7 +72,6 @@ class TestGoogleBigQuery(FakeCredentialTest):
         assert isinstance(result, Table)
         assert not len(result)
         assert tuple(result.columns) == tuple([])
-        
 
     @mock.patch("parsons.utilities.files.create_temp_file")
     def test_query__no_return(self, create_temp_file_mock):

--- a/test/test_databases/test_bigquery.py
+++ b/test/test_databases/test_bigquery.py
@@ -1,13 +1,13 @@
 import json
 import os
 import unittest.mock as mock
-
-from google.cloud import bigquery
-from google.cloud import exceptions
-
-from parsons import GoogleBigQuery as BigQuery, Table
-from parsons.google.google_cloud_storage import GoogleCloudStorage
 from test.test_google.test_utilities import FakeCredentialTest
+
+from google.cloud import bigquery, exceptions
+
+from parsons import GoogleBigQuery as BigQuery
+from parsons import Table
+from parsons.google.google_cloud_storage import GoogleCloudStorage
 
 
 class FakeClient:
@@ -58,7 +58,7 @@ class TestGoogleBigQuery(FakeCredentialTest):
         self.assertEqual(result[0], {"one": 1, "two": 2})
 
     def test_query__no_results(self):
-        query_string = "select * from table"
+        query_string = "select * from table limit 0"
 
         # Pass the mock class into our GoogleBigQuery constructor
         bq = self._build_mock_client_for_querying([])
@@ -67,7 +67,12 @@ class TestGoogleBigQuery(FakeCredentialTest):
         result = bq.query(query_string)
 
         # Check our return value
-        self.assertEqual(result, None)
+        # We can't use assertEqual(result, Table())
+        # Because Table() == Table() fails for some reason
+        assert isinstance(result, Table)
+        assert not len(result)
+        assert tuple(result.columns) == tuple([])
+        
 
     @mock.patch("parsons.utilities.files.create_temp_file")
     def test_query__no_return(self, create_temp_file_mock):
@@ -499,6 +504,8 @@ class TestGoogleBigQuery(FakeCredentialTest):
         cursor = mock.MagicMock()
         cursor.execute.return_value = None
         cursor.fetchmany.side_effect = [results, []]
+        if results:
+            cursor.description = [(key, None) for key in results[0]]
 
         # Create a mock that will play the role of the connection
         connection = mock.MagicMock()


### PR DESCRIPTION
This empty Table has columns defined. Prior behavior was to return None. This change brings the behavior into alignment with the Redshift connector.

Addresses #971 