### PR TITLE
Add option to disaggregate A/B test emails

### DIFF
--- a/parsons/ngpvan/email.py
+++ b/parsons/ngpvan/email.py
@@ -70,13 +70,13 @@ class Email(object):
         logger.debug(f"Found email {email_id}.")
         return r
 
-    def get_email_stats(self) -> Table:
+    def get_email_stats(self, aggregate_ab: bool = True) -> Table:
         """
         Get stats for all emails, aggregating any A/B tests.
 
         `Args:`
-            emails : list
-                A list of email message details.
+            aggregate_ab : bool
+                If A/B test results for emails should get aggregated.
 
         `Returns:`
             Parsons Table
@@ -95,50 +95,48 @@ class Email(object):
             email = self.get_email(fmid)
             email_list.append(email)
 
-        for email in email_list:
-            d = {}
-            d["name"] = email["name"]
-            d["createdBy"] = email["createdBy"]
-            d["dateCreated"] = email["dateCreated"]
-            d["dateModified"] = email["dateModified"]
-            d["dateScheduled"] = email["dateScheduled"]
-            d["foreignMessageId"] = email["foreignMessageId"]
-            d["recipientCount"] = 0
-            d["bounceCount"] = 0
-            d["contributionCount"] = 0
-            d["contributionTotal"] = 0
-            d["formSubmissionCount"] = 0
-            d["linksClickedCount"] = 0
-            d["machineOpenCount"] = 0
-            d["openCount"] = 0
-            d["unsubscribeCount"] = 0
-            try:
+        # Outside and inside emailMessageContentDistributions field
+        outer_fields = [
+            "name",
+            "createdBy",
+            "dateCreated",
+            "dateModified",
+            "dateScheduled",
+            "foreignMessageId",
+        ]
+        inner_fields = [
+            "recipientCount",
+            "bounceCount",
+            "contributionCount",
+            "contributionTotal",
+            "formSubmissionCount",
+            "linksClickedCount",
+            "machineOpenCount",
+            "openCount",
+            "unsubscribeCount",
+        ]
+        if aggregate_ab:
+            for email in email_list:
+                outer = {field: email[field] for field in outer_fields}
+                inner = {field: 0 for field in inner_fields}
                 for i in email["emailMessageContent"]:
-                    d["recipientCount"] += i["emailMessageContentDistributions"]["recipientCount"]
-                    d["bounceCount"] += i["emailMessageContentDistributions"]["bounceCount"]
-                    d["contributionCount"] += i["emailMessageContentDistributions"][
-                        "contributionCount"
-                    ]
-                    d["contributionTotal"] += i["emailMessageContentDistributions"][
-                        "contributionTotal"
-                    ]
-                    d["formSubmissionCount"] += i["emailMessageContentDistributions"][
-                        "formSubmissionCount"
-                    ]
-                    d["linksClickedCount"] += i["emailMessageContentDistributions"][
-                        "linksClickedCount"
-                    ]
-                    d["machineOpenCount"] += i["emailMessageContentDistributions"][
-                        "machineOpenCount"
-                    ]
-                    d["openCount"] += i["emailMessageContentDistributions"]["openCount"]
-                    d["unsubscribeCount"] += i["emailMessageContentDistributions"][
-                        "unsubscribeCount"
-                    ]
-            except TypeError as e:
-                logger.info(str(e))
-                pass
-
-            final_email_list.append(d)
+                    try:
+                        for field in inner_fields:
+                            inner[field] += i["emailMessageContentDistributions"][field]
+                    except KeyError as e:
+                        logger.info(str(e))
+                        pass
+                final_email_list.append({**outer, **inner})
+        else:
+            for email in email_list:
+                for i in email["emailMessageContent"]:
+                    outer = {field: email[field] for field in outer_fields}
+                    inner = {field: 0 for field in inner_fields}
+                    try:
+                        for field in inner_fields:
+                            inner[field] = i["emailMessageContentDistributions"][field]
+                    except KeyError as e:
+                        logger.info(str(e))
+                    final_email_list.append({**outer, **inner})
 
         return Table(final_email_list)

--- a/parsons/ngpvan/email.py
+++ b/parsons/ngpvan/email.py
@@ -128,8 +128,8 @@ class Email(object):
                     try:
                         for field in inner_fields:  # Aggregation of all inner values
                             inner[field] += i["emailMessageContentDistributions"][field]
-                            # Just replacing subject to get the last one
-                            inner["subject"] = i["subject"]
+                        # Just replacing subject to get the last one
+                        inner["subject"] = i["subject"]
                     except KeyError as e:
                         logger.info(str(e))
                         pass
@@ -143,7 +143,7 @@ class Email(object):
                     try:
                         for field in inner_fields:
                             inner[field] = i["emailMessageContentDistributions"][field]
-                            inner["subject"] = i["subject"]
+                        inner["subject"] = i["subject"]
                     except KeyError as e:
                         logger.info(str(e))
                     final_email_list.append({**outer, **inner})

--- a/test/test_van/test_email.py
+++ b/test/test_van/test_email.py
@@ -196,8 +196,6 @@ mock_response_enriched[2]["emailMessageContent"] = sample_content_single
 mock_response_enriched[3]["emailMessageContent"] = sample_content_single
 mock_response_enriched[4]["emailMessageContent"] = sample_content_full
 
-print(mock_response_enriched)
-
 
 class TestEmail(unittest.TestCase):
     def setUp(self):

--- a/test/test_van/test_email.py
+++ b/test/test_van/test_email.py
@@ -180,5 +180,5 @@ class TestEmail(unittest.TestCase):
         assert len(response_t.to_dicts()) == 5
         assert len(response_f.to_dicts()) == 6
 
-        # sassert response_t.to_dicts()[4]["recipientCount"] == 7
+        assert response_t.to_dicts()[4]["recipientCount"] == 7
         assert response_f.to_dicts()[4]["recipientCount"] == 3

--- a/test/test_van/test_email.py
+++ b/test/test_van/test_email.py
@@ -151,14 +151,20 @@ class TestEmail(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_email_message(self, m):
         m.get(
+            self.van.connection.uri + "email/message/0",
+            json=mock_response[0],
+            status_code=200,
+        )
+        m.get(
             self.van.connection.uri + "email/message/1",
             json=mock_response_enriched[0],
             status_code=200,
         )
+        response0 = self.van.get_email(0, expand=False)
+        response1 = self.van.get_email(1)
 
-        response = self.van.get_email(1)
-
-        assert_matching_tables(response, mock_response_enriched[0])
+        assert_matching_tables(response0, mock_response[0])
+        assert_matching_tables(response1, mock_response_enriched[0])
 
     @requests_mock.Mocker()
     def test_get_email_message_stats_agg(self, m):

--- a/test/test_van/test_email.py
+++ b/test/test_van/test_email.py
@@ -29,45 +29,112 @@ def assert_matching_tables(table1, table2, ignore_headers=False):
 
 os.environ["VAN_API_KEY"] = "SOME_KEY"
 
-sample_content = {
-    "name": "Test A",
-    "senderDisplayName": "Joe Biden",
-    "senderEmailAddress": "joe@biden.com",
-    "createdBy": "Joe Biden",
-    "dateCreated": "2024-02-01T11:55:00Z",
-    "emailMessageContentDistributions": {
-        "dateSent": "2024-02-01T11:55:00Z",
-        "recipientCount": 3,
-        "openCount": 1,
-        "machineOpenCount": 1,
-        "linksClickedCount": 1,
-        "unsubscribeCount": 0,
-        "bounceCount": 0,
-        "contributionTotal": 0.0,
-        "formSubmissionCount": 0,
-        "contributionCount": 0,
-    },
-}
 
-sample_content2 = {
-    "name": "Test B",
-    "senderDisplayName": "Kamala Harris",
-    "senderEmailAddress": "kamala@harris.com",
-    "createdBy": "Kamala Harris",
-    "dateCreated": "2024-02-01T11:55:00Z",
-    "emailMessageContentDistributions": {
-        "dateSent": "2024-02-01T11:55:00Z",
-        "recipientCount": 4,
-        "openCount": 2,
-        "machineOpenCount": 2,
-        "linksClickedCount": 2,
-        "unsubscribeCount": 1,
-        "bounceCount": 1,
-        "contributionTotal": 1.0,
-        "formSubmissionCount": 1,
-        "contributionCount": 1,
+sample_content_full = [
+    {
+        "name": "Email Name",
+        "senderDisplayName": "Joe Biden",
+        "senderEmailAddress": "joe@biden.org",
+        "subject": "This is Joe",
+        "createdBy": "Random Intern",
+        "dateCreated": "2023-05-17T15:04:00Z",
+        "emailMessageContentDistributions": {
+            "dateSent": "2023-05-17T15:05:00Z",
+            "recipientCount": 10,
+            "openCount": 0,
+            "linksClickedCount": 0,
+            "unsubscribeCount": 0,
+            "bounceCount": 0,
+            "contributionTotal": 0.0,
+            "formSubmissionCount": 0,
+            "contributionCount": 0,
+            "machineOpenCount": 0,
+        },
     },
-}
+    {
+        "name": "Email Name_B",
+        "senderDisplayName": "Kamala Harris",
+        "senderEmailAddress": "kamala@harris.org",
+        "subject": "This is Kamala",
+        "createdBy": "Random Intern",
+        "dateCreated": "2023-05-17T15:04:00Z",
+        "emailMessageContentDistributions": {
+            "dateSent": "2023-05-17T15:05:00Z",
+            "recipientCount": 10,
+            "openCount": 1,
+            "linksClickedCount": 1,
+            "unsubscribeCount": 1,
+            "bounceCount": 0,
+            "contributionTotal": 1.0,
+            "formSubmissionCount": 0,
+            "contributionCount": 1,
+            "machineOpenCount": 1,
+        },
+    },
+    {
+        "name": "Email Name_C",
+        "senderDisplayName": "Commander Biden",
+        "senderEmailAddress": "commander@barkbark.org",
+        "subject": "Bark Bark",
+        "createdBy": "Random Intern",
+        "dateCreated": "2023-05-17T15:04:00Z",
+        "emailMessageContentDistributions": {
+            "dateSent": "2023-05-17T15:05:00Z",
+            "recipientCount": 10,
+            "openCount": 5,
+            "linksClickedCount": 0,
+            "unsubscribeCount": 0,
+            "bounceCount": 0,
+            "contributionTotal": 0.0,
+            "formSubmissionCount": 0,
+            "contributionCount": 0,
+            "machineOpenCount": 2,
+        },
+    },
+    {
+        "name": "Email Name_Winner",
+        "senderDisplayName": "Commander Biden",
+        "senderEmailAddress": "commander@barkbark.org",
+        "subject": "Bark Bark",
+        "createdBy": "TargetedEmail InternalAPIUser",
+        "dateCreated": "2023-05-17T17:06:00Z",
+        "emailMessageContentDistributions": {
+            "dateSent": "2023-05-17T17:06:00Z",
+            "recipientCount": 100,
+            "openCount": 30,
+            "linksClickedCount": 10,
+            "unsubscribeCount": 10,
+            "bounceCount": 10,
+            "contributionTotal": 500.0,
+            "formSubmissionCount": 0,
+            "contributionCount": 3,
+            "machineOpenCount": 30,
+        },
+    },
+]
+
+sample_content_single = [
+    {
+        "name": "Email Name",
+        "senderDisplayName": "Joe Biden",
+        "senderEmailAddress": "joe@biden.org",
+        "subject": "This is Joe",
+        "createdBy": "Random Intern",
+        "dateCreated": "2023-05-17T15:04:00Z",
+        "emailMessageContentDistributions": {
+            "dateSent": "2023-05-17T15:05:00Z",
+            "recipientCount": 10,
+            "openCount": 0,
+            "linksClickedCount": 0,
+            "unsubscribeCount": 0,
+            "bounceCount": 0,
+            "contributionTotal": 0.0,
+            "formSubmissionCount": 0,
+            "contributionCount": 0,
+            "machineOpenCount": 0,
+        },
+    }
+]
 
 mock_response = [
     {
@@ -123,11 +190,11 @@ mock_response = [
 ]
 
 mock_response_enriched = deepcopy(mock_response)
-mock_response_enriched[0]["emailMessageContent"] = [sample_content]
-mock_response_enriched[1]["emailMessageContent"] = [sample_content]
-mock_response_enriched[2]["emailMessageContent"] = [sample_content]
-mock_response_enriched[3]["emailMessageContent"] = [sample_content]
-mock_response_enriched[4]["emailMessageContent"] = [sample_content, sample_content2]
+mock_response_enriched[0]["emailMessageContent"] = sample_content_single
+mock_response_enriched[1]["emailMessageContent"] = sample_content_single
+mock_response_enriched[2]["emailMessageContent"] = sample_content_single
+mock_response_enriched[3]["emailMessageContent"] = sample_content_single
+mock_response_enriched[4]["emailMessageContent"] = sample_content_full
 
 print(mock_response_enriched)
 
@@ -184,7 +251,7 @@ class TestEmail(unittest.TestCase):
         response_f = self.van.get_email_stats(aggregate_ab=False)
 
         assert len(response_t.to_dicts()) == 5
-        assert len(response_f.to_dicts()) == 6
+        assert len(response_f.to_dicts()) == 8
 
-        assert response_t.to_dicts()[4]["recipientCount"] == 7
-        assert response_f.to_dicts()[4]["recipientCount"] == 3
+        assert response_t.to_dicts()[4]["recipientCount"] == 130
+        assert response_f.to_dicts()[4]["recipientCount"] == 10

--- a/test/test_van/test_email.py
+++ b/test/test_van/test_email.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import requests_mock
+from copy import deepcopy
 from parsons import VAN, Table
 
 
@@ -28,6 +29,46 @@ def assert_matching_tables(table1, table2, ignore_headers=False):
 
 os.environ["VAN_API_KEY"] = "SOME_KEY"
 
+sample_content = {
+    "name": "Test A",
+    "senderDisplayName": "Joe Biden",
+    "senderEmailAddress": "joe@biden.com",
+    "createdBy": "Joe Biden",
+    "dateCreated": "2024-02-01T11:55:00Z",
+    "emailMessageContentDistributions": {
+        "dateSent": "2024-02-01T11:55:00Z",
+        "recipientCount": 3,
+        "openCount": 1,
+        "machineOpenCount": 1,
+        "linksClickedCount": 1,
+        "unsubscribeCount": 0,
+        "bounceCount": 0,
+        "contributionTotal": 0.0,
+        "formSubmissionCount": 0,
+        "contributionCount": 0,
+    },
+}
+
+sample_content2 = {
+    "name": "Test B",
+    "senderDisplayName": "Kamala Harris",
+    "senderEmailAddress": "kamala@harris.com",
+    "createdBy": "Kamala Harris",
+    "dateCreated": "2024-02-01T11:55:00Z",
+    "emailMessageContentDistributions": {
+        "dateSent": "2024-02-01T11:55:00Z",
+        "recipientCount": 4,
+        "openCount": 2,
+        "machineOpenCount": 2,
+        "linksClickedCount": 2,
+        "unsubscribeCount": 1,
+        "bounceCount": 1,
+        "contributionTotal": 1.0,
+        "formSubmissionCount": 1,
+        "contributionCount": 1,
+    },
+}
+
 mock_response = [
     {
         "foreignMessageId": "oK2ahdAcEe6F-QAiSCI3lA2",
@@ -50,7 +91,7 @@ mock_response = [
         "emailMessageContent": None,
     },
     {
-        "foreignMessageId": "_E1AfcnkEe6F-QAiSCI3lA2",
+        "foreignMessageId": "E1AfcnkEe6F-QAiSCI3lA2",
         "name": "Test Email 3",
         "createdBy": "Joe Biden",
         "dateCreated": "2024-02-12T15:26:00Z",
@@ -81,6 +122,15 @@ mock_response = [
     },
 ]
 
+mock_response_enriched = deepcopy(mock_response)
+mock_response_enriched[0]["emailMessageContent"] = [sample_content]
+mock_response_enriched[1]["emailMessageContent"] = [sample_content]
+mock_response_enriched[2]["emailMessageContent"] = [sample_content]
+mock_response_enriched[3]["emailMessageContent"] = [sample_content]
+mock_response_enriched[4]["emailMessageContent"] = [sample_content, sample_content2]
+
+print(mock_response_enriched)
+
 
 class TestEmail(unittest.TestCase):
     def setUp(self):
@@ -102,10 +152,33 @@ class TestEmail(unittest.TestCase):
     def test_get_email_message(self, m):
         m.get(
             self.van.connection.uri + "email/message/1",
-            json=mock_response[0],
+            json=mock_response_enriched[0],
             status_code=200,
         )
 
         response = self.van.get_email(1)
 
-        assert_matching_tables(response, mock_response[0])
+        assert_matching_tables(response, mock_response_enriched[0])
+
+    @requests_mock.Mocker()
+    def test_get_email_message_stats_agg(self, m):
+        m.get(
+            self.van.connection.uri + "email/messages",
+            json=mock_response_enriched,
+            status_code=200,
+        )
+        for resp in mock_response_enriched:
+            m.get(
+                self.van.connection.uri + f"email/message/{resp['foreignMessageId']}",
+                json=resp,
+                status_code=200,
+            )
+
+        response_t = self.van.get_email_stats(aggregate_ab=True)
+        response_f = self.van.get_email_stats(aggregate_ab=False)
+
+        assert len(response_t.to_dicts()) == 5
+        assert len(response_f.to_dicts()) == 6
+
+        # sassert response_t.to_dicts()[4]["recipientCount"] == 7
+        assert response_f.to_dicts()[4]["recipientCount"] == 3


### PR DESCRIPTION
Addresses #1059 - this gives us an optional parameter to the NGP email endpoint that lets us dis-aggregate A/B test results from the endpoint. I also did a bit of code cleanup and added some tests.