### PR TITLE
Fix typo in environment variable

### DIFF
--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -37,7 +37,7 @@ class GoogleSheets:
         env_credentials_path = str(uuid.uuid4())
         setup_google_application_credentials(
             google_keyfile_dict,
-            "GOOGLE_DRIVE_CREDENTIAL",
+            "GOOGLE_DRIVE_CREDENTIALS",
             target_env_var_name=env_credentials_path,
         )
 


### PR DESCRIPTION
This typo entered in 6dfaaec26dfee18e6f8f00f83bc7f02396f22944