### PR TITLE
Skip empty tables in GSheets append & overwrite methods

### DIFF
--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -375,10 +375,6 @@ class GoogleSheets:
                 Otherwise, values will be entered as strings or numbers only.
         """
 
-        if not len(table.columns) and not table.num_rows:
-            logger.warning("No data provided to overwrite sheet, skipping.")
-            return
-
         # This is in here to ensure backwards compatibility with previous versions of Parsons.
         if "sheet_index" in kwargs:
             worksheet = kwargs["sheet_index"]
@@ -387,6 +383,10 @@ class GoogleSheets:
         sheet = self._get_worksheet(spreadsheet_id, worksheet)
         sheet.clear()
 
+        if not len(table.columns):
+            logger.warning("No data provided, worksheet is empty.")
+            return
+
         value_input_option = "RAW"
         if user_entered_value:
             value_input_option = "USER_ENTERED"
@@ -394,14 +394,18 @@ class GoogleSheets:
         # Add header row
         sheet.append_row(table.columns, value_input_option=value_input_option)
 
-        cells = []
-        for row_num, row in enumerate(table.data):
-            for col_num, cell in enumerate(row):
-                # We start at row #2 to keep room for the header row we added above
-                cells.append(gspread.Cell(row_num + 2, col_num + 1, row[col_num]))
+        if table.num_rows:
+            cells = []
+            for row_num, row in enumerate(table.data):
+                for col_num, _ in enumerate(row):
+                    # We start at row #2 to keep room for the header row we added above
+                    cells.append(gspread.Cell(row_num + 2, col_num + 1, row[col_num]))
 
-        # Update the data in one batch
-        sheet.update_cells(cells, value_input_option=value_input_option)
+            # Update the data in one batch
+            sheet.update_cells(cells, value_input_option=value_input_option)
+        else:
+            logger.warning("No rows provided.")
+
         logger.info("Overwrote worksheet.")
 
     def format_cells(self, spreadsheet_id, range, cell_format, worksheet=0):

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -263,7 +263,7 @@ class GoogleSheets:
         """
 
         if not table.num_rows:
-            logger.warning(f"No data provided to append, skipping.")
+            logger.warning("No data provided to append, skipping.")
             return
 
         # This is in here to ensure backwards compatibility with previous versions of Parsons.
@@ -376,7 +376,7 @@ class GoogleSheets:
         """
 
         if not len(table.columns) and not table.num_rows:
-            logger.warning(f"No data provided to overwrite sheet, skipping.")
+            logger.warning("No data provided to overwrite sheet, skipping.")
             return
 
         # This is in here to ensure backwards compatibility with previous versions of Parsons.

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -262,6 +262,10 @@ class GoogleSheets:
                 Otherwise, values will be entered as strings or numbers only.
         """
 
+        if not table.num_rows:
+            logger.warning(f"No data provided to append, skipping.")
+            return
+
         # This is in here to ensure backwards compatibility with previous versions of Parsons.
         if "sheet_index" in kwargs:
             worksheet = kwargs["sheet_index"]
@@ -299,9 +303,9 @@ class GoogleSheets:
         """
         Pastes data from a Parsons table to a Google sheet. Note that this may overwrite
         presently existing data. This function is useful for adding data to a subsection
-        if an existint sheet that will have other existing data - constrast to
+        if an existing sheet that will have other existing data - contrast to
         `overwrite_sheet` (which will fully replace any existing data) and `append_to_sheet`
-        (whuch sticks the data only after all other existing data).
+        (which sticks the data only after all other existing data).
 
         `Args:`
             spreadsheet_id: str
@@ -317,6 +321,7 @@ class GoogleSheets:
             startcol: int
                 Starting column position of pasted data. Counts from 0.
         """
+
         sheet = self._get_worksheet(spreadsheet_id, worksheet)
 
         number_of_columns = len(table.columns)
@@ -369,6 +374,10 @@ class GoogleSheets:
                 If True, will submit cell values as entered (required for entering formulas).
                 Otherwise, values will be entered as strings or numbers only.
         """
+
+        if not len(table.columns) and not table.num_rows:
+            logger.warning(f"No data provided to overwrite sheet, skipping.")
+            return
 
         # This is in here to ensure backwards compatibility with previous versions of Parsons.
         if "sheet_index" in kwargs:


### PR DESCRIPTION
If a table with no data is provided the overwrite method an error that is hard to debug is raised:
`ValueError: min() arg is an empty sequence`. We ought to just log a warning.

The [`paste_data_in_sheet` method already had a check like this](https://github.com/MoveOnOrg/parsons/blob/b02a67a34b3f9235dd2dafa89251b46dcb544ddb/parsons/google/google_sheets.py#L330).