### PR TITLE
Issue 910 - Added timeout to BigQuery load_job.result()

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -41,6 +41,9 @@ BIGQUERY_TYPE_MAP = {
 # 100k rows per batch at ~1k bytes each = ~100MB per batch.
 QUERY_BATCH_SIZE = 100000
 
+# Max number of seconds to wait for a request before raising a timeout error
+MAX_TIMEOUT = 30
+
 
 def get_table_ref(client, table_name):
     # Helper function to build a TableReference for our table
@@ -464,7 +467,7 @@ class GoogleBigQuery(DatabaseConnector):
                     job_config=job_config,
                     **load_kwargs,
                 )
-                load_job.result()
+                load_job.result(timeout=MAX_TIMEOUT)
         except exceptions.BadRequest as e:
             if "one of the files is larger than the maximum allowed size." in str(e):
                 logger.debug(
@@ -632,7 +635,7 @@ class GoogleBigQuery(DatabaseConnector):
                 job_config=job_config,
                 **load_kwargs,
             )
-            load_job.result()
+            load_job.result(timeout=MAX_TIMEOUT)
         finally:
             if uncompressed_gcs_uri:
                 new_bucket_name, new_blob_name = gcs.split_uri(

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -507,7 +507,7 @@ class GoogleBigQuery(DatabaseConnector):
             else:
                 raise e
 
-        except exceptions.GatewayTimeout as e:
+        except exceptions.DeadlineExceeded as e:
             logger.error(f"Max timeout exceeded for {gcs_blob_uri.split('/')[-1]}")
             raise e
 
@@ -640,7 +640,7 @@ class GoogleBigQuery(DatabaseConnector):
                 **load_kwargs,
             )
             load_job.result(timeout=MAX_TIMEOUT)
-        except exceptions.GatewayTimeout as e:
+        except exceptions.DeadlineExceeded as e:
             logger.error(f"Max timeout exceeded for {gcs_blob_uri.split('/')[-1]}")
             raise e
         finally:

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -507,6 +507,10 @@ class GoogleBigQuery(DatabaseConnector):
             else:
                 raise e
 
+        except exceptions.GatewayTimeout as e:
+            logger.error(f"Max timeout exceeded for {gcs_blob_uri.split('/')[-1]}")
+            raise e
+
     def copy_large_compressed_file_from_gcs(
         self,
         gcs_blob_uri: str,
@@ -636,6 +640,9 @@ class GoogleBigQuery(DatabaseConnector):
                 **load_kwargs,
             )
             load_job.result(timeout=MAX_TIMEOUT)
+        except exceptions.GatewayTimeout as e:
+            logger.error(f"Max timeout exceeded for {gcs_blob_uri.split('/')[-1]}")
+            raise e
         finally:
             if uncompressed_gcs_uri:
                 new_bucket_name, new_blob_name = gcs.split_uri(


### PR DESCRIPTION
# Overview

This PR addresses [Issue #910](https://github.com/move-coop/parsons/issues/910). A timeout is added to prevent indefinite hanging.


From the original issue:

> Per [Google BQ query job documentation](https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.job.QueryJob#google_cloud_bigquery_job_QueryJob_result), it's possible to pass a default timeout parameter to the synchronous call that awaits a response.

> This change would require choosing a reasonable maximum default (30s?), setting that up as a configurable parameter, and passing that parameter into load_job.result.

# Changes
27/1/2024
- ~~Added `MAX_TIMEOUT = 30` constant~~ 
- ~~Updated `load_job.result()` to use `MAX_TIMEOUT`~~

31/1/2024 — @Jason94 
- Added `max_timeout: int = 30` as a keyword argument
- Updated `load_job.result()` to use `max_timeout`
- Added `DeadlineExceeded` error handling ([docs](https://googleapis.dev/python/google-api-core/latest/exceptions.html?highlight=deadlineexceeded#google.api_core.exceptions.DeadlineExceeded))