### PR TITLE
Fix ActionKit collect_upload_errors() Bug

### DIFF
--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -1307,15 +1307,34 @@ class ActionKit(object):
         for res in result_array:
             upload_id = res.get("id")
             if upload_id:
+                # Pend until upload is complete
                 while True:
                     upload = self._base_get(endpoint="upload", entity_id=upload_id)
-                    if not upload or upload.get("is_completed"):
+                    if upload.get("is_completed"):
                         break
                     else:
                         time.sleep(1)
-                error_data = self._base_get(
-                    endpoint="uploaderror", params={"upload": upload_id}
-                )
-                logger.debug(f"error collect result: {error_data}")
-                errors.extend(error_data.get("objects") or [])
+
+                # ActionKit limits length of error list returned
+                # Iterate until all errors are gathered
+                error_count = upload.get("has_errors")
+                limit = 20
+                offset = 0
+
+                while True:
+                    error_data = self._base_get(
+                        endpoint="uploaderror",
+                        params={
+                            "upload": upload_id,
+                            "_limit": limit,
+                            "_offset": offset,
+                        },
+                    )
+                    logger.debug(f"error collect result: {error_data}")
+                    errors.extend(error_data.get("objects") or [])
+                    offset = offset + limit
+
+                    if error_count <= offset:
+                        break
+
         return errors

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -2,6 +2,7 @@ import json
 import logging
 import requests
 import time
+import math
 
 from parsons.etl.table import Table
 from parsons.utilities import check_env
@@ -1319,22 +1320,18 @@ class ActionKit(object):
                 # Iterate until all errors are gathered
                 error_count = upload.get("has_errors")
                 limit = 20
-                offset = 0
 
-                while True:
+                error_pages = math.ceil(error_count / limit)
+                for page in range(0, error_pages):
                     error_data = self._base_get(
                         endpoint="uploaderror",
                         params={
                             "upload": upload_id,
                             "_limit": limit,
-                            "_offset": offset,
+                            "_offset": page * limit,
                         },
                     )
                     logger.debug(f"error collect result: {error_data}")
                     errors.extend(error_data.get("objects") or [])
-                    offset = offset + limit
-
-                    if error_count <= offset:
-                        break
 
         return errors

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -1332,6 +1332,6 @@ class ActionKit(object):
                         },
                     )
                     logger.debug(f"error collect result: {error_data}")
-                    errors.extend(error_data.get("objects") or [])
+                    errors.extend(error_data.get("objects", []))
 
         return errors

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -1309,7 +1309,7 @@ class ActionKit(object):
             if upload_id:
                 while True:
                     upload = self._base_get(endpoint="upload", entity_id=upload_id)
-                    if not upload or upload.get("status") != "new":
+                    if not upload or upload.get("is_completed"):
                         break
                     else:
                         time.sleep(1)


### PR DESCRIPTION
Test steps:
* Create an .csv file with many invalid rows (e.g. a donations import file with 200+ rows, with a non-existent payment account like "BAD PAYMENT ACCOUNT" as the donation_payment_account value for each row).
* Launch a python terminal
* Import dependencies: `from parsons.etl.table import Table`, `from parsons.action_kit import ActionKit`
* Create an ActionKit object `ak` with access to a sandbox ActionKit instance (e.g. `ak = ActionKit(**credentials['action_kit_sandbox'])`)
* Import the data from .csv: `ak_table = Table.from_csv('path/to/upload.csv')`
* Set the import page: `import_page='some-test-import-page'`
* Then, all on one line, run: `res = ak.bulk_upload_table(ak_table, import_page=import_page); errors = ak.collect_upload_errors(res['results']); print(errors); print(len(errors))`.

The final commands are on a single line because the delay of a human entering terminal commands is long enough hide the problem. Before this change, you will get fewer errors than the total number of invalid rows in the file. After the change, you will get as many errors as there are invalid rows.