### PR TITLE
Update get_columns_list() to accept tables with spaces in the name

### DIFF
--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -428,7 +428,8 @@ class RedshiftTableUtilities(object):
         `Returns:`
             A list of column names.
         """
-
+        schema = f'"{schema}"'
+        table_name = f'"{table_name}"'
         first_row = self.query(f"select * from {schema}.{table_name} limit 1")
 
         return first_row.columns

--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -428,8 +428,18 @@ class RedshiftTableUtilities(object):
         `Returns:`
             A list of column names.
         """
-        schema = f'"{schema}"'
-        table_name = f'"{table_name}"'
+        schema = (
+            f'"{schema}"'
+            if not (schema.startswith('"') and schema.endswith('"'))
+            else schema
+        )
+
+        table_name = (
+            f'"{table_name}"'
+            if not (table_name.startswith('"') and table_name.endswith('"'))
+            else table_name
+        )
+
         first_row = self.query(f"select * from {schema}.{table_name} limit 1")
 
         return first_row.columns


### PR DESCRIPTION
Updates `get_columns_list()` to work with table names that include spaces or begin with invalid characters.