### PR TITLE
Gcs upload table csview fix

### DIFF
--- a/parsons/google/google_cloud_storage.py
+++ b/parsons/google/google_cloud_storage.py
@@ -322,6 +322,10 @@ class GoogleCloudStorage(object):
         blob = storage.Blob(blob_name, bucket)
 
         if data_type == "csv":
+            # If a parsons Table is loaded from a CSV and has had no
+            # transformations, the Table.table object will be a petl
+            # CSVView. Once any transformations are made, the Table.table
+            # becomes a different petl class
             local_file = table.to_csv()
             content_type = "text/csv"
         elif data_type == "json":

--- a/parsons/google/google_cloud_storage.py
+++ b/parsons/google/google_cloud_storage.py
@@ -1,6 +1,5 @@
 import datetime
 import gzip
-import petl
 import logging
 import time
 import uuid
@@ -322,10 +321,6 @@ class GoogleCloudStorage(object):
         blob = storage.Blob(blob_name, bucket)
 
         if data_type == "csv":
-            # If a parsons Table is loaded from a CSV and has had no
-            # transformations, the Table.table object will be a petl
-            # CSVView. Once any transformations are made, the Table.table
-            # becomes a different petl class
             local_file = table.to_csv()
             content_type = "text/csv"
         elif data_type == "json":

--- a/parsons/google/google_cloud_storage.py
+++ b/parsons/google/google_cloud_storage.py
@@ -322,14 +322,7 @@ class GoogleCloudStorage(object):
         blob = storage.Blob(blob_name, bucket)
 
         if data_type == "csv":
-            # If a parsons Table is loaded from a CSV and has had no
-            # transformations, the Table.table object will be a petl
-            # CSVView. Once any transformations are made, the Table.table
-            # becomes a different petl class
-            if isinstance(table.table, petl.io.csv_py3.CSVView):
-                local_file = table.table.source.filename
-            else:
-                local_file = table.to_csv()
+            local_file = table.to_csv()
             content_type = "text/csv"
         elif data_type == "json":
             local_file = table.to_json()


### PR DESCRIPTION
A quick fix because it seems like the attributes for a CSVView isn't consistent across ALL views, (i.e. I'v  been getting errors like `AttributeError: 'URLSource' object has no attribute 'filename'`, which is indeed true when I looked at the object. Treating it as a normal csv seemed to have done the trick!