### PR TITLE
Update Dockerfile  with uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ ENV DISPLAY=:99
 RUN mkdir /src
 
 COPY requirements.txt /src/
-RUN pip install -r /src/requirements.txt
+RUN pip install uv
+RUN uv pip install --system -r /src/requirements.txt
 
 COPY . /src/
 WORKDIR /src


### PR DESCRIPTION
The dockerhub workflow is timing out due to a 4 hour long dependency resolution issue when using pip.
This uses uv instead, which was a solution when this happened in a recent PR.