### PR TITLE
Postgres copy explicates columns and column order

### DIFF
--- a/parsons/databases/postgres/postgres.py
+++ b/parsons/databases/postgres/postgres.py
@@ -87,7 +87,7 @@ class Postgres(PostgresCore, Alchemy, DatabaseConnector):
                 self.query_with_connection(sql, connection, commit=False)
                 logger.info(f"{table_name} created.")
 
-            sql = f"COPY {table_name} ({','.join(tbl.columns)}) FROM STDIN CSV HEADER;"
+            sql = f"""COPY "{table_name}" ("{'","'.join(tbl.columns)}") FROM STDIN CSV HEADER;"""
 
             with self.cursor(connection) as cursor:
                 cursor.copy_expert(sql, open(tbl.to_csv(), "r"))

--- a/parsons/databases/postgres/postgres.py
+++ b/parsons/databases/postgres/postgres.py
@@ -125,13 +125,18 @@ class PostgresTable(BaseTable):
         sql = f"""
             SELECT *
             FROM {self.table}
-            WHERE "{updated_at_column}" > %s
         """
+        parameters = []
+
+        if cutoff_value is not None:
+            sql += f'WHERE "{updated_at_column}" > %s'
+            parameters.append(cutoff_value)
+
         if chunk_size:
             sql += f" LIMIT {chunk_size}"
 
         sql += f" OFFSET {offset}"
 
-        result = self.db.query(sql, parameters=[cutoff_value])
+        result = self.db.query(sql, parameters=parameters)
 
         return result

--- a/parsons/databases/postgres/postgres.py
+++ b/parsons/databases/postgres/postgres.py
@@ -87,7 +87,7 @@ class Postgres(PostgresCore, Alchemy, DatabaseConnector):
                 self.query_with_connection(sql, connection, commit=False)
                 logger.info(f"{table_name} created.")
 
-            sql = f"COPY {table_name} FROM STDIN CSV HEADER;"
+            sql = f"COPY {table_name} ({','.join(tbl.columns)}) FROM STDIN CSV HEADER;"
 
             with self.cursor(connection) as cursor:
                 cursor.copy_expert(sql, open(tbl.to_csv(), "r"))

--- a/parsons/databases/postgres/postgres_core.py
+++ b/parsons/databases/postgres/postgres_core.py
@@ -226,9 +226,9 @@ class PostgresCore(PostgresCreateStatement):
         # Extract the table and schema from this. If no schema is detected then
         # will default to the public schema.
         try:
-            schema, table = table_name.lower().split(".", 1)
+            schema, table = table_name.split(".", 1)
         except ValueError:
-            schema, table = "public", table_name.lower()
+            schema, table = "public", table_name
 
         with self.cursor(connection) as cursor:
             # Check in pg tables for the table


### PR DESCRIPTION
Without this change, the Postgres copy method only works if the Table has the same columns in the same order as the destination table. With this change, the source table can have a subset of columns in a different order but still successfully load to the destination table.