### PR TITLE
Fix misspecified tests using MagicMock().called_with()

### DIFF
--- a/docs/write_tests.rst
+++ b/docs/write_tests.rst
@@ -133,7 +133,7 @@ Now, we can test our Salesforce Parsons Connector's query method:
     # Call the query method with a fake value
     response = self.sf.query('FAKESOQL')
     # Check that our mock client's query_all method was also called with the fake value
-    assert self.sf._client.query_all.called_with('FAKESOQL')
+    self.sf._client.query_all.assert_called_with('FAKESOQL')
     # Check that the response from our query method is what we expect
     self.assertEqual(response[0]['value'], 'FAKE')
 

--- a/test/test_salesforce/test_salesforce.py
+++ b/test/test_salesforce/test_salesforce.py
@@ -49,13 +49,13 @@ class TestSalesforce(unittest.TestCase):
     def test_query(self):
         fake_soql = "FAKESOQL"
         response = self.sf.query(fake_soql)
-        assert self.sf.client.query_all.called_with(fake_soql)
+        self.sf.client.query_all.assert_called_with(fake_soql)
         self.assertEqual(response["records"][0]["Id"], "1234567890AaBbC")
 
     def test_insert(self):
         fake_data = Table([{"firstname": "Chrisjen", "lastname": "Avasarala"}])
         response = self.sf.insert_record("Contact", fake_data)
-        assert self.sf.client.bulk.Contact.insert.called_with(fake_data)
+        self.sf.client.bulk.Contact.insert.assert_called_with(fake_data.to_dicts())
         assert response[0]["created"]
 
     def test_update(self):
@@ -69,7 +69,7 @@ class TestSalesforce(unittest.TestCase):
             ]
         )
         response = self.sf.update_record("Contact", fake_data)
-        assert self.sf.client.bulk.Contact.update.called_with(fake_data)
+        self.sf.client.bulk.Contact.update.assert_called_with(fake_data.to_dicts())
         assert not response[0]["created"]
 
     def test_upsert(self):
@@ -84,7 +84,7 @@ class TestSalesforce(unittest.TestCase):
             ]
         )
         response = self.sf.upsert_record("Contact", fake_data, "id")
-        assert self.sf.client.bulk.Contact.update.called_with(fake_data)
+        self.sf.client.bulk.Contact.upsert.assert_called_with(fake_data.to_dicts(), "id")
         print(response)
         assert not response[0]["created"]
         assert response[1]["created"]
@@ -92,5 +92,5 @@ class TestSalesforce(unittest.TestCase):
     def test_delete(self):
         fake_data = Table([{"id": "1234567890AaBbC"}])
         response = self.sf.delete_record("Contact", fake_data)
-        assert self.sf.client.bulk.Contact.update.called_with(fake_data)
+        self.sf.client.bulk.Contact.delete.assert_called_with(fake_data.to_dicts())
         assert not response[0]["created"]

--- a/test/test_twilio/test_twilio.py
+++ b/test/test_twilio/test_twilio.py
@@ -17,40 +17,54 @@ class TestTwilio(unittest.TestCase):
 
         fake_sid = "FAKESID"
         self.twilio.get_account(fake_sid)
-        assert self.twilio.client.api.accounts.called_with(fake_sid)
+        self.twilio.client.api.accounts.assert_called_with(fake_sid)
 
     def test_get_accounts(self):
 
         self.twilio.get_accounts(name="MyOrg", status="active")
-        assert self.twilio.client.api.accounts.list.called_with(
+        self.twilio.client.api.accounts.list.assert_called_with(
             friendly_name="MyOrg", status="active"
         )
 
     def test_get_messages(self):
 
         self.twilio.get_messages(date_sent="2019-10-29")
-        assert self.twilio.client.messages.list.called_with(date_sent="2019-10-29")
+        self.twilio.client.messages.list.assert_called_with(
+            date_sent="2019-10-29",
+            to=None,
+            from_=None,
+            date_sent_before=None,
+            date_sent_after=None,
+        )
 
     def test_get_account_usage(self):
 
         # Make sure that it is calling the correct Twilio methods
+        self.twilio.client.usage.records.today.list.assert_not_called()
         self.twilio.get_account_usage(time_period="today")
-        assert self.twilio.client.usage.records.today.list.called_with(time_period="today")
+        self.twilio.client.usage.records.today.list.assert_called()
+
+        self.twilio.client.usage.records.last_month.list.assert_not_called()
         self.twilio.get_account_usage(time_period="last_month")
-        assert self.twilio.client.usage.records.last_month.list.called_with(
-            time_period="last_month"
-        )
+        self.twilio.client.usage.records.last_month.list.assert_called()
+
+        self.twilio.client.usage.records.this_month.list.assert_not_called()
         self.twilio.get_account_usage(time_period="this_month")
-        assert self.twilio.client.usage.records.this_month.list.called_with(
-            time_period="this_month"
-        )
+        self.twilio.client.usage.records.this_month.list.assert_called()
+
+        self.twilio.client.usage.records.yesterday.list.assert_not_called()
         self.twilio.get_account_usage(time_period="yesterday")
-        assert self.twilio.client.usage.records.today.list.called_with(time_period="yesterday")
+        self.twilio.client.usage.records.yesterday.list.assert_called()
 
         # Make sure that it is calling the correct Twilio methods
-        self.twilio.get_account_usage(time_period="daily", start_date="10-19-2019")
-        assert self.twilio.client.usage.records.daily.list.called_with(start_date="10-19-2019")
-        self.twilio.get_account_usage(time_period="monthly", start_date="10-19-2019")
-        assert self.twilio.client.usage.records.monthly.list.called_with(start_date="10-19-2019")
-        self.twilio.get_account_usage(time_period="yearly", start_date="10-19-2019")
-        assert self.twilio.client.usage.records.yearly.list.called_with(start_date="10-19-2019")
+        self.twilio.client.usage.records.daily.list.assert_not_called()
+        self.twilio.get_account_usage(group_by="daily", start_date="10-19-2019")
+        self.twilio.client.usage.records.daily.list.assert_called_with(start_date="10-19-2019")
+
+        self.twilio.client.usage.records.monthly.list.assert_not_called()
+        self.twilio.get_account_usage(group_by="monthly", start_date="10-19-2019")
+        self.twilio.client.usage.records.monthly.list.assert_called_with(start_date="10-19-2019")
+
+        self.twilio.client.usage.records.yearly.list.assert_not_called()
+        self.twilio.get_account_usage(group_by="yearly", start_date="10-19-2019")
+        self.twilio.client.usage.records.yearly.list.assert_called_with(start_date="10-19-2019")


### PR DESCRIPTION
See issue #1071 

The tests which use this method must be rewritten - some of them fail once the misspecified method is fixed, and will need to be rewritten to actually test what they intend to test.

TO DO:
- [x] Fix remaining twilio tests
- [x] Fix salesforce tests
- [x] Fix documentation recommending use of `called_with()`

BLOCKING: 
- [x] In python 3.12 it's no longer syntactical to use MagicMock().called_with(), so these fixes must be made before the python 3.12 migration can be made (#1070)

