### PR TITLE
Dev tool updates

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -2,9 +2,7 @@ name: Python checks
 
 on:
     push:
-        branches: [ "main", "major-release" ]
     pull_request:
-        branches: [ "main", "major-release" ]
     workflow_dispatch:
 
 permissions:

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -25,7 +25,7 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -54,7 +54,7 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Set up Python 3.12
-              uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
               with:
                   python-version: "3.12"
 
@@ -76,7 +76,7 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Set up Python 3.12
-              uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
               with:
                   python-version: "3.12"
 
@@ -98,7 +98,7 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Set up Python 3.12
-              uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
               with:
                   python-version: "3.12"
 
@@ -120,7 +120,7 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Set up Python 3.12
-              uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
               with:
                   python-version: "3.12"
 
@@ -159,7 +159,7 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: pip

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -30,7 +30,7 @@ jobs:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install uv
-              uses: install-pinned/uv@42b3e2a67abaefa8cd01c6f53ac3e86b4b420d4a  # 0.4.12
+              uses: install-pinned/uv@5b839da9b8ff8cba3562ea328e09d977ca162ed4  # 0.5.25
 
             - name: Patch install error when using Python 3.9, limited dependencies, and MacOS
               if: ${{ matrix.limited-dependencies }} == True and ${{ matrix.os }} == "macos-latest" and ${{ matrix.python-version }} == "3.9"
@@ -59,7 +59,7 @@ jobs:
                   python-version: "3.12"
 
             - name: Install uv
-              uses: install-pinned/uv@42b3e2a67abaefa8cd01c6f53ac3e86b4b420d4a  # 0.4.12
+              uses: install-pinned/uv@5b839da9b8ff8cba3562ea328e09d977ca162ed4  # 0.5.25
 
             - name: Install dependencies
               run: |
@@ -81,7 +81,7 @@ jobs:
                   python-version: "3.12"
 
             - name: Install uv
-              uses: install-pinned/uv@42b3e2a67abaefa8cd01c6f53ac3e86b4b420d4a  # 0.4.12
+              uses: install-pinned/uv@5b839da9b8ff8cba3562ea328e09d977ca162ed4  # 0.5.25
 
             - name: Install dependencies
               run: |
@@ -103,7 +103,7 @@ jobs:
                   python-version: "3.12"
 
             - name: Install uv
-              uses: install-pinned/uv@42b3e2a67abaefa8cd01c6f53ac3e86b4b420d4a  # 0.4.12
+              uses: install-pinned/uv@5b839da9b8ff8cba3562ea328e09d977ca162ed4  # 0.5.25
 
             - name: Install bandit
               run: |
@@ -125,7 +125,7 @@ jobs:
                   python-version: "3.12"
 
             - name: Install uv
-              uses: install-pinned/uv@42b3e2a67abaefa8cd01c6f53ac3e86b4b420d4a  # 0.4.12
+              uses: install-pinned/uv@5b839da9b8ff8cba3562ea328e09d977ca162ed4  # 0.5.25
 
             - name: Install dependencies
               run: |

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -65,7 +65,7 @@ jobs:
 
             - name: Run ruff format
               run: |
-                ruff format --diff --target-version=py38 .
+                ruff format --diff --target-version=py39 .
 
     ruff:
         runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.9.3
     hooks:
-      # Run the linter.
       - id: ruff
         args: [ --fix ]
-      # Run the formatter.
       - id: ruff-format

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Testing Requirements
-bandit[toml]==1.8.0
+bandit[toml]==1.8.2
 coverage==7.6.1
 pycodestyle==2.12.1
 pytest-datadir==1.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,5 @@ pytest-datadir==1.5.0
 pytest-mock==3.14.0
 pytest==8.3.3
 requests-mock==1.12.1
-ruff==0.6.9
+ruff==0.9.3
 testfixtures==8.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ coverage==7.6.1
 pycodestyle==2.12.1
 pytest-datadir==1.5.0
 pytest-mock==3.14.0
-pytest==8.3.3
+pytest==8.3.4
 requests-mock==1.12.1
 ruff==0.9.3
 testfixtures==8.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 # Testing Requirements
 bandit[toml]==1.8.2
 coverage==7.6.1
-pycodestyle==2.12.1
 pytest-datadir==1.5.0
 pytest-mock==3.14.0
 pytest==8.3.4


### PR DESCRIPTION
Notes:
ruff format now targets python 3.9+ since this is the lowest version we support.
ruff changes required some reformatting of files.
pycodestyle was in requirements-dev.txt but not used.
python-checks.yml workflow now runs on commits pushed to any branches, not just main and major-release.
pre-commit updated with new ruff version to match CI workflow (as this does not pull from requirements-dev.txt/ installed version)