### PR TITLE
Use ruff's recommended github output format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           uv pip install --system -r requirements-dev.txt
       - name: Lint
         run: |
-          ruff check parsons/ test/ useful_resources/
+          ruff check --output-format=github parsons/ test/ useful_resources/
       - name: Tests
         run: pytest -rf test/
       - name: Format


### PR DESCRIPTION
This adds the `--output-format=github` arg to the ruff check command so that github can annotate PRs and create links in the failure messages to the offending lines of code.

https://docs.astral.sh/ruff/integrations/#github-actions