### PR TITLE
BigQuery extract table method

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1345,6 +1345,26 @@ class GoogleBigQuery(DatabaseConnector):
 
         return BigQueryTable(self, table_name)
 
+    def extract(
+        self,
+        dataset: str,
+        table_name: str,
+        gcs_bucket: str,
+        gcs_blob_name: str,
+        project: Optional[str] = None,
+    ) -> None:
+        dataset_ref = bigquery.DatasetReference(project or self.client.project, dataset)
+        table_ref = dataset_ref.table(table_name)
+        gs_destination = f"gs://{gcs_bucket}/{gcs_blob_name}"
+
+        extract_job = self.client.extract_table(
+            table_ref,
+            gs_destination,
+        )
+        extract_job.result()  # Waits for job to complete.
+
+        logger.info(f"Finished exporting query result to {gs_destination}.")
+
 
 class BigQueryTable(BaseTable):
     """BigQuery table object."""


### PR DESCRIPTION
Addresses #921 

Unlike in Redshift, you can't directly export query results to GCS. You can only extract a table.