### PR TITLE
Add cautionary note about performance in get_row_count method

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1121,6 +1121,10 @@ class GoogleBigQuery(DatabaseConnector):
         """
         Gets the row count for a BigQuery materialization.
 
+        Caution: This method uses SELECT COUNT(*) which can be expensive for large tables,
+        especially those with many columns. This is because BigQuery scans all table data
+        to perform the count, even though only the row count is returned.
+
         `Args`:
             schema: str
                 The schema name


### PR DESCRIPTION
This pull request adds a cautionary note about the performance of the get_row_count method in the BigQuery materialization. The note warns that using SELECT COUNT(*) can be expensive for large tables, especially those with many columns, as BigQuery scans all table data to perform the count. The note aims to inform developers about the potential performance impact and encourage them to consider alternative approaches when dealing with large tables.