### PR TITLE
Add skipMatching to apply_response()

### DIFF
--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -587,6 +587,7 @@ class People(object):
         omit_contact=False,
         phone=None,
         campaignId=None,
+        skip_matching=False,
     ):
         """
         Apply responses such as survey questions, activist codes, and volunteer actions
@@ -624,6 +625,8 @@ class People(object):
                 `Optional`; Phone number of any type (Work, Cell, Home)
             campaignId: int
                 `Optional`; a valid Campaign ID.
+            skip_matching: boolean
+                `Optional`; if set to true, skips matching/de-duping of contact history. Defaults to a null value, aka false.
         `Returns:`
             ``True`` if successful
 
@@ -652,6 +655,7 @@ class People(object):
                 "dateCanvassed": date_canvassed,
                 "omitActivistCodeContactHistory": omit_contact,
                 "campaignId": campaignId,
+                "skipMatching": skip_matching
             },
             "resultCodeId": result_code_id,
         }

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -655,7 +655,7 @@ class People(object):
                 "dateCanvassed": date_canvassed,
                 "omitActivistCodeContactHistory": omit_contact,
                 "campaignId": campaignId,
-                "skipMatching": skip_matching
+                "skipMatching": skip_matching,
             },
             "resultCodeId": result_code_id,
         }


### PR DESCRIPTION
Responding to this issue - https://github.com/move-coop/parsons/issues/1133

Adding skipMatching() to the canvass context for apply response method!