### PR TITLE
Remove support for Python 3.8 (& fix failing MacOs 3.9 tests)

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -32,6 +32,10 @@ jobs:
             - name: Install uv
               uses: install-pinned/uv@de03c60d508703a83d3f8f49afcf1249590ecda1  # 0.4.12
 
+            - name: Patch install error when using Python 3.9, limited dependencies, and MacOS
+              if: ${{ matrix.limited-dependencies }} == True and ${{ matrix.os }} == "macos-latest" and ${{ matrix.python-version }} == "3.9"
+              run: uv pip install --system psycopg2-binary==2.9.9
+
             - name: Install dependencies
               env:
                   PARSONS_LIMITED_DEPENDENCIES: ${{ matrix.limited-dependencies }}
@@ -159,6 +163,10 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: pip
+
+            - name: Patch install error when using Python 3.9, limited dependencies, and MacOS
+              if: ${{ matrix.limited-dependencies }} == True and ${{ matrix.os }} == "macos-latest" and ${{ matrix.python-version }} == "3.9"
+              run: uv pip install --system psycopg2-binary==2.9.9
 
             - name: Install dependencies
               env:

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+                python-version: ["3.9", "3.10", "3.11", "3.12"]
                 os: ["ubuntu-latest", "windows-latest", "macos-latest"]
                 limited-dependencies: ["", "TRUE"]
 
@@ -140,7 +140,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+                python-version: ["3.9", "3.10", "3.11", "3.12"]
                 os: ["ubuntu-latest", "windows-latest", "macos-latest"]
                 limited-dependencies: ["", "TRUE"]
 

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -166,7 +166,7 @@ jobs:
 
             - name: Patch install error when using Python 3.9, limited dependencies, and MacOS
               if: ${{ matrix.limited-dependencies }} == True and ${{ matrix.os }} == "macos-latest" and ${{ matrix.python-version }} == "3.9"
-              run: uv pip install --system psycopg2-binary==2.9.9
+              run: pip install --system psycopg2-binary==2.9.9
 
             - name: Install dependencies
               env:

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -166,7 +166,7 @@ jobs:
 
             - name: Patch install error when using Python 3.9, limited dependencies, and MacOS
               if: ${{ matrix.limited-dependencies }} == True and ${{ matrix.os }} == "macos-latest" and ${{ matrix.python-version }} == "3.9"
-              run: pip install --system psycopg2-binary==2.9.9
+              run: pip install psycopg2-binary==2.9.9
 
             - name: Install dependencies
               env:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project is maintained by [The Movement Cooperative](https://movementcoopera
 after [Lucy Parsons](https://en.wikipedia.org/wiki/Lucy_Parsons). The Movement Cooperative is a member-led organization
 focused on providing data, tools, and strategic support for the progressive community.
 
-Parsons is only supported for Python 3.8-12.
+Parsons is only supported for Python 3.9-12.
 
 ## Table of Contents
 

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -659,21 +659,13 @@ class ETL(object):
             orig.concat(melted_list)
             # Add unique id column by hashing all the other fields
             if "uid" not in self.columns:
-                if sys.version_info.minor >= 9:
-                    orig.add_column(
-                        "uid",
-                        lambda row: hashlib.md5(
-                            str.encode("".join([str(x) for x in row])), usedforsecurity=False
-                        ).hexdigest(),
-                    )
-                elif sys.version_info.minor < 9:
-                    orig.add_column(
-                        "uid",
-                        lambda row: hashlib.md5(  # nosec B324
-                            str.encode("".join([str(x) for x in row]))
-                        ).hexdigest(),
-                    )
-                orig.move_column("uid", 0)
+                orig.add_column(
+                    "uid",
+                    lambda row: hashlib.md5(
+                        str.encode("".join([str(x) for x in row])), usedforsecurity=False
+                    ).hexdigest(),
+                )
+                orig.move_column("uid", 0)             
 
             # Rename value column in case this is done again to this Table
             orig.rename_column("value", f"{column}_value")
@@ -684,18 +676,12 @@ class ETL(object):
         else:
             orig = self.remove_column(column)
             # Add unique id column by hashing all the other fields
-            if sys.version_info.minor >= 9:
-                melted_list.add_column(
-                    "uid",
-                    lambda row: hashlib.md5(
-                        str.encode("".join([str(x) for x in row])), usedforsecurity=False
-                    ).hexdigest(),
-                )
-            elif sys.version_info.minor < 9:
-                melted_list.add_column(
-                    "uid",
-                    lambda row: hashlib.md5(str.encode("".join([str(x) for x in row]))).hexdigest(),  # nosec B324
-                )
+            melted_list.add_column(
+                "uid",
+                lambda row: hashlib.md5(
+                    str.encode("".join([str(x) for x in row])), usedforsecurity=False
+                ).hexdigest(),
+            )
             melted_list.move_column("uid", 0)
             output = melted_list
 

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -664,7 +664,7 @@ class ETL(object):
                         str.encode("".join([str(x) for x in row])), usedforsecurity=False
                     ).hexdigest(),
                 )
-                orig.move_column("uid", 0)             
+                orig.move_column("uid", 0)
 
             # Rename value column in case this is done again to this Table
             orig.rename_column("value", f"{column}_value")

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import petl
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ line-length = 100
 indent-width = 4
 
 # Assume Python 3.8
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.

--- a/setup.py
+++ b/setup.py
@@ -94,13 +94,12 @@ def main():
         classifiers=[
             "Development Status :: 3 - Alpha",
             "Intended Audience :: Developers",
-            "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
         ],
-        python_requires=">=3.8.0,<3.13.0",
+        python_requires=">=3.9.0,<3.13.0",
         long_description=long_description,
         long_description_content_type="text/markdown",
     )


### PR DESCRIPTION
Not sure what to do about the test failures of 3.9 and higher, but we can treat them separately.

For the record, there appear to be two distinct issues, a slightly older one where the combo of Mac, Python 3.9, and limited dependencies leads to [a psycopg2 install error](https://github.com/move-coop/parsons/actions/runs/11957548537/job/33334963382?pr=1192#step:5:24) and then one that's an issue for all limited dependency installs related to [this pydantic release](https://github.com/pydantic/pydantic/issues/10910) - the latter issue will hopefully have an easy fix soon but I'm not sure about the former.