### PR TITLE
Enhance and fix Zoom methods

### DIFF
--- a/parsons/zoom/zoom.py
+++ b/parsons/zoom/zoom.py
@@ -1,5 +1,7 @@
+import datetime
 import logging
 import uuid
+from typing import Dict, Literal, Optional
 
 from parsons import Table
 from parsons.utilities import check_env
@@ -164,7 +166,15 @@ class Zoom:
         logger.info(f"Retrieved {tbl.num_rows} users.")
         return tbl
 
-    def get_meetings(self, user_id, meeting_type="scheduled"):
+    def get_meetings(
+        self,
+        user_id,
+        meeting_type: Literal[
+            "scheduled", "live", "upcoming", "upcoming_meetings", "previous_meetings"
+        ] = "scheduled",
+        from_date: Optional[datetime.date] = None,
+        to_date: Optional[datetime.date] = None,
+    ):
         """
         Get meetings scheduled by a user.
 
@@ -192,8 +202,13 @@ class Zoom:
             Parsons Table
                 See :ref:`parsons-table` for output options.
         """
+        params: Dict[str, str] = {"type": meeting_type}
+        if from_date:
+            params["from"] = from_date.isoformat()
+        if to_date:
+            params["to"] = to_date.isoformat()
 
-        tbl = self._get_request(f"users/{user_id}/meetings", "meetings")
+        tbl = self._get_request(f"users/{user_id}/meetings", "meetings", params=params)
         logger.info(f"Retrieved {tbl.num_rows} meetings.")
         return tbl
 

--- a/parsons/zoom/zoom.py
+++ b/parsons/zoom/zoom.py
@@ -198,6 +198,10 @@ class Zoom:
                       - All the ongoing meetings.
                     * - ``upcoming``
                       - All upcoming meetings including live meetings.
+            from_date: datetime.date or None
+                Optional start date for the range of meetings to retrieve.
+            to_date: datetime.date or None
+                Optional end date for the range of meetings to retrieve.
         `Returns:`
             Parsons Table
                 See :ref:`parsons-table` for output options.


### PR DESCRIPTION
This PR makes two changes to the Zoom connector.
- get_meetings() takes new optional arguments to date filter results
- the post processing on the `get_past_meeting_poll_metadata` method is fixed