### PR TITLE
Parsons 4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ def main():
 
     setup(
         name="parsons",
-        version="3.2.1",
+        version="4",
         author="The Movement Cooperative",
         author_email="info@movementcooperative.org",
         url="https://github.com/move-coop/parsons",


### PR DESCRIPTION
Got the version number wrong, because I forgot this release drops Python 3.8 support, which is a breaking change.