### PR TITLE
bump braintree to 4.17.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ airtable-python-wrapper==0.13.0
 azure-storage-blob==12.3.2
 boto3>=1.17.98
 boxsdk==2.10.0
-braintree==4.0.0
+braintree==4.17.1
 bs4==0.0.1
 censusgeocode==0.4.3.post1
 civis==1.16.0


### PR DESCRIPTION
As mentioned in [this bug report](https://github.com/move-coop/parsons/issues/1007), **_the currently pinned version of braintree (4.0.0) is a yanked version_** (due to "critical bugs" -- see more [here](https://pypi.org/project/braintree/4.28.0/#history)).

While this PR bumps to _**earliest non-yanked version**_ (4.17.1)
The latest version is 4.28, however it appears 4.18-4.28 all give Deprecation Warnings
- _DeprecationWarning: Use ProtectionLevel enum instead_ 
- _DeprecationWarning: Use protection_level parameter instead_

(Thought being: handle immediate issue first, then worry about upgrade to latest, if/as needed)