### PR TITLE
Prefer float over int for bigquery type coercion

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1236,6 +1236,8 @@ class GoogleBigQuery(DatabaseConnector):
             not_none_petl_types = [i for i in petl_types if i != "NoneType"]
             if "str" in petl_types:
                 best_type = "str"
+            elif ("int" in petl_types) and ("float" in petl_types):
+                best_type = "float"
             elif not_none_petl_types:
                 best_type = not_none_petl_types[0]
             else:


### PR DESCRIPTION
We encountered a situation where a parsons table had a column with `int`, `float` and `NoneType` values. Bigquery kept complaining about there being `float`s in an `int` column, so it seemed like the schema generation wasn't behaving properly. This fix specifically ensures that the schema chooses `float` when both `float` and `int` are present in the petl_types.