### PR TITLE
Remove self.project reference from GoogleBigQuery.get_columns() query

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1076,7 +1076,7 @@ class GoogleBigQuery(DatabaseConnector):
         base_query = f"""
         SELECT
             *
-        FROM `{self.project}.{schema}.INFORMATION_SCHEMA.COLUMNS`
+        FROM `{schema}.INFORMATION_SCHEMA.COLUMNS`
         WHERE
             table_name = '{table_name}'
         """


### PR DESCRIPTION
The `GoogleBigQuery.get_columns()` base query `from` statement references `{self.project}` which causes an error (below). Removing `{self.project`} solves this issue and aligns with the format used in other queries in this class, such as `get_columns_list`.

```
raise exceptions.DatabaseError(exc)
03/06/2024 10:11:26 AM
google.cloud.bigquery.dbapi.exceptions.DatabaseError: 400 Invalid project ID 'None'. Project IDs must contain 6-63 lowercase letters, digits, or dashes. Some project IDs also include domain name separated by a colon. IDs must start with a letter and may not end with a dash.
```

