### PR TITLE
Allow to_gcs_csv function to accept a gcs instance instead of creating one

### DIFF
--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -464,6 +464,7 @@ class ToFrom(object):
         self,
         bucket_name,
         blob_name,
+        gcs=None,
         app_creds=None,
         project=None,
         compression=None,
@@ -523,9 +524,11 @@ class ToFrom(object):
             **csvargs,
         )
 
-        from parsons.google.google_cloud_storage import GoogleCloudStorage
+        if not gcs:
+            from parsons.google.google_cloud_storage import GoogleCloudStorage
 
-        gcs = GoogleCloudStorage(app_creds=app_creds, project=project)
+            gcs = GoogleCloudStorage(app_creds=app_creds, project=project)
+
         gcs.put_blob(bucket_name, blob_name, local_path)
 
         if public_url:

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -464,7 +464,7 @@ class ToFrom(object):
         self,
         bucket_name,
         blob_name,
-        gcs=None,
+        gcs_client=None,
         app_creds=None,
         project=None,
         compression=None,
@@ -524,15 +524,15 @@ class ToFrom(object):
             **csvargs,
         )
 
-        if not gcs:
+        if not gcs_client:
             from parsons.google.google_cloud_storage import GoogleCloudStorage
 
-            gcs = GoogleCloudStorage(app_creds=app_creds, project=project)
+            gcs_client = GoogleCloudStorage(app_creds=app_creds, project=project)
 
-        gcs.put_blob(bucket_name, blob_name, local_path)
+        gcs_client.put_blob(bucket_name, blob_name, local_path)
 
         if public_url:
-            return gcs.get_url(bucket_name, blob_name, expires_in=public_url_expires)
+            return gcs_client.get_url(bucket_name, blob_name, expires_in=public_url_expires)
         else:
             return None
 


### PR DESCRIPTION
At TMC, we instantiate BigQuery and GCS outside of main, for dependency injection, but this function always creates a new GCS instance inside of it. This is breaking some of our code. This PR allows the user to send in a GCS instance, but should be backwards compatible and not breaking anyone else's code. 