### PR TITLE
Update mac runner to macos-12 instead of mac-latest

### DIFF
--- a/.github/workflows/tests-mac.yml
+++ b/.github/workflows/tests-mac.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ['3.8', '3.11']
         limited-dependencies: ['','TRUE']  
 
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
 


### PR DESCRIPTION
Hopefully this will fix the breaking tests that are stalling PR merges