### PR TITLE
Allow Table(None)

### DIFF
--- a/parsons/etl/table.py
+++ b/parsons/etl/table.py
@@ -1,6 +1,5 @@
 import logging
 import pickle
-from enum import Enum
 from typing import Union
 
 import petl
@@ -12,20 +11,6 @@ from parsons.utilities import files
 logger = logging.getLogger(__name__)
 
 DIRECT_INDEX_WARNING_COUNT = 10
-
-
-class _EmptyDefault(Enum):
-    """Default argument for Table()
-
-    This is used because Table(None) should not be allowed, but we
-    need a default argument that isn't the mutable []
-
-    See https://stackoverflow.com/a/76606310 for discussion."""
-
-    token = 0
-
-
-_EMPTYDEFAULT = _EmptyDefault.token
 
 
 class Table(ETL, ToFrom):
@@ -46,16 +31,11 @@ class Table(ETL, ToFrom):
 
     def __init__(
         self,
-        lst: Union[list, tuple, petl.util.base.Table, _EmptyDefault] = _EMPTYDEFAULT,
+        lst: Union[list, tuple, petl.util.base.Table, None] = None,
     ):
         self.table = None
 
-        # Normally we would use None as the default argument here
-        # Instead of using None, we use a sentinal
-        # This allows us to maintain the existing behavior
-        # This is allowed: Table()
-        # This should fail: Table(None)
-        if lst is _EMPTYDEFAULT:
+        if lst is None:
             self.table = petl.fromdicts([])
 
         elif isinstance(lst, list) or isinstance(lst, tuple):

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -67,9 +67,8 @@ class TestParsonsTable(unittest.TestCase):
         self.assertRaises(ValueError, Table, list_of_invalid)
 
     def test_from_empty_petl(self):
-        # This test ensures that this would fail: Table(None)
-        # Even while allowing Table() to work
-        self.assertRaises(ValueError, Table, None)
+        # Just ensure this doesn't throw an error
+        Table(None)
 
     def test_from_empty_list(self):
         # Just ensure this doesn't throw an error


### PR DESCRIPTION
This change allows `Table(None)` to work, equivalent to `Table()`. This is reasonable behavior and also simplifies the implementation to avoid the necessity of a sentinal as a default argument. 

This may be a breaking change if code depends on `Table(None)` raising a ValueError.