### PR TITLE
Fix NGPVAN _people_search arbitrary fields feature

### DIFF
--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -343,7 +343,7 @@ class People(object):
                 id = match_json["vanId"]
 
         if kwargs:
-            match_json.update(kwargs)
+            json.update(kwargs)
 
         url = "people/"
 


### PR DESCRIPTION
This is a followup and fix to #916, `kwargs` were being passed to the wrong variable