### PR TITLE
Update Sphinx to 8.1.3, sphinx-rtd-theme to 3.0.0 and myst-parser to 4.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -r ../requirements.txt
-Sphinx==5.3.0
+Sphinx==8.1.3
 sphinx-rtd-theme==3.0.0
 myst-parser==1.0.0
 sphinx-multiversion

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -r ../requirements.txt
 Sphinx==8.1.3
 sphinx-rtd-theme==3.0.0
-myst-parser==1.0.0
+myst-parser==4.0.0
 sphinx-multiversion

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -r ../requirements.txt
 Sphinx==5.3.0
-sphinx-rtd-theme==2.0.0
+sphinx-rtd-theme==3.0.0
 myst-parser==1.0.0
 sphinx-multiversion


### PR DESCRIPTION
Addresses this test failure: https://app.circleci.com/pipelines/github/move-coop/parsons/6091/workflows/95129bb5-5b40-464e-b95f-f36f6712c732/jobs/7680?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary

Bumping Sphinx (see #1201) and myst-parser (#1199) too for circularity reasons