### PR TITLE
Remove and/or resolve "NO Quality Assurance" tags

### DIFF
--- a/parsons/action_builder/action_builder.py
+++ b/parsons/action_builder/action_builder.py
@@ -182,7 +182,7 @@ class ActionBuilder(object):
                 retrieved or edited. Not necessary if supplied when instantiating the class.
         `Returns:`
             Dict containing Action Builder entity data.
-        """  # noqa: E501
+        """
 
         name_keys = ("name", "action_builder:name", "given_name")
         error = "Must provide data with name or given_name when inserting new record"
@@ -224,7 +224,7 @@ class ActionBuilder(object):
                 retrieved or edited. Not necessary if supplied when instantiating the class.
         `Returns:`
             Dict containing Action Builder entity data.
-        """  # noqa: E501
+        """
 
         campaign = self._campaign_check(campaign)
 
@@ -401,7 +401,7 @@ class ActionBuilder(object):
                 if the Connection exists and has `inactive` set to True. True by default.
         `Returns:`
             Dict containing Action Builder connection data.
-        """  # noqa: E501
+        """
 
         # Check that there are exactly two identifiers and that campaign is provided first
         if not isinstance(identifiers, list):

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -1282,7 +1282,7 @@ class ActionKit(object):
         `Returns`:
             dict
                 The response json
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         if not email or ak_id:
             raise ValueError("One of email or ak_id is required.")
@@ -1353,7 +1353,7 @@ class ActionKit(object):
                 success: whether upload was successful
                 progress_url: an API URL to get progress on upload processing
                 res: requests http response object
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         # self.conn defaults to JSON, but this has to be form/multi-part....
         upload_client = self._conn({"accepts": "application/json"})
@@ -1422,7 +1422,7 @@ class ActionKit(object):
                 success: bool -- whether upload was successful (individual rows may not have been)
                 results: [dict] -- This is a list of the full results.
                          progress_url and res for any results
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         import_page = check_env.check("ACTION_KIT_IMPORTPAGE", import_page)
         upload_tables = self._split_tables_no_empties(

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -1282,7 +1282,7 @@ class ActionKit(object):
         `Returns`:
             dict
                 The response json
-        """  # noqa: E501
+        """
 
         if not email or ak_id:
             raise ValueError("One of email or ak_id is required.")
@@ -1353,7 +1353,7 @@ class ActionKit(object):
                 success: whether upload was successful
                 progress_url: an API URL to get progress on upload processing
                 res: requests http response object
-        """  # noqa: E501
+        """
 
         # self.conn defaults to JSON, but this has to be form/multi-part....
         upload_client = self._conn({"accepts": "application/json"})
@@ -1422,7 +1422,7 @@ class ActionKit(object):
                 success: bool -- whether upload was successful (individual rows may not have been)
                 results: [dict] -- This is a list of the full results.
                          progress_url and res for any results
-        """  # noqa: E501
+        """
 
         import_page = check_env.check("ACTION_KIT_IMPORTPAGE", import_page)
         upload_tables = self._split_tables_no_empties(

--- a/parsons/azure/azure_blob_storage.py
+++ b/parsons/azure/azure_blob_storage.py
@@ -120,7 +120,7 @@ class AzureBlobStorage(object):
                 for more info.
         `Returns:`
             `ContainerClient`
-        """  # noqa
+        """
 
         container_client = self.client.create_container(
             container_name, metadata=metadata, public_access=public_access, **kwargs
@@ -303,7 +303,7 @@ class AzureBlobStorage(object):
                 provided to that class directly.
         `Returns:`
             `BlobClient`
-        """  # noqa
+        """
 
         blob_client = self.get_blob(container_name, blob_name)
 

--- a/parsons/bloomerang/bloomerang.py
+++ b/parsons/bloomerang/bloomerang.py
@@ -117,7 +117,7 @@ class Bloomerang(object):
             **kwargs:`
                 Fields to include, e.g., FirstName = 'Rachel'.
 
-                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Constituents/post_constituent>`_. # noqa
+                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Constituents/post_constituent>`_.
         """
         return self._base_create("constituent", **kwargs)
 
@@ -129,7 +129,7 @@ class Bloomerang(object):
             **kwargs:`
                 Fields to update, e.g., FirstName = 'RJ'.
 
-                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Constituents/put_constituent__id_>`_. # noqa
+                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Constituents/put_constituent__id_>`_.
         """
         return self._base_update("constituent", entity_id=constituent_id, **kwargs)
 
@@ -189,7 +189,7 @@ class Bloomerang(object):
             **kwargs:`
                 Fields to include, e.g., CreditCardType = 'Visa'.
 
-                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Transactions/post_transaction>`_. # noqa
+                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Transactions/post_transaction>`_.
         """
         return self._base_create("transaction", **kwargs)
 
@@ -201,7 +201,7 @@ class Bloomerang(object):
             **kwargs:`
                 Fields to update, e.g., CreditCardType = 'Visa'.
 
-                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Transactions/put_transaction__id_>`_. # noqa
+                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Transactions/put_transaction__id_>`_.
         """
         return self._base_update("transaction", entity_id=transaction_id, **kwargs)
 
@@ -281,7 +281,7 @@ class Bloomerang(object):
             **kwargs:`
                 Fields to include, e.g., Channel = "Email".
 
-                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Interactions/post_interaction>`_. # noqa
+                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Interactions/post_interaction>`_.
         """
         return self._base_create("interaction", **kwargs)
 
@@ -293,7 +293,7 @@ class Bloomerang(object):
             **kwargs:`
                 Fields to update, e.g., EmailAddress = "user@example.com".
 
-                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Interactions/put_interaction__id_>`_. # noqa
+                See the Bloomerang API docs for a full list of `fields <https://bloomerang.co/features/integrations/api/rest-api#/Interactions/put_interaction__id_>`_.
         """
         return self._base_update("interaction", entity_id=interaction_id, **kwargs)
 

--- a/parsons/civis/civisclient.py
+++ b/parsons/civis/civisclient.py
@@ -119,7 +119,7 @@ class CivisClient(object):
                 the future object.
         `Returns`
             ``None`` or ``civis.CivisFuture``
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         fut = civis.io.dataframe_to_civis(
             table_obj.to_dataframe(),

--- a/parsons/civis/civisclient.py
+++ b/parsons/civis/civisclient.py
@@ -17,7 +17,7 @@ class CivisClient(object):
             Option settings for the client that are `described in the documentation <https://civis-python.readthedocs.io/en/stable/client.html#civis.APIClient>`_.
     `Returns:`
         Civis class
-    """  # noqa: E501
+    """
 
     def __init__(self, db=None, api_key=None, **kwargs):
         self.db = check_env.check("CIVIS_DATABASE", db)
@@ -27,7 +27,7 @@ class CivisClient(object):
         The Civis API client. Utilize this attribute to access to lower level and more
         advanced methods which might not be surfaced in Parsons. A list of the methods
         can be found by reading the Civis API client `documentation <https://civis-python.readthedocs.io/en/stable/client.html>`_.
-        """  # noqa: E501
+        """
 
     def query(self, sql, preview_rows=10, polling_interval=None, hidden=True, wait=True):
         """
@@ -90,7 +90,7 @@ class CivisClient(object):
     ):
         """
         Write the table to a Civis Redshift cluster. Additional key word
-        arguments can passed to `civis.io.dataframe_to_civis()  <https://civis-python.readthedocs.io/en/v1.9.0/generated/civis.io.dataframe_to_civis.html#civis.io.dataframe_to_civis>`_ # noqa: E501
+        arguments can passed to `civis.io.dataframe_to_civis()  <https://civis-python.readthedocs.io/en/v1.9.0/generated/civis.io.dataframe_to_civis.html#civis.io.dataframe_to_civis>`_
 
         `Args`
             table_obj: obj
@@ -119,7 +119,7 @@ class CivisClient(object):
                 the future object.
         `Returns`
             ``None`` or ``civis.CivisFuture``
-        """  # noqa: E501
+        """
 
         fut = civis.io.dataframe_to_civis(
             table_obj.to_dataframe(),

--- a/parsons/copper/copper.py
+++ b/parsons/copper/copper.py
@@ -279,20 +279,20 @@ class Copper(object):
 
         # Unpack all list columns
         if len(list_cols) > 0:
-            for l in list_cols:  # noqa E741
+            for column in list_cols:
                 # Check for nested data
                 list_rows = obj_table.select_rows(
-                    lambda row: isinstance(row[l], list)
-                    and any(isinstance(x, dict) for x in row[l])
+                    lambda row: isinstance(row[column], list)
+                    and any(isinstance(x, dict) for x in row[column])
                 )
                 # Add separate long table for each column with nested data
                 if list_rows.num_rows > 0:
-                    logger.debug(l, "is a nested column")
-                    if len([x for x in cols if x["name"] == l]) == 1:
+                    logger.debug(column, "is a nested column")
+                    if len([x for x in cols if x["name"] == column]) == 1:
                         table_list.append(
                             {
-                                "name": f"{obj_type}_{l}",
-                                "tbl": obj_table.long_table(["id"], l),
+                                "name": f"{obj_type}_{column}",
+                                "tbl": obj_table.long_table(["id"], column),
                             }
                         )
                     else:
@@ -300,8 +300,8 @@ class Copper(object):
                         continue
                 else:
                     if tidy is False:
-                        logger.debug(l, "is a normal list column")
-                        obj_table.unpack_list(l)
+                        logger.debug(column, "is a normal list column")
+                        obj_table.unpack_list(column)
 
         # Unpack all dict columns
         if len(dict_cols) > 0 and tidy is False:

--- a/parsons/copper/copper.py
+++ b/parsons/copper/copper.py
@@ -126,7 +126,7 @@ class Copper(object):
                 * people_custom_fields
                 * people_socials
                 * people_websites
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         return self.get_standard_object("people", filters=filters, tidy=tidy)
 
@@ -151,7 +151,7 @@ class Copper(object):
                 * companies_custom_fields
                 * companies_socials
                 * companies_websites
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         return self.get_standard_object("companies", filters=filters, tidy=tidy)
 
@@ -171,7 +171,7 @@ class Copper(object):
         `Returns:`
             List of dicts of Parsons Tables:
                 * activities
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         return self.get_standard_object("activities", filters=filters, tidy=tidy)
 
@@ -192,7 +192,7 @@ class Copper(object):
             List of dicts of Parsons Tables:
                 * opportunities
                 * opportunities_custom_fields
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         return self.get_standard_object("opportunities", filters=filters, tidy=tidy)
 
@@ -218,7 +218,7 @@ class Copper(object):
                 * custom_fields
                 * custom_fields_available
                 * custom_fields_options
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         logger.info("Retrieving custom fields.")
         blob = self.paginate_request("/custom_field_definitions/", req_type="GET")
@@ -236,7 +236,7 @@ class Copper(object):
         `Returns:`
             List of dicts of Parsons Tables:
                 * activitiy_types
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         logger.info("Retrieving activity types.")
 
@@ -260,7 +260,7 @@ class Copper(object):
         `Returns:`
             Parsons Table
                 See :ref:`parsons-table` for output options.
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         response = self.paginate_request("/contact_types/", req_type="GET")
         return Table(response)

--- a/parsons/copper/copper.py
+++ b/parsons/copper/copper.py
@@ -126,7 +126,7 @@ class Copper(object):
                 * people_custom_fields
                 * people_socials
                 * people_websites
-        """  # noqa: E501
+        """
 
         return self.get_standard_object("people", filters=filters, tidy=tidy)
 
@@ -151,7 +151,7 @@ class Copper(object):
                 * companies_custom_fields
                 * companies_socials
                 * companies_websites
-        """  # noqa: E501
+        """
 
         return self.get_standard_object("companies", filters=filters, tidy=tidy)
 
@@ -171,7 +171,7 @@ class Copper(object):
         `Returns:`
             List of dicts of Parsons Tables:
                 * activities
-        """  # noqa: E501
+        """
 
         return self.get_standard_object("activities", filters=filters, tidy=tidy)
 
@@ -192,7 +192,7 @@ class Copper(object):
             List of dicts of Parsons Tables:
                 * opportunities
                 * opportunities_custom_fields
-        """  # noqa: E501
+        """
 
         return self.get_standard_object("opportunities", filters=filters, tidy=tidy)
 
@@ -218,7 +218,7 @@ class Copper(object):
                 * custom_fields
                 * custom_fields_available
                 * custom_fields_options
-        """  # noqa: E501
+        """
 
         logger.info("Retrieving custom fields.")
         blob = self.paginate_request("/custom_field_definitions/", req_type="GET")
@@ -236,7 +236,7 @@ class Copper(object):
         `Returns:`
             List of dicts of Parsons Tables:
                 * activitiy_types
-        """  # noqa: E501
+        """
 
         logger.info("Retrieving activity types.")
 
@@ -260,7 +260,7 @@ class Copper(object):
         `Returns:`
             Parsons Table
                 See :ref:`parsons-table` for output options.
-        """  # noqa: E501
+        """
 
         response = self.paginate_request("/contact_types/", req_type="GET")
         return Table(response)

--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -125,7 +125,7 @@ class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
             Parsons Table
                 See :ref:`parsons-table` for output options.
 
-        """  # noqa: E501
+        """
 
         with self.connection() as connection:
             return self.query_with_connection(sql, connection, parameters=parameters)

--- a/parsons/databases/postgres/postgres_core.py
+++ b/parsons/databases/postgres/postgres_core.py
@@ -98,7 +98,7 @@ class PostgresCore(PostgresCreateStatement):
             Parsons Table
                 See :ref:`parsons-table` for output options.
 
-        """  # noqa: E501
+        """
 
         with self.connection() as connection:
             return self.query_with_connection(sql, connection, parameters=parameters)

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -190,7 +190,7 @@ class Redshift(
             Parsons Table
                 See :ref:`parsons-table` for output options.
 
-        """  # noqa: E501
+        """
 
         with self.connection() as connection:
             return self.query_with_connection(sql, connection, parameters=parameters)
@@ -614,7 +614,7 @@ class Redshift(
         `Returns`
             Parsons Table or ``None``
                 See :ref:`parsons-table` for output options.
-        """  # noqa: E501
+        """
 
         # Specify the columns for a copy statement.
         if specifycols or (specifycols is None and template_table):
@@ -1180,7 +1180,7 @@ class Redshift(
         # Determine the max width of the varchar columns in the Redshift table
         s, t = self.split_full_table_name(table_name)
         cols = self.get_columns(s, t)
-        rc = {k: v["max_length"] for k, v in cols.items() if v["data_type"] == "character varying"}  # noqa: E501
+        rc = {k: v["max_length"] for k, v in cols.items() if v["data_type"] == "character varying"}
 
         # Figure out if any of the destination table varchar columns are smaller than the
         # associated Parsons table columns. If they are, then alter column types to expand

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1180,7 +1180,7 @@ class Redshift(
         # Determine the max width of the varchar columns in the Redshift table
         s, t = self.split_full_table_name(table_name)
         cols = self.get_columns(s, t)
-        rc = {k: v["max_length"] for k, v in cols.items() if v["data_type"] == "character varying"}  # noqa: E501, E261
+        rc = {k: v["max_length"] for k, v in cols.items() if v["data_type"] == "character varying"}  # noqa: E501
 
         # Figure out if any of the destination table varchar columns are smaller than the
         # associated Parsons table columns. If they are, then alter column types to expand

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -767,7 +767,7 @@ class Redshift(
         aws_secret_access_key:
             An AWS secret access key granted to the bucket where the file is located. Not
             required if keys are stored as environmental variables.
-        """  # NOQA W605
+        """
 
         # The sql query is provided between single quotes, therefore single
         # quotes within the actual query must be escaped.
@@ -996,7 +996,7 @@ class Redshift(
                 The column name(s) of the sortkey. If not provided, will default to ``primary_key``.
             \**copy_args: kwargs
                 See :func:`~parsons.databases.Redshift.copy` for options.
-        """  # noqa: W605
+        """
 
         if isinstance(primary_key, str):
             primary_keys = [primary_key]

--- a/parsons/databases/redshift/rs_schema.py
+++ b/parsons/databases/redshift/rs_schema.py
@@ -18,7 +18,7 @@ class RedshiftSchema(object):
                 The type of permissions to grant. Supports `select`, `all`, etc. (For
                 full list, see the
                 `Redshift GRANT docs <https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html>`_)
-        """  # noqa: E501
+        """
 
         if not self.schema_exists(schema):
             self.query(f"create schema {schema}")
@@ -37,7 +37,7 @@ class RedshiftSchema(object):
                 The type of permissions to grant. Supports `select`, `all`, etc. (For
                 full list, see the
                 `Redshift GRANT docs <https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html>`_)
-        """  # noqa: E501
+        """
 
         sql = f"""
             grant usage on schema {schema} to group {group};

--- a/parsons/databases/redshift/rs_schema.py
+++ b/parsons/databases/redshift/rs_schema.py
@@ -18,7 +18,7 @@ class RedshiftSchema(object):
                 The type of permissions to grant. Supports `select`, `all`, etc. (For
                 full list, see the
                 `Redshift GRANT docs <https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html>`_)
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         if not self.schema_exists(schema):
             self.query(f"create schema {schema}")
@@ -37,7 +37,7 @@ class RedshiftSchema(object):
                 The type of permissions to grant. Supports `select`, `all`, etc. (For
                 full list, see the
                 `Redshift GRANT docs <https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html>`_)
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         sql = f"""
             grant usage on schema {schema} to group {group};

--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -112,7 +112,7 @@ class RedshiftTableUtilities(object):
                 Drop the source table.
         Returns:
                 None
-        """  # noqa: E501
+        """
 
         # To Do: Add the grants
         # To Do: Argument for if the table exists?
@@ -472,7 +472,7 @@ class RedshiftTableUtilities(object):
 
         logger.info("Retrieving running and queued queries.")
 
-        # Lifted from Redshift Utils https://github.com/awslabs/amazon-redshift-utils/blob/master/src/AdminScripts/running_queues.sql # noqa: E501
+        # Lifted from Redshift Utils https://github.com/awslabs/amazon-redshift-utils/blob/master/src/AdminScripts/running_queues.sql
         sql = """
               select trim(u.usename) as user,
                 s.pid,
@@ -496,21 +496,21 @@ class RedshiftTableUtilities(object):
                 decode(m.blocks_to_disk,-1,null,m.blocks_to_disk) spill_mb,
                 m2.rows as return_rows,
                 m3.rows as NL_rows,
-                substring(replace(nvl(qrytext_cur.text,trim(translate(s.text,chr(10)||chr(13)||chr(9) ,''))),'\\n',' '),1,90) as sql, -- # noqa: E501
-                trim(decode(event&1,1,'SK ','') || decode(event&2,2,'Del ','') || decode(event&4,4,'NL ','') ||  decode(event&8,8,'Dist ','') || decode(event&16,16,'Bcast ','') || decode(event&32,32,'Stats ','')) as Alert -- # noqa: E501
+                substring(replace(nvl(qrytext_cur.text,trim(translate(s.text,chr(10)||chr(13)||chr(9) ,''))),'\\n',' '),1,90) as sql, --
+                trim(decode(event&1,1,'SK ','') || decode(event&2,2,'Del ','') || decode(event&4,4,'NL ','') ||  decode(event&8,8,'Dist ','') || decode(event&16,16,'Bcast ','') || decode(event&32,32,'Stats ','')) as Alert --
             from stv_wlm_query_state q
             left outer join stl_querytext s on (s.query=q.query and sequence = 0)
             left outer join stv_query_metrics m on ( q.query = m.query and m.segment=-1 and m.step=-1 )
             left outer join stv_query_metrics m2 on ( q.query = m2.query and m2.step_type = 38 )
-            left outer join ( select query, sum(rows) as rows from stv_query_metrics m3 where step_type = 15 group by 1) as m3 on ( q.query = m3.query ) -- # noqa: E501
+            left outer join ( select query, sum(rows) as rows from stv_query_metrics m3 where step_type = 15 group by 1) as m3 on ( q.query = m3.query ) --
             left outer join pg_user u on ( s.userid = u.usesysid )
             LEFT OUTER JOIN (SELECT ut.xid,'CURSOR ' || TRIM( substring ( TEXT from strpos(upper(TEXT),'SELECT') )) as TEXT
             FROM stl_utilitytext ut
             WHERE sequence = 0
                AND upper(TEXT) like 'DECLARE%'
                GROUP BY text, ut.xid) qrytext_cur ON (q.xid = qrytext_cur.xid)
-            left outer join ( select query,sum(decode(trim(split_part(event,':',1)),'Very selective query filter',1,'Scanned a large number of deleted rows',2,'Nested Loop Join in the query plan',4,'Distributed a large number of rows across the network',8,'Broadcasted a large number of rows across the network',16,'Missing query planner statistics',32,0)) as event from STL_ALERT_EVENT_LOG -- # noqa: E501
-            where event_time >=  dateadd(hour, -8, current_Date) group by query  ) as alrt on alrt.query = q.query -- # noqa: E501
+            left outer join ( select query,sum(decode(trim(split_part(event,':',1)),'Very selective query filter',1,'Scanned a large number of deleted rows',2,'Nested Loop Join in the query plan',4,'Distributed a large number of rows across the network',8,'Broadcasted a large number of rows across the network',16,'Missing query planner statistics',32,0)) as event from STL_ALERT_EVENT_LOG --
+            where event_time >=  dateadd(hour, -8, current_Date) group by query  ) as alrt on alrt.query = q.query --
             """
 
         return self.query(sql)

--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -112,7 +112,7 @@ class RedshiftTableUtilities(object):
                 Drop the source table.
         Returns:
                 None
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         # To Do: Add the grants
         # To Do: Argument for if the table exists?

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -216,7 +216,7 @@ class ETL(object):
                 The update function, method, or variable to process the update
         `Returns:`
             `Parsons Table` and also updates self
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         self.table = petl.convert(self.table, *column, **kwargs)
 
@@ -1100,7 +1100,7 @@ class ETL(object):
         `Returns:`
             `Parsons Table` and also updates self
 
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         self.table = petl.rowreduce(
             self.table,

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -78,7 +78,7 @@ class ETL(object):
                 Column names
         `Returns:`
             `Parsons Table` and also updates self
-        """  # noqa: W605
+        """
 
         self.table = petl.cutout(self.table, *columns)
 
@@ -445,7 +445,7 @@ class ETL(object):
                 The update function, method, or variable to process the update. Can also
         `Returns:`
             `Parsons Table` and also updates self
-        """  # noqa: W605
+        """
 
         self.convert_column(self.columns, *args)
 
@@ -777,7 +777,7 @@ class ETL(object):
                 Columns in the parsons table
         `Returns:`
             A new parsons table containing the selected columnns
-        """  # noqa: W605
+        """
 
         from parsons.etl.table import Table
 
@@ -813,7 +813,7 @@ class ETL(object):
             \*filters: function or str
         `Returns:`
             A new parsons table containing the selected rows
-        """  # noqa: W605
+        """
 
         from parsons.etl.table import Table
 

--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -216,7 +216,7 @@ class ETL(object):
                 The update function, method, or variable to process the update
         `Returns:`
             `Parsons Table` and also updates self
-        """  # noqa: E501
+        """
 
         self.table = petl.convert(self.table, *column, **kwargs)
 
@@ -530,7 +530,7 @@ class ETL(object):
 
           tbl.unpack_list('phones', replace=True)
           print (tbl)
-          >>> {'id': '5421', 'name': 'Jane Green', 'phones_0': '512-699-3334', 'phones_1': '512-222-5478'} # noqa: E501
+          >>> {'id': '5421', 'name': 'Jane Green', 'phones_0': '512-699-3334', 'phones_1': '512-222-5478'}
 
         `Args:`
             column: str
@@ -712,8 +712,8 @@ class ETL(object):
                   ]
            tbl = Table(json)
            print (tbl)
-           >>> {'id': '5421', 'name': 'Jane Green', 'emails': [{'home': 'jane@gmail.com'}, {'work': 'jane@mywork.com'}]} # noqa: E501
-           >>> {'id': '5421', 'name': 'Jane Green', 'emails': [{'home': 'jane@gmail.com'}, {'work': 'jane@mywork.com'}]} # noqa: E501
+           >>> {'id': '5421', 'name': 'Jane Green', 'emails': [{'home': 'jane@gmail.com'}, {'work': 'jane@mywork.com'}]}
+           >>> {'id': '5421', 'name': 'Jane Green', 'emails': [{'home': 'jane@gmail.com'}, {'work': 'jane@mywork.com'}]}
 
            # Create skinny table of just the nested dicts
            email_skinny = tbl.long_table(['id'], 'emails')
@@ -1100,7 +1100,7 @@ class ETL(object):
         `Returns:`
             `Parsons Table` and also updates self
 
-        """  # noqa: E501
+        """
 
         self.table = petl.rowreduce(
             self.table,
@@ -1192,7 +1192,7 @@ class ETL(object):
                 The keyword arguements to pass to the petl function.
         `Returns:`
             `parsons.Table` or `petl` table
-        """  # noqa: E501
+        """
         update_table = kwargs.pop("update_table", False)
         to_petl = kwargs.pop("to_petl", False)
 

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -665,7 +665,7 @@ class ToFrom(object):
         """
         Write the table to a Civis Redshift cluster. Additional key word
         arguments can passed to `civis.io.dataframe_to_civis()
-        <https://civis-python.readthedocs.io/en/v1.9.0/generated/civis.io.dataframe_to_civis.html#civis.io.dataframe_to_civis>`_ # noqa: E501
+        <https://civis-python.readthedocs.io/en/v1.9.0/generated/civis.io.dataframe_to_civis.html#civis.io.dataframe_to_civis>`_
 
         `Args`
             table: str

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -140,7 +140,7 @@ class ToFrom(object):
         `Returns:`
             str
                 The path of the new file
-        """  # noqa: W605
+        """
 
         # If a zip archive.
         if files.zip_check(local_path, temp_file_compression):
@@ -192,7 +192,7 @@ class ToFrom(object):
         `Returns:`
             str
                 The path of the file
-        """  # noqa: W605
+        """
 
         petl.appendcsv(self.table, source=local_path, encoding=encoding, errors=errors, **csvargs)
         return local_path
@@ -239,7 +239,7 @@ class ToFrom(object):
         `Returns:`
             str
                 The path of the archive
-        """  # noqa: W605
+        """
 
         if not archive_path:
             archive_path = files.create_temp_file(suffix=".zip")
@@ -359,7 +359,7 @@ class ToFrom(object):
                 to authenticate stfp connection
             \**csvargs: kwargs
                 ``csv_writer`` optional arguments
-        """  # noqa: W605
+        """
 
         from parsons.sftp import SFTP
 
@@ -429,7 +429,7 @@ class ToFrom(object):
                 ``csv_writer`` optional arguments
         `Returns:`
             Public url if specified. If not ``None``.
-        """  # noqa: W605
+        """
 
         compression = compression or files.compression_type_for_path(key)
 
@@ -508,7 +508,7 @@ class ToFrom(object):
                 ``csv_writer`` optional arguments
         `Returns:`
             Public url if specified. If not ``None``.
-        """  # noqa: W605
+        """
 
         compression = compression or files.compression_type_for_path(blob_name)
 
@@ -568,7 +568,7 @@ class ToFrom(object):
 
         Returns:
             ``None``
-        """  # noqa: W605
+        """
 
         from parsons.databases.redshift import Redshift
 
@@ -606,7 +606,7 @@ class ToFrom(object):
 
         Returns:
             ``None``
-        """  # noqa: W605
+        """
 
         from parsons.databases.postgres import Postgres
 
@@ -727,7 +727,7 @@ class ToFrom(object):
         `Returns:`
             Parsons Table
                 See :ref:`parsons-table` for output options.
-        """  # noqa: W605
+        """
 
         remote_prefixes = ["http://", "https://", "ftp://", "s3://"]
         if any(map(local_path.startswith, remote_prefixes)):
@@ -892,7 +892,7 @@ class ToFrom(object):
                 ``csv_reader`` optional arguments
         `Returns:`
             `parsons.Table` object
-        """  # noqa: W605
+        """
 
         from parsons.aws import S3
 

--- a/parsons/facebook_ads/facebook_ads.py
+++ b/parsons/facebook_ads/facebook_ads.py
@@ -346,7 +346,7 @@ class FacebookAds(object):
             users_table: obj
                 Parsons table
 
-        """  # noqa: E501
+        """
 
         logger.info(
             f"Adding custom audience users from provided table with " f"{users_table.num_rows} rows"

--- a/parsons/facebook_ads/facebook_ads.py
+++ b/parsons/facebook_ads/facebook_ads.py
@@ -346,7 +346,7 @@ class FacebookAds(object):
             users_table: obj
                 Parsons table
 
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         logger.info(
             f"Adding custom audience users from provided table with " f"{users_table.num_rows} rows"

--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -22,7 +22,7 @@ class CensusGeocoder(object):
         vintage: str
             The US Census vintage file to utilize. By default the current vintage is used, but
             other options can be found `here <https://geocoding.geo.census.gov/geocoder/vintages?form>`_.
-    """  # noqa E501
+    """
 
     def __init__(self, benchmark="Public_AR_Current", vintage="Current_Current"):
         self.cg = censusgeocode.CensusGeocode(benchmark=benchmark, vintage=vintage)

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -983,7 +983,7 @@ class GoogleBigQuery(DatabaseConnector):
                 arguments to upsert a pre-existing s3 file into the target_table
             \**copy_args: kwargs
                 See :func:`~parsons.databases.bigquery.BigQuery.copy` for options.
-        """  # noqa: W605
+        """
         if not self.table_exists(target_table):
             logger.info(
                 "Target table does not exist. Copying into newly \

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -455,7 +455,7 @@ class GoogleSheets:
                         }
                     }, worksheet=0)
 
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         ws = self._get_worksheet(spreadsheet_id, worksheet)
         ws.format(range, cell_format)

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -455,7 +455,7 @@ class GoogleSheets:
                         }
                     }, worksheet=0)
 
-        """  # noqa: E501
+        """
 
         ws = self._get_worksheet(spreadsheet_id, worksheet)
         ws.format(range, cell_format)

--- a/parsons/ngpvan/changed_entities.py
+++ b/parsons/ngpvan/changed_entities.py
@@ -74,7 +74,7 @@ class ChangedEntities(object):
         `Returns:`
             Parsons Table
                 See :ref:`parsons-table` for output options.
-        """  # noqa: E501
+        """
 
         json = {
             "dateChangedFrom": date_from,

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -640,7 +640,7 @@ class People(object):
                          "type": "SurveyResponse"}
                         ]
             van.apply_response(5222, response)
-        """  # noqa: E501
+        """
 
         # Set url based on id_type
         if id_type == "vanid":

--- a/parsons/ngpvan/people.py
+++ b/parsons/ngpvan/people.py
@@ -640,7 +640,7 @@ class People(object):
                          "type": "SurveyResponse"}
                         ]
             van.apply_response(5222, response)
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         # Set url based on id_type
         if id_type == "vanid":

--- a/parsons/notifications/gmail.py
+++ b/parsons/notifications/gmail.py
@@ -60,7 +60,7 @@ class Gmail(SendMail):
                 i.e. the objects created by the create_* instance methods
         `Returns:`
             dict
-                A Users.messages object see `https://developers.google.com/gmail/api/v1/reference/users/messages#resource.` # noqa
+                A Users.messages object see `https://developers.google.com/gmail/api/v1/reference/users/messages#resource.`
                 for more info.
         """
         self.log.info("Sending a message...")

--- a/parsons/salesforce/salesforce.py
+++ b/parsons/salesforce/salesforce.py
@@ -72,7 +72,7 @@ class Salesforce:
                 For reference, see the `Salesforce SOQL documentation <https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm>`_.
         `Returns:`
             list of dicts with Salesforce data
-        """  # noqa: E501
+        """
 
         q = self.client.query_all(soql)
         q = json.loads(json.dumps(q))

--- a/parsons/salesforce/salesforce.py
+++ b/parsons/salesforce/salesforce.py
@@ -72,7 +72,7 @@ class Salesforce:
                 For reference, see the `Salesforce SOQL documentation <https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm>`_.
         `Returns:`
             list of dicts with Salesforce data
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         q = self.client.query_all(soql)
         q = json.loads(json.dumps(q))

--- a/parsons/sisense/sisense.py
+++ b/parsons/sisense/sisense.py
@@ -37,7 +37,7 @@ class Sisense(object):
     def publish_shared_dashboard(self, dashboard_id, chart_id=None, **kwargs):
         """
         This method publishes a dashboard or chart using the provided arguments.
-        For available options, see the `API documentation <https://dtdocs.sisense.com/article/embed-api-options>`_. # noqa
+        For available options, see the `API documentation <https://dtdocs.sisense.com/article/embed-api-options>`_.
 
         `Args:`
             dashboard_id: str or int

--- a/parsons/targetsmart/targetsmart_automation.py
+++ b/parsons/targetsmart/targetsmart_automation.py
@@ -45,7 +45,7 @@ class TargetSmartAutomation(object):
     """
     * `Automation overview <https://docs.targetsmart.com/my_tsmart/automation/overview.html>`_
     * `Automation integration doc <https://docs.targetsmart.com/my_tsmart/automation/developer.html>`_
-    """  # noqa
+    """
 
     def __init__(self, sftp_username=None, sftp_password=None):
         self.sftp_host = TS_STFP_HOST

--- a/parsons/targetsmart/targetsmart_automation.py
+++ b/parsons/targetsmart/targetsmart_automation.py
@@ -108,7 +108,7 @@ class TargetSmartAutomation(object):
                 Remove the configuration, file to be matched and matched file from
                 the TargetSmart SFTP upon completion or failure of match.
 
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         # Generate a match job
         job_name = job_name or str(uuid.uuid1())

--- a/parsons/targetsmart/targetsmart_automation.py
+++ b/parsons/targetsmart/targetsmart_automation.py
@@ -108,7 +108,7 @@ class TargetSmartAutomation(object):
                 Remove the configuration, file to be matched and matched file from
                 the TargetSmart SFTP upon completion or failure of match.
 
-        """  # noqa: E501
+        """
 
         # Generate a match job
         job_name = job_name or str(uuid.uuid1())

--- a/parsons/targetsmart/targetsmart_smartmatch.py
+++ b/parsons/targetsmart/targetsmart_smartmatch.py
@@ -290,14 +290,14 @@ class SmartMatch:
                     shutil.copyfileobj(gz_reader, tmp_csv)
                 tmp_csv.flush()
 
-                raw_outtable = petl.fromcsv(  # pylint: disable=no-member
-                    tmp_csv.name, encoding="utf8"
-                ).convert(INTERNAL_JOIN_ID, int)
+                raw_outtable = petl.fromcsv(tmp_csv.name, encoding="utf8").convert(
+                    INTERNAL_JOIN_ID, int
+                )
                 logger.info(
                     "SmartMatch remote execution successful. Joining results to" " input table."
                 )
                 outtable = (
-                    petl.leftjoin(  # pylint: disable=no-member
+                    petl.leftjoin(
                         input_table,
                         raw_outtable,
                         key=INTERNAL_JOIN_ID,

--- a/parsons/targetsmart/targetsmart_smartmatch.py
+++ b/parsons/targetsmart/targetsmart_smartmatch.py
@@ -185,7 +185,7 @@ class SmartMatch:
                 match indicator, ``vb.voterbase_id``, and zero or more additional data
                 element fields based on your TargetSmart account configuration.
                 See :ref:`parsons-table` for output options.
-        """  # noqa
+        """
 
         # If `input_table` is a Parsons table, convert it to a Petl table.
         if hasattr(input_table, "table"):

--- a/parsons/twilio/twilio.py
+++ b/parsons/twilio/twilio.py
@@ -101,7 +101,7 @@ class Twilio:
         `Returns:`
             Parsons Table
                 See :ref:`parsons-table` for output options.
-        """  # noqa: E501,E261
+        """  # noqa: E501
 
         # Add populated arguments
         args = {"category": category, "start_date": start_date, "end_date": end_date}

--- a/parsons/twilio/twilio.py
+++ b/parsons/twilio/twilio.py
@@ -101,7 +101,7 @@ class Twilio:
         `Returns:`
             Parsons Table
                 See :ref:`parsons-table` for output options.
-        """  # noqa: E501
+        """
 
         # Add populated arguments
         args = {"category": category, "start_date": start_date, "end_date": end_date}

--- a/parsons/utilities/sql_helpers.py
+++ b/parsons/utilities/sql_helpers.py
@@ -8,7 +8,7 @@ def redact_credentials(sql):
     Redact any credentials explicitly represented in SQL (e.g. COPY statement)
     """
 
-    pattern = "credentials\s+'(.+\n?)+[^(\\)]'"  # noqa: W605
+    pattern = "credentials\s+'(.+\n?)+[^(\\)]'"
     sql_censored = re.sub(pattern, "CREDENTIALS REDACTED", sql, flags=re.IGNORECASE)
 
     return sql_censored

--- a/test/test_alchemer/test_getresponses.py
+++ b/test/test_alchemer/test_getresponses.py
@@ -57,7 +57,7 @@ class TestAlchemErGetResponses(unittest.TestCase):
                     "url_variables": [],
                     "ip_address": "50.232.185.226",
                     "referer": "https://app.surveygizmo.com/distribute/share/id/4599075",
-                    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",  # noqa
+                    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
                     "response_time": 10,
                     "data_quality": [],
                     "longitude": "-105.20369720459",
@@ -111,7 +111,7 @@ class TestAlchemErGetResponses(unittest.TestCase):
                     },
                     "ip_address": "50.232.185.226",
                     "referer": "",
-                    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",  # noqa
+                    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
                     "response_time": 10,
                     "data_quality": [],
                     "longitude": "-105.20369720459",

--- a/test/test_crowdtangle/leaderboard.py
+++ b/test/test_crowdtangle/leaderboard.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 expected_leaderboard = {
     "status": 200,
     "result": {

--- a/test/test_crowdtangle/link_post.py
+++ b/test/test_crowdtangle/link_post.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 expected_post = {
     "status": 200,
     "result": {

--- a/test/test_crowdtangle/post.py
+++ b/test/test_crowdtangle/post.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 expected_posts = {
     "status": 200,
     "result": {

--- a/test/test_databases/test_mysql.py
+++ b/test/test_databases/test_mysql.py
@@ -116,7 +116,7 @@ class TestMySQL(unittest.TestCase):
 
 
 # TODO: figure out why there are 2 of these
-class TestMySQL(unittest.TestCase):  # noqa
+class TestMySQL(unittest.TestCase):  # noqa: F811
     def setUp(self):
         self.mysql = MySQL(username="test", password="test", host="test", db="test", port=123)
 

--- a/test/test_databases/test_postgres.py
+++ b/test/test_databases/test_postgres.py
@@ -121,14 +121,14 @@ class TestPostgresCreateStatement(unittest.TestCase):
             "a",
             "",
             "SELECT",
-            "asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjklasdfjklasjkldfakljsdfjalsdkfjklasjdfklasjdfklasdkljf",  # noqa: E501
+            "asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjklasdfjklasjkldfakljsdfjalsdkfjklasjdfklasjdfklasdkljf",
         ]
         fixed_cols = [
             "a",
             "a_1",
             "col_2",
             "col_3",
-            "asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjkl",  # noqa: E501
+            "asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjkl",
         ]
         self.assertEqual(self.pg.column_name_validate(bad_cols), fixed_cols)
 
@@ -136,7 +136,7 @@ class TestPostgresCreateStatement(unittest.TestCase):
         # Assert that copy statement is expected
         sql = self.pg.create_statement(self.tbl, "tmc.test", distkey="ID")
         exp_sql = (
-            """create table tmc.test (\n  "id" smallint,\n  "name" varchar(5)) \ndistkey(ID) ;"""  # noqa: E501
+            """create table tmc.test (\n  "id" smallint,\n  "name" varchar(5)) \ndistkey(ID) ;"""
         )
         self.assertEqual(sql, exp_sql)
 
@@ -165,7 +165,7 @@ class TestPostgresDB(unittest.TestCase):
         other_sql = f"""
                     create table {self.temp_schema}.test (id smallint,name varchar(5));
                     create view {self.temp_schema}.test_view as (select * from {self.temp_schema}.test);
-                    """  # noqa: E501
+                    """
 
         self.pg.query(setup_sql)
 

--- a/test/test_databases/test_redshift.py
+++ b/test/test_databases/test_redshift.py
@@ -147,7 +147,7 @@ class TestRedshift(unittest.TestCase):
     def test_create_statement(self):
         # Assert that copy statement is expected
         sql = self.rs.create_statement(self.tbl, "tmc.test", distkey="ID")
-        exp_sql = """create table tmc.test (\n  "id" int,\n  "name" varchar(5)) \ndistkey(ID) ;"""  # noqa: E501
+        exp_sql = """create table tmc.test (\n  "id" int,\n  "name" varchar(5)) \ndistkey(ID) ;"""
         self.assertEqual(sql, exp_sql)
 
         # Assert that an error is raised by an empty table
@@ -158,7 +158,7 @@ class TestRedshift(unittest.TestCase):
         # Test passing kwargs
         creds = self.rs.get_creds("kwarg_key", "kwarg_secret_key")
         expected = (
-            """credentials 'aws_access_key_id=kwarg_key;aws_secret_access_key=kwarg_secret_key'\n"""  # noqa: E501
+            """credentials 'aws_access_key_id=kwarg_key;aws_secret_access_key=kwarg_secret_key'\n"""
         )
         self.assertEqual(creds, expected)
 
@@ -169,7 +169,7 @@ class TestRedshift(unittest.TestCase):
         os.environ["AWS_SECRET_ACCESS_KEY"] = "env_secret_key"
         creds = self.rs.get_creds(None, None)
         expected = (
-            """credentials 'aws_access_key_id=env_key;aws_secret_access_key=env_secret_key'\n"""  # noqa: E501
+            """credentials 'aws_access_key_id=env_key;aws_secret_access_key=env_secret_key'\n"""
         )
         self.assertEqual(creds, expected)
 

--- a/test/test_gmail/test_gmail.py
+++ b/test/test_gmail/test_gmail.py
@@ -29,7 +29,7 @@ class TestGmail(unittest.TestCase):
                             "project_id": "some-project-id-12345",
                             "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                             "token_uri": "https://www.googleapis.com/oauth2/v3/token",
-                            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",  # noqa: E501
+                            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
                             "client_secret": "someclientsecret",
                             "redirect_uris": [
                                 "urn:ietf:wg:oauth:2.0:oob",

--- a/test/test_gmail/test_gmail.py
+++ b/test/test_gmail/test_gmail.py
@@ -129,7 +129,7 @@ class TestGmail(unittest.TestCase):
         # avoid failures
         updated_items = []
         for i in decoded.items():
-            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:  # noqa
+            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:
                 updated_items.append(("Content-Type", "multipart/alternative;\n boundary="))
             else:
                 updated_items.append((i[0], i[1]))
@@ -171,7 +171,7 @@ class TestGmail(unittest.TestCase):
         # avoid failures
         updated_items = []
         for i in decoded.items():
-            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:  # noqa
+            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:
                 updated_items.append(("Content-Type", "multipart/alternative;\n boundary="))
             else:
                 updated_items.append((i[0], i[1]))
@@ -216,7 +216,7 @@ class TestGmail(unittest.TestCase):
         # avoid failures
         updated_items = []
         for i in decoded.items():
-            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:  # noqa
+            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:
                 updated_items.append(("Content-Type", "multipart/alternative;\n boundary="))
             else:
                 updated_items.append((i[0], i[1]))
@@ -273,7 +273,7 @@ class TestGmail(unittest.TestCase):
         # avoid failures
         updated_items = []
         for i in decoded.items():
-            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:  # noqa
+            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:
                 updated_items.append(("Content-Type", "multipart/alternative;\n boundary="))
             else:
                 updated_items.append((i[0], i[1]))
@@ -327,7 +327,7 @@ class TestGmail(unittest.TestCase):
         # avoid failures
         updated_items = []
         for i in decoded.items():
-            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:  # noqa
+            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:
                 updated_items.append(("Content-Type", "multipart/alternative;\n boundary="))
             else:
                 updated_items.append((i[0], i[1]))
@@ -379,7 +379,7 @@ class TestGmail(unittest.TestCase):
         # avoid failures
         updated_items = []
         for i in decoded.items():
-            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:  # noqa
+            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:
                 updated_items.append(("Content-Type", "multipart/alternative;\n boundary="))
             else:
                 updated_items.append((i[0], i[1]))
@@ -431,7 +431,7 @@ class TestGmail(unittest.TestCase):
         # avoid failures
         updated_items = []
         for i in decoded.items():
-            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:  # noqa
+            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:
                 updated_items.append(("Content-Type", "multipart/alternative;\n boundary="))
             else:
                 updated_items.append((i[0], i[1]))
@@ -484,7 +484,7 @@ class TestGmail(unittest.TestCase):
         # avoid failures
         updated_items = []
         for i in decoded.items():
-            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:  # noqa
+            if "Content-Type" in i[0] and "multipart/alternative;\n boundary=" in i[1]:
                 updated_items.append(("Content-Type", "multipart/alternative;\n boundary="))
             else:
                 updated_items.append((i[0], i[1]))

--- a/test/test_google/googlecivic_responses.py
+++ b/test/test_google/googlecivic_responses.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 elections_resp = {
     "kind": "civicinfo#electionsQueryResponse",
     "elections": [

--- a/test/test_pdi/test_flag_ids.py
+++ b/test/test_pdi/test_flag_ids.py
@@ -127,7 +127,7 @@ def test_delete_flag_id(live_pdi, create_temp_flag_id, my_flag_id):
 def test_update_flag_id(live_pdi, create_temp_flag_id, my_flag_id):
     with create_temp_flag_id(live_pdi, my_flag_id) as flag_id:
         # flag initial state:
-        # {"id":flag_id,"flagId":"amm","flagIdDescription":null,"compile":"","isDefault":false}  # noqa
+        # {"id":flag_id,"flagId":"amm","flagIdDescription":null,"compile":"","isDefault":false}
         id = live_pdi.update_flag_id(flag_id, "bnh", True)
         assert id == flag_id
 

--- a/test/test_sisense/test_data.py
+++ b/test/test_sisense/test_data.py
@@ -1,7 +1,7 @@
 ENV_PARAMETERS = {"SISENSE_SITE_NAME": "my_site_name", "SISENSE_API_KEY": "my_api_key"}
 
 TEST_PUBLISH_SHARED_DASHBOARD = {
-    "url": "https://www.periscopedata.com/api/embedded_dashboard?data=%7B%22dashboard%22%3A7863%2C%22embed%22%3A%22v2%22%2C%22filters%22%3A%5B%7B%22name%22%3A%22Filter1%22%2C%22value%22%3A%22value1%22%7D%2C%7B%22name%22%3A%22Filter2%22%2C%22value%22%3A%221234%22%7D%5D%7D&signature=adcb671e8e24572464c31e8f9ffc5f638ab302a0b673f72554d3cff96a692740"  # noqa: E501
+    "url": "https://www.periscopedata.com/api/embedded_dashboard?data=%7B%22dashboard%22%3A7863%2C%22embed%22%3A%22v2%22%2C%22filters%22%3A%5B%7B%22name%22%3A%22Filter1%22%2C%22value%22%3A%22value1%22%7D%2C%7B%22name%22%3A%22Filter2%22%2C%22value%22%3A%221234%22%7D%5D%7D&signature=adcb671e8e24572464c31e8f9ffc5f638ab302a0b673f72554d3cff96a692740"
 }
 
 TEST_LIST_SHARED_DASHBOARDS = [

--- a/test/test_sisense/test_sisense.py
+++ b/test/test_sisense/test_sisense.py
@@ -33,7 +33,7 @@ class TestSisense(unittest.TestCase):
         self.assertEqual(
             self.sisense.publish_shared_dashboard(dashboard_id="1234"),
             TEST_PUBLISH_SHARED_DASHBOARD,
-        )  # noqa
+        )
 
     @requests_mock.Mocker()
     def test_list_shared_dashboards(self, m):
@@ -41,7 +41,7 @@ class TestSisense(unittest.TestCase):
         self.assertEqual(
             self.sisense.list_shared_dashboards(dashboard_id="1234"),
             TEST_LIST_SHARED_DASHBOARDS,
-        )  # noqa
+        )
 
     @requests_mock.Mocker()
     def test_delete_shared_dashboard(self, m):
@@ -52,4 +52,4 @@ class TestSisense(unittest.TestCase):
         self.assertEqual(
             self.sisense.delete_shared_dashboard(token="abc"),
             TEST_DELETE_SHARED_DASHBOARD,
-        )  # noqa
+        )

--- a/test/test_van/test_saved_lists.py
+++ b/test/test_van/test_saved_lists.py
@@ -144,7 +144,7 @@ class TestSavedLists(unittest.TestCase):
             "dateExpired": "2018-09-08T16:04:00Z",
             "surveyQuestions": "null",
             "webhookUrl": "https://www.nothing.com/",
-            "downloadUrl": "https://ngpvan.blob.core.windows.net/canvass-files-savedlistexport/bf4d1297-1c77-3fb2-03bd-f0acda122d37_2018-09-08T13:03:27.7191831-04:00.csv",  # noqa: E501
+            "downloadUrl": "https://ngpvan.blob.core.windows.net/canvass-files-savedlistexport/bf4d1297-1c77-3fb2-03bd-f0acda122d37_2018-09-08T13:03:27.7191831-04:00.csv",
             "savedListId": 517612,
             "districtFields": "null",
             "canvassFileRequestGuid": "bf4d1297-1c77-3fb2-03bd-f0acda122d37",
@@ -187,7 +187,7 @@ class TestSavedLists(unittest.TestCase):
             "dateExpired": "2018-09-08T16:04:00Z",
             "surveyQuestions": "null",
             "webhookUrl": "https://www.nothing.com/",
-            "downloadUrl": "https://ngpvan.blob.core.windows.net/canvass-files-savedlistexport/bf4d1297-1c77-3fb2-03bd-f0acda122d37_2018-09-08T13:03:27.7191831-04:00.csv",  # noqa: E501
+            "downloadUrl": "https://ngpvan.blob.core.windows.net/canvass-files-savedlistexport/bf4d1297-1c77-3fb2-03bd-f0acda122d37_2018-09-08T13:03:27.7191831-04:00.csv",
             "savedListId": 517612,
             "districtFields": "null",
             "canvassFileRequestGuid": "bf4d1297-1c77-3fb2-03bd-f0acda122d37",

--- a/test/test_van/test_targets.py
+++ b/test/test_van/test_targets.py
@@ -119,7 +119,7 @@ class TestTargets(unittest.TestCase):
         }
 
         download_url = (
-            "https://ngpvan.blob.core.windows.net/target-export-files/TargetExport_455961790.csv"  # noqa: E501
+            "https://ngpvan.blob.core.windows.net/target-export-files/TargetExport_455961790.csv"
         )
         fromcsv.return_value = petl.fromcolumns(
             [

--- a/test/test_zoom.py
+++ b/test/test_zoom.py
@@ -364,7 +364,7 @@ class TestZoom(unittest.TestCase):
                     "custom_questions": [
                         {
                             "title": "What do you hope to learn from this Webinar?",
-                            "value": "Look forward to learning how you come up with recipes and services",  # noqa: E501
+                            "value": "Look forward to learning how you come up with recipes and services",
                         }
                     ],
                     "status": "approved",
@@ -392,7 +392,7 @@ class TestZoom(unittest.TestCase):
                     "custom_questions": [
                         {
                             "title": "What do you hope to learn from this Webinar?",
-                            "value": "Look forward to learning how you come up with recipes and services",  # noqa: E501
+                            "value": "Look forward to learning how you come up with recipes and services",
                         }
                     ],
                     "status": "approved",
@@ -425,7 +425,7 @@ class TestZoom(unittest.TestCase):
                     "custom_questions": [
                         {
                             "title": "What do you hope to learn from this Webinar?",
-                            "value": "Look forward to learning how you come up with recipes and services",  # noqa: E501
+                            "value": "Look forward to learning how you come up with recipes and services",
                         }
                     ],
                     "status": "approved",
@@ -453,7 +453,7 @@ class TestZoom(unittest.TestCase):
                     "custom_questions": [
                         {
                             "title": "What do you hope to learn from this Webinar?",
-                            "value": "Look forward to learning how you come up with recipes and services",  # noqa: E501
+                            "value": "Look forward to learning how you come up with recipes and services",
                         }
                     ],
                     "status": "approved",


### PR DESCRIPTION
Removes E261 as it's not currently used in ruff (without preview flag)
Removes E501 as ruff line length is smart enough to not need this anywhere it was being used
Removes W605 invalid escape sequence as ruff isn't flagging these lines
Resolve one E741 ambiguous variable name in copper.py
Remove any "# noqa" that isn't for a specific code, including some files that were entirely being skipped. Where codes were thrown, re-add noqa for that specific code (protects against future failing changes not being caught).