### PR TITLE
Update old reference to Parsons API key type

### DIFF
--- a/docs/ngpvan.rst
+++ b/docs/ngpvan.rst
@@ -13,9 +13,10 @@ additional details and information.
 .. note::
    API Keys
       - API Keys are specific to each committee and state.
-      - There is a Parsons type API Key that can be requested via the Integrations menu on the main page.
-      	If you have an issue gaining access to this key, or an admin has questions, please email
-	<parsons@movementcooperative.org>.
+      - There was once a Parsons type API Key that could be requested via the VAN Integrations menu,
+        but that key type has been deprecated by NGPVAN. API keys should now be requested as a custom
+        integration. For additional guidance, refer to the Parsons Slack or reach out to
+        <parsons@movementcooperative.org>.
 
 
 .. warning::


### PR DESCRIPTION
Resolves #1084 by updating the language previously used to refer to the now-nonexistent "Parsons" API key type provisioned by NGPVAN, pointing users to request a custom integration instead.