### PR TITLE
Raise Error for Big Query .copy() when no GCS_TEMP_BUCKET environment variable or tmp_gcs_bucket parameter

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -779,6 +779,10 @@ class GoogleBigQuery(DatabaseConnector):
                 client.
         """
         tmp_gcs_bucket = check_env.check("GCS_TEMP_BUCKET", tmp_gcs_bucket)
+        if not tmp_gcs_bucket:
+            raise ValueError(
+                "Must set GCS_TEMP_BUCKET environment variable or pass in tmp_gcs_bucket parameter"
+            )
 
         if not job_config:
             job_config = bigquery.LoadJobConfig()


### PR DESCRIPTION
Raise Error for Big Query .copy() when no GCS_TEMP_BUCKET environment variable is set or tmp_gcs_bucket parameter is passed