### PR TITLE
fix gmail test failing with invalid email address

### DIFF
--- a/test/test_gmail/test_gmail.py
+++ b/test/test_gmail/test_gmail.py
@@ -7,7 +7,6 @@ import shutil
 import base64
 import email
 
-
 _dir = os.path.dirname(__file__)
 
 
@@ -516,8 +515,9 @@ class TestGmail(unittest.TestCase):
             {"email": "<sender@email.com>", "expected": True},
             {"email": "Sender sender@email.com", "expected": False},
             {"email": "Sender <sender2email.com>", "expected": False},
-            {"email": "Sender <sender@email,com>", "expected": True},
-            {"email": "Sender <sender+alias@email,com>", "expected": True},
+            {"email": "Sender <sender@email,com>", "expected": False},
+            {"email": "Sender <sender+alias@email.com>", "expected": True},
+            {"email": "Sender <sender+alias@email,com>", "expected": False},
         ]
 
         for e in emails:


### PR DESCRIPTION
not sure why this didn't show up yet via github actions but I just downloaded the main branch and ran pytest locally and was getting a failed test here because ,com is not valid but the test expects it to validate...