### PR TITLE
Python3.8 Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.7
+FROM --platform=linux/amd64 python:3.8
 
 ####################
 ## Selenium setup ##

--- a/setup.py
+++ b/setup.py
@@ -89,14 +89,13 @@ def main():
         classifiers=[
             "Development Status :: 3 - Alpha",
             "Intended Audience :: Developers",
-            "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
         ],
-        python_requires=">=3.7.0,<3.13.0",
+        python_requires=">=3.8.0,<3.13.0",
         long_description=long_description,
         long_description_content_type="text/markdown",
     )


### PR DESCRIPTION
The Parsons image officially broke ... this PR swaps out the base image in the Dockerfile and officially deprecates 3.7 as a supported version (not sure the latter bit here is necessary).

![image](https://github.com/move-coop/parsons/assets/47256454/588f335f-3922-48c0-8c11-c2718812094f)
