### PR TITLE
Add methods to update phone, order user detail, and import action

### DIFF
--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -169,11 +169,31 @@ class ActionKit(object):
                 in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
                 manual/api/rest/actionprocessing.html>`_.
         `Returns:`
-            ``None``
+            ``HTTP response from the patch request``
         """
 
         resp = self.conn.patch(self._base_endpoint("user", user_id), data=json.dumps(kwargs))
         logger.info(f"{resp.status_code}: {user_id}")
+
+        return resp
+
+    def update_phone(self, phone_id, **kwargs):
+        """
+        Update a phone record.
+
+        `Args:`
+            phone_id: int
+                The phone id of the phone to update
+            **kwargs:
+                Optional arguments and fields to pass to the client. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
+        `Returns:`
+            ``HTTP response from the patch request``
+        """
+
+        resp = self.conn.patch(self._base_endpoint("phone", phone_id), data=json.dumps(kwargs))
+        logger.info(f"{resp.status_code}: {phone_id}")
 
         return resp
 
@@ -833,6 +853,28 @@ class ActionKit(object):
         resp = self.conn.patch(self._base_endpoint("order", order_id), data=json.dumps(kwargs))
         logger.info(f"{resp.status_code}: {order_id}")
 
+    def update_order_user_detail(self, user_detail_id, **kwargs):
+        """
+        Update an order user detail.
+
+        `Args:`
+            user_detail_id: int
+                The id of the order user detail to update
+            **kwargs:
+                Optional arguments and fields to pass to the client. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
+        `Returns:`
+            ``HTTP response from the patch request``
+        """
+
+        resp = self.conn.patch(
+            self._base_endpoint("orderuserdetail", user_detail_id), data=json.dumps(kwargs)
+        )
+        logger.info(f"{resp.status_code}: {user_detail_id}")
+
+        return resp
+
     def get_orderrecurring(self, orderrecurring_id):
         """
         Get an orderrecurring.
@@ -1118,6 +1160,28 @@ class ActionKit(object):
             return_full_json=True,
             **kwargs,
         )
+
+    def update_import_action(self, action_id, **kwargs):
+        """
+        Update an import action.
+
+        `Args:`
+            action_id: int
+                The action id of the import action to update
+            **kwargs:
+                Optional arguments and fields to pass to the client. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
+        `Returns:`
+            ``HTTP response from the patch request``
+        """
+
+        resp = self.conn.patch(
+            self._base_endpoint("importaction", action_id), data=json.dumps(kwargs)
+        )
+        logger.info(f"{resp.status_code}: {action_id}")
+
+        return resp
 
     def bulk_upload_csv(
         self,

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -186,8 +186,7 @@ class ActionKit(object):
                 The phone id of the phone to update
             **kwargs:
                 Optional arguments and fields to pass to the client. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
-                manual/api/rest/actionprocessing.html>`_.
+                at the /rest/v1/phone/schema/ path on any ActionKit instance.
         `Returns:`
             ``HTTP response from the patch request``
         """
@@ -862,8 +861,7 @@ class ActionKit(object):
                 The id of the order user detail to update
             **kwargs:
                 Optional arguments and fields to pass to the client. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
-                manual/api/rest/actionprocessing.html>`_.
+                at the /rest/v1/orderuserdetail/schema/ path on any ActionKit instance.
         `Returns:`
             ``HTTP response from the patch request``
         """
@@ -1170,8 +1168,7 @@ class ActionKit(object):
                 The action id of the import action to update
             **kwargs:
                 Optional arguments and fields to pass to the client. A full list can be found
-                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
-                manual/api/rest/actionprocessing.html>`_.
+                at the /rest/v1/importaction/schema/ path on any ActionKit instance.
         `Returns:`
             ``HTTP response from the patch request``
         """

--- a/test/test_action_kit.py
+++ b/test/test_action_kit.py
@@ -97,6 +97,22 @@ class TestActionKit(unittest.TestCase):
 
         assert res.status_code == 202
 
+    def test_update_phone(self):
+        # Test update phone
+
+        # Mock resp and status code
+        resp_mock = mock.MagicMock()
+        type(resp_mock.patch()).status_code = mock.PropertyMock(return_value=202)
+        self.actionkit.conn = resp_mock
+
+        res = self.actionkit.update_phone(123, type="mobile")
+        self.actionkit.conn.patch.assert_called_with(
+            "https://domain.actionkit.com/rest/v1/phone/123/",
+            data=json.dumps({"type": "mobile"}),
+        )
+
+        assert res.status_code == 202
+
     def test_update_event(self):
         # Test update event
 
@@ -453,6 +469,22 @@ class TestActionKit(unittest.TestCase):
             data=json.dumps({"account": "test"}),
         )
 
+    def test_update_order_user_detail(self):
+        # Test update order user detail
+
+        # Mock resp and status code
+        resp_mock = mock.MagicMock()
+        type(resp_mock.patch()).status_code = mock.PropertyMock(return_value=202)
+        self.actionkit.conn = resp_mock
+
+        res = self.actionkit.update_order_user_detail(123, first_name="new name")
+        self.actionkit.conn.patch.assert_called_with(
+            "https://domain.actionkit.com/rest/v1/orderuserdetail/123/",
+            data=json.dumps({"first_name": "new name"}),
+        )
+
+        assert res.status_code == 202
+
     def test_get_orders(self):
         # Test get orders
         resp_mock = mock.MagicMock()
@@ -637,6 +669,22 @@ class TestActionKit(unittest.TestCase):
             "https://domain.actionkit.com/rest/v1/action/",
             data=json.dumps({"email": "bob@bob.com", "page": "my_action"}),
         )
+
+    def test_update_import_action(self):
+        # Test update import action
+
+        # Mock resp and status code
+        resp_mock = mock.MagicMock()
+        type(resp_mock.patch()).status_code = mock.PropertyMock(return_value=202)
+        self.actionkit.conn = resp_mock
+
+        res = self.actionkit.update_import_action(123, source="new source")
+        self.actionkit.conn.patch.assert_called_with(
+            "https://domain.actionkit.com/rest/v1/importaction/123/",
+            data=json.dumps({"source": "new source"}),
+        )
+
+        assert res.status_code == 202
 
     def test_bulk_upload_table(self):
         resp_mock = mock.MagicMock()


### PR DESCRIPTION
This pull request:
- Adds methods to update phone, order user detail, and import action in ActionKit
- Adds corresponding unit tests
- Fixes code comments/documentation for the `update_user()` function