### PR TITLE
BigQuery connector handles queries without return values (create table, create view)

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -315,6 +315,12 @@ class GoogleBigQuery(DatabaseConnector):
             if not return_values:
                 return None
 
+            # This applies when running a SQL statement without any return value
+            # e.g. when creating a view or a table
+            # This does not apply when 0 rows are returned
+            if not cursor.description:
+                return None
+
             final_table = self._fetch_query_results(cursor=cursor)
 
             return final_table


### PR DESCRIPTION
Addresses #999

The BigQuery connector can now successfully run a query to create a table or a view without raising an AttributeError when unsuccessfully trying to fetch results from the query.

Normally you can use the return_value=False flag, but that shouldn't be necessary