### PR TITLE
New Feature: DBSync can upsert or append updated rows

### DIFF
--- a/parsons/databases/database_connector.py
+++ b/parsons/databases/database_connector.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Optional
 from parsons.etl.table import Table
+from parsons.databases.table import BaseTable
 
 
 class DatabaseConnector(ABC):
@@ -187,4 +188,9 @@ class DatabaseConnector(ABC):
             Parsons Table
                 See :ref:`parsons-table` for output options.
         """
+        pass
+
+    @abstractmethod
+    def table(self, table_name: str) -> BaseTable:
+        """Return a table instance."""
         pass

--- a/parsons/databases/db_sync.py
+++ b/parsons/databases/db_sync.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import Literal
+from typing import Literal, Union
 
 from parsons.databases.database_connector import DatabaseConnector
 from parsons.etl.table import Table
@@ -400,7 +400,9 @@ class DBSync:
         self,
         source_table_name: str,
         destination_table_name: str,
-        cutoff,
+        cutoff: Union[
+            str, int, float, datetime.date, datetime.datetime
+        ],  # Type hint is probably incomplete
         updated_at_column: str,
         primary_key: str,
     ) -> int:

--- a/parsons/databases/db_sync.py
+++ b/parsons/databases/db_sync.py
@@ -122,9 +122,7 @@ class DBSync:
         primary_key: str,
         distinct_check: bool = True,
         verify_row_count: bool = True,
-        strategy: Literal[
-            "primary_key", "append_updates", "upsert_updates"
-        ] = "primary_key",
+        strategy: Literal["primary_key", "append_updates", "upsert_updates"] = "primary_key",
         updated_at_column: str = "updated_at",
         **kwargs,
     ):
@@ -230,9 +228,7 @@ class DBSync:
                 primary_key,
             )
 
-            logger.info(
-                "Upserted %s updated rows to %s.", rows_upserted, destination_table
-            )
+            logger.info("Upserted %s updated rows to %s.", rows_upserted, destination_table)
 
         if verify_row_count:
             if strategy == "append_updates":
@@ -450,13 +446,9 @@ class DBSync:
 
             # If our buffer reaches our write threshold, write it out
             if not len(rows) or len(buffer) >= self.write_chunk_size:
-                logger.debug(
-                    "Copying %s rows to %s", len(buffer), destination_table_name
-                )
+                logger.debug("Copying %s rows to %s", len(buffer), destination_table_name)
                 if not self.dest_db.table_exists(destination_table_name):
-                    self.dest_db.copy(
-                        buffer, destination_table_name, if_exists="append"
-                    )
+                    self.dest_db.copy(buffer, destination_table_name, if_exists="append")
                 else:
                     # Load buffer to temp table, upsert from temp table
                     temp_table_name = (


### PR DESCRIPTION
The DBSync method can already append new rows from a source db into a target db based on an incremental primary key.

This new method generalizes that behavior in a new feature which allows for appending or upserting rows that have an updated_at_column value in the source db greater than the value in the target db.