### PR TITLE
pin python 3.12.3 for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,24 +27,24 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python-version:
-          - "3.12"
-          - "3.11"
-          - "3.10"
-          - "3.9"
-          - "3.8"
+          - "3.12.3"
+          - "3.11.9"
+          - "3.10.14"
+          - "3.9.19"
+          - "3.8.18"
         limited-dependencies:
           - ""
           - "TRUE"
         include:
           - os: macos-latest
-            python-version: "3.12"
+            python-version: "3.12.3"
           - os: macos-latest
-            python-version: "3.12"
+            python-version: "3.12.3"
             limited-dependencies: "TRUE"
           - os: macos-latest
-            python-version: "3.8"
+            python-version: "3.8.18"
           - os: macos-latest
-            python-version: "3.8"
+            python-version: "3.8.18"
             limited-dependencies: "TRUE"
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
there is a breaking change to email.parseaddr standard library package on all recent patches of all python versions

see https://docs.python.org/3.8/library/email.utils.html#email.utils.parseaddr

Alternatively we should update the test to work with the most recent patches of python versions