### PR TITLE
Return PATCH response when updating AK user

### DIFF
--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -177,6 +177,8 @@ class ActionKit(object):
         )
         logger.info(f"{resp.status_code}: {user_id}")
 
+        return resp
+
     def get_event(self, event_id):
         """Get an event.
 

--- a/test/test_action_kit.py
+++ b/test/test_action_kit.py
@@ -89,11 +89,13 @@ class TestActionKit(unittest.TestCase):
         type(resp_mock.patch()).status_code = mock.PropertyMock(return_value=202)
         self.actionkit.conn = resp_mock
 
-        self.actionkit.update_user(123, last_name="new name")
+        res = self.actionkit.update_user(123, last_name="new name")
         self.actionkit.conn.patch.assert_called_with(
             "https://domain.actionkit.com/rest/v1/user/123/",
             data=json.dumps({"last_name": "new name"}),
         )
+
+        assert res.status_code == 202
 
     def test_update_event(self):
         # Test update event


### PR DESCRIPTION
Return the response after patching an AK user. This is necessary to parse the status code after calling the `update_user` function