### PR TITLE
Update GET helper function, add custom columns to create profile

### DIFF
--- a/parsons/mobilecommons/mobilecommons.py
+++ b/parsons/mobilecommons/mobilecommons.py
@@ -353,7 +353,8 @@ class MobileCommons:
         custom_cols = "true" if include_custom_columns else "false"
         subscriptions = "true" if include_subscriptions else "false"
 
-        phones = ",".join(phones)
+        if phones:
+            phones = ",".join(phones)
 
         params = {
             "phone_number": phones,

--- a/parsons/mobilecommons/mobilecommons.py
+++ b/parsons/mobilecommons/mobilecommons.py
@@ -151,7 +151,8 @@ class MobileCommons:
             if not empty_page:
                 # Extract data
                 response_data = response_dict["response"][first_data_key][second_data_key]
-                # When only one row of data it is returned as dict instead of list, which cannot be put into table
+                # When only one row of data it is returned as dict instead of list, which
+                # cannot be put into table
                 if isinstance(response_data, dict):
                     response_data = [response_data]
 
@@ -411,7 +412,8 @@ class MobileCommons:
                 ID of the opt-in path to send new profile through. This will determine the welcome
                 text they receive.
             custom_column_values: dict
-                Dictionary with custom column names as keys and custom column values as dictionary values
+                Dictionary with custom column names as keys and custom column values
+                as dictionary values
 
         `Returns:`
             ID of created/updated  profile

--- a/parsons/mobilecommons/mobilecommons.py
+++ b/parsons/mobilecommons/mobilecommons.py
@@ -150,7 +150,13 @@ class MobileCommons:
 
             if not empty_page:
                 # Extract data
-                response_table = Table(response_dict["response"][first_data_key][second_data_key])
+                response_data = response_dict["response"][first_data_key][second_data_key]
+                # When only one row of data it is returned as dict instead of list, which cannot be put into table
+                if isinstance(response_data, dict):
+                    response_data = [response_data]
+
+                response_table = Table(response_data)
+
                 # Append to final table
                 final_table.concat(response_table)
                 final_table.materialize()
@@ -418,9 +424,11 @@ class MobileCommons:
             "city": city,
             "state": state,
             "opt_in_path_id": opt_in_path_id,
-            **custom_column_values,
             **self.default_params,
         }
+
+        if custom_column_values:
+            params = params.merge(custom_column_values)
 
         response = self._mc_post_request("profile_update", params=params)
         return response["profile"]["id"]

--- a/parsons/mobilecommons/mobilecommons.py
+++ b/parsons/mobilecommons/mobilecommons.py
@@ -146,7 +146,7 @@ class MobileCommons:
             response_dict = self._parse_get_request(endpoint=endpoint, params=page_params)
             # Check to see if page was empty if num parameter is available
             if page_indicator == "num":
-                empty_page = int(response_dict["response"][first_data_key]["num"]) > 0
+                empty_page = int(response_dict["response"][first_data_key]["num"]) == 0
 
             if not empty_page:
                 # Extract data
@@ -376,9 +376,10 @@ class MobileCommons:
         city=None,
         state=None,
         opt_in_path_id=None,
+        custom_column_values=None,
     ):
         """
-        A function for creating a single MobileCommons profile
+        A function for creating or updating a single MobileCommons profile
 
         `Args:`
             phone: str
@@ -400,9 +401,11 @@ class MobileCommons:
             opt_in_path_id: str
                 ID of the opt-in path to send new profile through. This will determine the welcome
                 text they receive.
+            custom_column_values: dict
+                Dictionary with custom column names as keys and custom column values as dictionary values
 
         `Returns:`
-            ID of created profile
+            ID of created/updated  profile
         """
 
         params = {
@@ -415,6 +418,7 @@ class MobileCommons:
             "city": city,
             "state": state,
             "opt_in_path_id": opt_in_path_id,
+            **custom_column_values,
             **self.default_params,
         }
 

--- a/parsons/mobilecommons/mobilecommons.py
+++ b/parsons/mobilecommons/mobilecommons.py
@@ -353,6 +353,8 @@ class MobileCommons:
         custom_cols = "true" if include_custom_columns else "false"
         subscriptions = "true" if include_subscriptions else "false"
 
+        phones = ",".join(phones)
+
         params = {
             "phone_number": phones,
             "from": _format_date(first_date),


### PR DESCRIPTION
1) Update GET helper function - There was a small bug in the logic for get endpoints where pagination is controled with a "num" page indicator. In short, line 140 was returning false when it should have been returning true! 
2) Correct phone_numbers aspect of get_profiles - turns out mobile commons accepts a comma separated string of phone numbers, not a list. 
3) Added the option to write custom column data to profiles in the create_profiles method. Also updated documentation to indicate that the create_profiles method can also be used to update existing records. Considered creating a new method all together for update_profile, but it seemed a little bit redundant... 