### PR TITLE
Move variable definition outside try/except block

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1324,13 +1324,14 @@ class GoogleBigQuery(DatabaseConnector):
             raise ValueError(f"Only supports csv or json files [data_type = {data_type}]")
 
     def _load_table_from_uri(self, source_uris, destination, job_config, **load_kwargs):
+        load_job = self.client.load_table_from_uri(
+            source_uris=source_uris,
+            destination=destination,
+            job_config=job_config,
+            **load_kwargs,
+        )
+
         try:
-            load_job = self.client.load_table_from_uri(
-                source_uris=source_uris,
-                destination=destination,
-                job_config=job_config,
-                **load_kwargs,
-            )
             load_job.result()
             return load_job
         except exceptions.BadRequest as e:


### PR DESCRIPTION
A variable definition is used in the except block, so if the variable definition fails, the except block will raise another variable not defined exception.

