### PR TITLE
Fix failing linting test in #827

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -r ../requirements.txt
-Sphinx==4.3.2
-sphinx-rtd-theme==1.0.0
-myst-parser==0.16.1
+Sphinx==5.3.0
+sphinx-rtd-theme==2.0.0
+myst-parser==1.0.0
 sphinx-multiversion

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -293,7 +293,7 @@ class Redshift(
         bucket_region=None,
         strict_length=True,
         template_table=None,
-        encoding='utf-8'
+        encoding="utf-8",
     ):
         """
         Copy a file from s3 to Redshift.
@@ -411,8 +411,9 @@ class Redshift(
 
                     local_path = s3.get_file(bucket, key)
                     if data_type == "csv":
-                        tbl = Table.from_csv(local_path, delimiter=csv_delimiter, 
-                                             encoding=encoding)
+                        tbl = Table.from_csv(
+                            local_path, delimiter=csv_delimiter, encoding=encoding
+                        )
                     else:
                         raise TypeError("Invalid data type provided")
 


### PR DESCRIPTION
This fixes workflow errors in #827 by correcting formatting by changing quotes to double and making a slight change in how a long line is wrapped.

I also had to cherry-pick d4e85ab6fc532c919269fd7a6fc8e34ebd1d9414 to get doc build to pass because the branch is outdated.