### PR TITLE
Fix VAN create_event location_ids list bug

### DIFF
--- a/parsons/ngpvan/events.py
+++ b/parsons/ngpvan/events.py
@@ -215,7 +215,7 @@ class Events(object):
         }
 
         if location_ids:
-            event["locations"] = ([{"locationId": location_id} for location_id in location_ids],)
+            event["locations"] = [{"locationId": location_id} for location_id in location_ids]
 
         if code_ids:
             event["codes"] = [{"codeID": c} for c in code_ids]


### PR DESCRIPTION
Looks like this was defined as a list within a tuple, and events were not being associated with provided locations. Confirmed provided locations are properly associated with created events with this change.