### PR TITLE
assert correct arguments for test in #976

### DIFF
--- a/test/test_databases/test_bigquery.py
+++ b/test/test_databases/test_bigquery.py
@@ -292,6 +292,7 @@ class TestGoogleBigQuery(FakeCredentialTest):
 
     def test_copy_s3(self):
         # setup dependencies / inputs
+        source = "s3"
         table_name = "table_name"
         bucket = "aws_bucket"
         key = "file.gzip"
@@ -317,7 +318,8 @@ class TestGoogleBigQuery(FakeCredentialTest):
 
         # check that the method did the right things
         gcs_client.copy_bucket_to_gcs.assert_called_once_with(
-            aws_source_bucket=bucket,
+            source=source,
+            source_bucket=bucket,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             gcs_sink_bucket=tmp_gcs_bucket,


### PR DESCRIPTION
There was an additional failure in #976 which I missed in #1019
I have addressed it here by changing the arguments and pytest now passes `810 passed, 190 skipped, 1 xfailed, 29 warnings in 25.60s`

It seems like the fix-copy-s3 branch is not getting linted and tested (only doc-build is being run by the "build" check) because it's behind significant changes to the CI workflow on main.