### PR TITLE
Add head and tail methods to Parsons Table

### DIFF
--- a/docs/table.rst
+++ b/docs/table.rst
@@ -156,6 +156,10 @@ of commonly used methods. The full list can be found in the API section.
 
     * - Method
       - Description
+    * - :py:meth:`~parsons.etl.etl.ETL.head`
+      - Get the first n rows of a table
+    * - :py:meth:`~parsons.etl.etl.ETL.tail`
+      - Get the last n rows of a table
     * - :py:meth:`~parsons.etl.etl.ETL.add_column`
       - Add a column
     * - :py:meth:`~parsons.etl.etl.ETL.remove_column`

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -9,6 +9,37 @@ class ETL(object):
     def __init__(self):
         pass
 
+    def head(self, n=5):
+        """
+        Return the first n rows of the table
+
+        `Args:`
+            n: int
+                The number of rows to return. Defaults to 5.
+        `Returns:`
+            `Parsons Table`
+        """
+
+        self.table = petl.head(self.table, n)
+
+        return self
+
+    def tail(self, n=5):
+        """
+        Return the last n rows of the table. Defaults to 5.
+
+        `Args:`
+            n: int
+                The number of rows to return
+
+        `Returns:`
+            `Parsons Table`
+        """
+
+        self.table = petl.tail(self.table, n)
+
+        return self
+
     def add_column(self, column, value=None, index=None, if_exists="fail"):
         """
         Add a column to your table
@@ -724,7 +755,7 @@ class ETL(object):
                 The new long table
         """
 
-        if type(key) == str:
+        if type(key) is str:
             key = [key]
 
         lt = self.cut(*key, column)  # Create a table of key and column

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -997,3 +997,15 @@ class TestParsonsTable(unittest.TestCase):
         tbl_expected = Table([["a", "b", "c"], [1, 2, 3], [1, 3, 2], [2, 3, 4]])
         tbl.deduplicate(["a", "b"])
         assert_matching_tables(tbl_expected, tbl)
+
+    def test_head(self):
+        tbl = Table([["a", "b"], [1, 2], [3, 4], [5, 6], [7, 8], [9, 10]])
+        tbl_expected = Table([["a", "b"], [1, 2], [3, 4]])
+        tbl.head(2)
+        assert_matching_tables(tbl_expected, tbl)
+
+    def test_tail(self):
+        tbl = Table([["a", "b"], [1, 2], [3, 4], [5, 6], [7, 8], [9, 10]])
+        tbl_expected = Table([["a", "b"], [7, 8], [9, 10]])
+        tbl.tail(2)
+        assert_matching_tables(tbl_expected, tbl)


### PR DESCRIPTION
This pull request adds the `head` and `tail` methods to the `Parsons Table` class in the `ETL` module. The `head` method returns the first n rows of the table, while the `tail` method returns the last n rows of the table. Tests and documentation have also been added for these new methods.