### PR TITLE
Map 'Decimal' type from incomping Table in BQ

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -34,6 +34,7 @@ BIGQUERY_TYPE_MAP = {
     "NoneType": "STRING",
     "UUID": "STRING",
     "timestamp": "TIMESTAMP",
+    "Decimal": "FLOAT",
 }
 
 # Max number of rows that we query at a time, so we can avoid loading huge


### PR DESCRIPTION
This adds support for loading any data wrapped in the high-precision Python `Decimal` class directly into a BQ table.