### PR TITLE
fix failing test in #976

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -r ../requirements.txt
-Sphinx==4.3.2
-sphinx-rtd-theme==1.0.0
-myst-parser==0.16.1
+Sphinx==5.3.0
+sphinx-rtd-theme==2.0.0
+myst-parser==1.0.0
 sphinx-multiversion

--- a/test/test_databases/test_bigquery.py
+++ b/test/test_databases/test_bigquery.py
@@ -316,12 +316,12 @@ class TestGoogleBigQuery(FakeCredentialTest):
         )
 
         # check that the method did the right things
-        gcs_client.copy_s3_to_gcs.assert_called_once_with(
+        gcs_client.copy_bucket_to_gcs.assert_called_once_with(
             aws_source_bucket=bucket,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             gcs_sink_bucket=tmp_gcs_bucket,
-            aws_s3_key=key,
+            source_path=key,
         )
         bq.copy_from_gcs.assert_called_once()
         gcs_client.delete_blob.assert_called_once()


### PR DESCRIPTION
This fixes the following workflow error in #976:
`AssertionError: Expected 'copy_s3_to_gcs' to be called once. Called 0 times.` [[log]](https://github.com/move-coop/parsons/actions/runs/7618537381/job/20749902079?pr=976#step:6:185)

The test was checking for the method to have been called, but the previous commit changed the call to another method.

I also had to cherry-pick d4e85ab6fc532c919269fd7a6fc8e34ebd1d9414 to get doc build to pass because the branch is outdated.