### PR TITLE
Remove sshtunnel from requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,4 @@ pytest-mock==3.12.0
 pytest==8.1.1
 requests-mock==1.11.0
 testfixtures==8.1.0
-sshtunnel==0.4.0
 


### PR DESCRIPTION
This belongs in requirements.txt and also in setup.py, but not here.