### PR TITLE
Catalist + SFTP: Export Files from Server in Chunks

### DIFF
--- a/parsons/catalist/catalist.py
+++ b/parsons/catalist/catalist.py
@@ -75,7 +75,9 @@ class CatalistMatch:
         )
         self.sftp = SFTP("t.catalist.us", sftp_username, sftp_password, timeout=7200)
 
-    def load_table_to_sftp(self, table: Table, input_subfolder: Optional[str] = None) -> str:
+    def load_table_to_sftp(
+        self, table: Table, input_subfolder: Optional[str] = None
+    ) -> str:
         """Load table to Catalist sftp bucket as gzipped CSV for matching.
 
         If input_subfolder is specific, the file will be uploaded to a subfolder of the
@@ -116,6 +118,7 @@ class CatalistMatch:
         input_subfolder: Optional[str] = None,
         copy_to_sandbox: bool = False,
         static_values: Optional[Dict[str, Union[str, int]]] = None,
+        export_chunk_size: Optional[int] = None,
     ) -> Table:
         """Load table to the Catalist Match API, returns matched table.
 
@@ -141,6 +144,8 @@ class CatalistMatch:
                   Defaults to False.
              static_values: dict
                   Optional. Any included values are mapped to every row of the input table.
+            export_chunk_size: int
+                  Optional. Size in bytes to iteratively export from SFTP server to local filesystem.
         """
         response = self.upload(
             table=table,
@@ -151,7 +156,9 @@ class CatalistMatch:
             copy_to_sandbox=copy_to_sandbox,
             static_values=static_values,
         )
-        result = self.await_completion(response["id"])
+        result = self.await_completion(
+            response["id"], export_chunk_size=export_chunk_size
+        )
         return result
 
     def upload(
@@ -195,7 +202,9 @@ class CatalistMatch:
 
         # upload table to s3 temp location
         sftp_file_path = self.load_table_to_sftp(table, input_subfolder)
-        sftp_file_path_encoded = base64.b64encode(sftp_file_path.encode("ascii")).decode("ascii")
+        sftp_file_path_encoded = base64.b64encode(
+            sftp_file_path.encode("ascii")
+        ).decode("ascii")
 
         if export:
             action = "export%2Cpublish"
@@ -219,7 +228,9 @@ class CatalistMatch:
         endpoint = "/".join(endpoint_params)
 
         # Assemble query parameters
-        query_params: Dict[str, Union[str, int]] = {"token": self.connection.token["access_token"]}
+        query_params: Dict[str, Union[str, int]] = {
+            "token": self.connection.token["access_token"]
+        }
         if copy_to_sandbox:
             query_params["copyToSandbox"] = "true"
         if static_values:
@@ -305,15 +316,20 @@ class CatalistMatch:
         result = self.connection.get_request(endpoint, params=query_params)
         return result
 
-    def await_completion(self, id: str, wait: int = 30) -> Table:
-        """Await completion of a match job. Return matches when ready.
+    def await_completion(
+        self, id: str, wait: int = 30, export_chunk_size: Optional[int] = None
+    ) -> Table:
+        """
+        Await completion of a match job. Return matches when ready.
 
         This method will poll the status of a match job on a timer until the job is
         complete. By default, polls once every 30 seconds.
 
         Note that match job completion can take from 10 minutes up to 6 hours or more
         depending on concurrent traffic. Consider your strategy for polling for
-        completion."""
+        completion.
+        """
+
         while True:
             response = self.status(id)
             status = response["process"]["processState"]
@@ -324,10 +340,10 @@ class CatalistMatch:
             logger.info(f"Job {id} has status {status}, awaiting completion.")
             time.sleep(wait)
 
-        result = self.load_matches(id)
+        result = self.load_matches(id, export_chunk_size=export_chunk_size)
         return result
 
-    def load_matches(self, id: str) -> Table:
+    def load_matches(self, id: str, export_chunk_size: Optional[int] = None) -> Table:
         """Take a completed job ID, download and open the match file as a Table.
 
         Result will be a Table with all the original columns along with columns 'DWID',
@@ -356,9 +372,13 @@ class CatalistMatch:
             raise RuntimeError(err_msg)
 
         remote_filepaths = self.sftp.list_directory("/myDownloads/")
-        remote_filename = [filename for filename in remote_filepaths if id in filename][0]
+        remote_filename = [filename for filename in remote_filepaths if id in filename][
+            0
+        ]
         remote_filepath = "/myDownloads/" + remote_filename
-        temp_file_zip = self.sftp.get_file(remote_filepath)
+        temp_file_zip = self.sftp.get_file(
+            remote_path=remote_filepath, export_chunk_size=export_chunk_size
+        )
         temp_dir = tempfile.mkdtemp()
 
         with ZipFile(temp_file_zip) as zf:
@@ -410,6 +430,8 @@ class CatalistMatch:
             errors["missing_required_columns"] = missing_required_columns
 
         if errors:
-            raise ValueError("Input table does not have the right structure. %s", errors)
+            raise ValueError(
+                "Input table does not have the right structure. %s", errors
+            )
         else:
             logger.info("Table structure validated.")

--- a/parsons/catalist/catalist.py
+++ b/parsons/catalist/catalist.py
@@ -19,7 +19,7 @@ from parsons.utilities.oauth_api_connector import OAuth2APIConnector
 logger = logging.getLogger(__name__)
 
 # Default byte size to export under the hood via Paramiko
-DEFAULT_EXPORT_BYTE_SIZE = 1024 * 1024 * 50
+DEFAULT_EXPORT_CHUNK_SIZE = 1024 * 1024 * 50
 
 
 class CatalistMatch:
@@ -369,7 +369,7 @@ class CatalistMatch:
         remote_filename = [filename for filename in remote_filepaths if id in filename][0]
         remote_filepath = "/myDownloads/" + remote_filename
         temp_file_zip = self.sftp.get_file(
-            remote_path=remote_filepath, export_chunk_size=DEFAULT_EXPORT_BYTE_SIZE
+            remote_path=remote_filepath, export_chunk_size=DEFAULT_EXPORT_CHUNK_SIZE
         )
         temp_dir = tempfile.mkdtemp()
 

--- a/parsons/catalist/catalist.py
+++ b/parsons/catalist/catalist.py
@@ -18,6 +18,9 @@ from parsons.utilities.oauth_api_connector import OAuth2APIConnector
 
 logger = logging.getLogger(__name__)
 
+# Default byte size to export under the hood via Paramiko
+DEFAULT_EXPORT_BYTE_SIZE = 1024 * 1024 * 50
+
 
 class CatalistMatch:
     """Connector for working with the Catalist Match API.
@@ -365,7 +368,9 @@ class CatalistMatch:
         remote_filepaths = self.sftp.list_directory("/myDownloads/")
         remote_filename = [filename for filename in remote_filepaths if id in filename][0]
         remote_filepath = "/myDownloads/" + remote_filename
-        temp_file_zip = self.sftp.get_file(remote_path=remote_filepath)
+        temp_file_zip = self.sftp.get_file(
+            remote_path=remote_filepath, export_chunk_size=DEFAULT_EXPORT_BYTE_SIZE
+        )
         temp_dir = tempfile.mkdtemp()
 
         with ZipFile(temp_file_zip) as zf:

--- a/parsons/catalist/catalist.py
+++ b/parsons/catalist/catalist.py
@@ -340,7 +340,7 @@ class CatalistMatch:
             logger.info(f"Job {id} has status {status}, awaiting completion.")
             time.sleep(wait)
 
-        result = self.load_matches(id, export_chunk_size=export_chunk_size)
+        result = self.load_matches(id=id, export_chunk_size=export_chunk_size)
         return result
 
     def load_matches(self, id: str, export_chunk_size: Optional[int] = None) -> Table:

--- a/parsons/catalist/catalist.py
+++ b/parsons/catalist/catalist.py
@@ -75,9 +75,7 @@ class CatalistMatch:
         )
         self.sftp = SFTP("t.catalist.us", sftp_username, sftp_password, timeout=7200)
 
-    def load_table_to_sftp(
-        self, table: Table, input_subfolder: Optional[str] = None
-    ) -> str:
+    def load_table_to_sftp(self, table: Table, input_subfolder: Optional[str] = None) -> str:
         """Load table to Catalist sftp bucket as gzipped CSV for matching.
 
         If input_subfolder is specific, the file will be uploaded to a subfolder of the
@@ -156,9 +154,7 @@ class CatalistMatch:
             copy_to_sandbox=copy_to_sandbox,
             static_values=static_values,
         )
-        result = self.await_completion(
-            response["id"], export_chunk_size=export_chunk_size
-        )
+        result = self.await_completion(response["id"], export_chunk_size=export_chunk_size)
         return result
 
     def upload(
@@ -202,9 +198,7 @@ class CatalistMatch:
 
         # upload table to s3 temp location
         sftp_file_path = self.load_table_to_sftp(table, input_subfolder)
-        sftp_file_path_encoded = base64.b64encode(
-            sftp_file_path.encode("ascii")
-        ).decode("ascii")
+        sftp_file_path_encoded = base64.b64encode(sftp_file_path.encode("ascii")).decode("ascii")
 
         if export:
             action = "export%2Cpublish"
@@ -228,9 +222,7 @@ class CatalistMatch:
         endpoint = "/".join(endpoint_params)
 
         # Assemble query parameters
-        query_params: Dict[str, Union[str, int]] = {
-            "token": self.connection.token["access_token"]
-        }
+        query_params: Dict[str, Union[str, int]] = {"token": self.connection.token["access_token"]}
         if copy_to_sandbox:
             query_params["copyToSandbox"] = "true"
         if static_values:
@@ -372,9 +364,7 @@ class CatalistMatch:
             raise RuntimeError(err_msg)
 
         remote_filepaths = self.sftp.list_directory("/myDownloads/")
-        remote_filename = [filename for filename in remote_filepaths if id in filename][
-            0
-        ]
+        remote_filename = [filename for filename in remote_filepaths if id in filename][0]
         remote_filepath = "/myDownloads/" + remote_filename
         temp_file_zip = self.sftp.get_file(
             remote_path=remote_filepath, export_chunk_size=export_chunk_size
@@ -430,8 +420,6 @@ class CatalistMatch:
             errors["missing_required_columns"] = missing_required_columns
 
         if errors:
-            raise ValueError(
-                "Input table does not have the right structure. %s", errors
-            )
+            raise ValueError("Input table does not have the right structure. %s", errors)
         else:
             logger.info("Table structure validated.")

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -368,6 +368,7 @@ class GoogleBigQuery(DatabaseConnector):
         compression_type: str = "gzip",
         new_file_extension: str = "csv",
         template_table: Optional[str] = None,
+        max_timeout: int = 21600,
         **load_kwargs,
     ):
         """
@@ -428,6 +429,8 @@ class GoogleBigQuery(DatabaseConnector):
             template_table: str
                 Table name to be used as the load schema. Load operation wil use the same
                 columns and data types as the template table.
+            max_timeout: int
+                The maximum number of seconds to wait for a request before the job fails.
             **load_kwargs: kwargs
                 Other arguments to pass to the underlying load_table_from_uri
                 call on the BigQuery client.
@@ -470,12 +473,14 @@ class GoogleBigQuery(DatabaseConnector):
                     job_config=job_config,
                     compression_type=compression_type,
                     new_file_extension=new_file_extension,
+                    max_timeout=max_timeout,
                 )
             else:
                 return self._load_table_from_uri(
                     source_uris=gcs_blob_uri,
                     destination=table_ref,
                     job_config=job_config,
+                    max_timeout=max_timeout,
                     **load_kwargs,
                 )
         except exceptions.BadRequest as e:
@@ -500,6 +505,7 @@ class GoogleBigQuery(DatabaseConnector):
                     job_config=job_config,
                     compression_type=compression_type,
                     new_file_extension=new_file_extension,
+                    max_timeout=max_timeout,
                 )
             elif "Schema has no field" in str(e):
                 logger.debug(f"{gcs_blob_uri.split('/')[-1]} is empty, skipping file")
@@ -507,6 +513,10 @@ class GoogleBigQuery(DatabaseConnector):
 
             else:
                 raise e
+
+        except exceptions.DeadlineExceeded as e:
+            logger.error(f"Max timeout exceeded for {gcs_blob_uri.split('/')[-1]}")
+            raise e
 
     def copy_large_compressed_file_from_gcs(
         self,
@@ -526,6 +536,7 @@ class GoogleBigQuery(DatabaseConnector):
         compression_type: str = "gzip",
         new_file_extension: str = "csv",
         template_table: Optional[str] = None,
+        max_timeout: int = 21600,
         **load_kwargs,
     ):
         """
@@ -584,6 +595,8 @@ class GoogleBigQuery(DatabaseConnector):
             template_table: str
                 Table name to be used as the load schema. Load operation wil use the same
                 columns and data types as the template table.
+            max_timeout: int
+                The maximum number of seconds to wait for a request before the job fails.
             **load_kwargs: kwargs
                 Other arguments to pass to the underlying load_table_from_uri call on the BigQuery
                 client.
@@ -628,6 +641,7 @@ class GoogleBigQuery(DatabaseConnector):
                 source_uris=uncompressed_gcs_uri,
                 destination=table_ref,
                 job_config=job_config,
+                max_timeout=max_timeout,
                 **load_kwargs,
             )
 
@@ -654,6 +668,7 @@ class GoogleBigQuery(DatabaseConnector):
         tmp_gcs_bucket: Optional[str] = None,
         template_table: Optional[str] = None,
         job_config: Optional[LoadJobConfig] = None,
+        max_timeout: int = 21600,
         **load_kwargs,
     ):
         """
@@ -700,6 +715,8 @@ class GoogleBigQuery(DatabaseConnector):
                 on the BigQuery client. The function will create its own if not provided. Note
                 if there are any conflicts between the job_config and other parameters, the
                 job_config values are preferred.
+            max_timeout: int
+                The maximum number of seconds to wait for a request before the job fails.
 
         `Returns`
             Parsons Table or ``None``
@@ -736,6 +753,7 @@ class GoogleBigQuery(DatabaseConnector):
                 nullas=nullas,
                 job_config=job_config,
                 template_table=template_table,
+                max_timeout=max_timeout,
                 **load_kwargs,
             )
         finally:
@@ -757,6 +775,7 @@ class GoogleBigQuery(DatabaseConnector):
         allow_jagged_rows: bool = True,
         quote: Optional[str] = None,
         schema: Optional[List[dict]] = None,
+        max_timeout: int = 21600,
         convert_dict_columns_to_json: bool = True,
         **load_kwargs,
     ):
@@ -788,6 +807,8 @@ class GoogleBigQuery(DatabaseConnector):
             template_table: str
                 Table name to be used as the load schema. Load operation wil use the same
                 columns and data types as the template table.
+            max_timeout: int
+                The maximum number of seconds to wait for a request before the job fails.
             convert_dict_columns_to_json: bool
                 If set to True, will convert any dict columns (which cannot by default be successfully loaded to BigQuery to JSON strings)
             **load_kwargs: kwargs
@@ -867,6 +888,7 @@ class GoogleBigQuery(DatabaseConnector):
                 source_uris=temp_blob_uri,
                 destination=self.get_table_ref(table_name=table_name),
                 job_config=job_config,
+                max_timeout=max_timeout,
                 **load_kwargs,
             )
         finally:
@@ -1385,7 +1407,9 @@ class GoogleBigQuery(DatabaseConnector):
         if data_type not in ["csv", "json"]:
             raise ValueError(f"Only supports csv or json files [data_type = {data_type}]")
 
-    def _load_table_from_uri(self, source_uris, destination, job_config, **load_kwargs):
+    def _load_table_from_uri(
+        self, source_uris, destination, job_config, max_timeout, **load_kwargs
+    ):
         load_job = self.client.load_table_from_uri(
             source_uris=source_uris,
             destination=destination,
@@ -1394,7 +1418,7 @@ class GoogleBigQuery(DatabaseConnector):
         )
 
         try:
-            load_job.result()
+            load_job.result(timeout=max_timeout)
             return load_job
         except exceptions.BadRequest as e:
             for idx, error_ in enumerate(load_job.errors):

--- a/parsons/sftp/sftp.py
+++ b/parsons/sftp/sftp.py
@@ -12,9 +12,6 @@ from parsons.utilities import files as file_utilities
 
 logger = logging.getLogger(__name__)
 
-# Default byte size to export under the hood via Paramiko
-DEFAULT_EXPORT_BYTE_SIZE = 1024 * 1024 * 50
-
 
 class SFTP(object):
     """
@@ -148,7 +145,7 @@ class SFTP(object):
         remote_path,
         local_path=None,
         connection=None,
-        export_chunk_size: int = DEFAULT_EXPORT_BYTE_SIZE,
+        export_chunk_size: Optional[int] = None,
     ):
         """
         Download a file from the SFTP server
@@ -177,21 +174,27 @@ class SFTP(object):
             local_path = file_utilities.create_temp_file_for_path(remote_path)
 
         if connection:
-            self.__get_file_in_chunks(
-                remote_path=remote_path,
-                local_path=local_path,
-                connection=connection,
-                export_chunk_size=export_chunk_size,
-            )
-
-        else:
-            with self.create_connection() as connection:
+            if export_chunk_size:
                 self.__get_file_in_chunks(
                     remote_path=remote_path,
                     local_path=local_path,
                     connection=connection,
                     export_chunk_size=export_chunk_size,
                 )
+            else:
+                connection.get(remote_path, local_path)
+
+        else:
+            with self.create_connection() as connection:
+                if export_chunk_size:
+                    self.__get_file_in_chunks(
+                        remote_path=remote_path,
+                        local_path=local_path,
+                        connection=connection,
+                        export_chunk_size=export_chunk_size,
+                    )
+                else:
+                    connection.get(remote_path, local_path)
 
         return local_path
 

--- a/parsons/sftp/sftp.py
+++ b/parsons/sftp/sftp.py
@@ -220,9 +220,7 @@ class SFTP(object):
                 Optional. Size in bytes to iteratively export from the remote server.
         """
 
-        logger.info(
-            f"Reading from {remote_path} to {local_path} in {export_chunk_size}B chunks"
-        )
+        logger.info(f"Reading from {remote_path} to {local_path} in {export_chunk_size}B chunks")
 
         with connection.open(remote_path, "rb") as _remote_file:
             with open(local_path, "wb") as _local_file:
@@ -239,9 +237,7 @@ class SFTP(object):
 
                     # Write to the destination file
                     _local_file.write(response)
-                    logger.debug(
-                        f"Successfully read {export_chunk_size} rows to {local_path}"
-                    )
+                    logger.debug(f"Successfully read {export_chunk_size} rows to {local_path}")
 
     @connect
     def get_files(
@@ -290,8 +286,7 @@ class SFTP(object):
                 files_to_download.extend(
                     f
                     for file_list in [
-                        self.list_files(directory, connection, pattern)
-                        for directory in remote
+                        self.list_files(directory, connection, pattern) for directory in remote
                     ]
                     for f in file_list
                 )
@@ -431,9 +426,7 @@ class SFTP(object):
                 entry_pathname = remote_path + "/" + entry.filename
                 for method, pattern, do_search_full_path, paths in dirs_and_files:
                     string = entry_pathname if do_search_full_path else entry.filename
-                    if method(entry.st_mode) and (
-                        not pattern or re.search(pattern, string)
-                    ):
+                    if method(entry.st_mode) and (not pattern or re.search(pattern, string)):
                         paths.append(entry_pathname)
         except FileNotFoundError:  # This error is raised when a directory is empty
             pass
@@ -547,9 +540,7 @@ class SFTP(object):
 
         depth += 1
 
-        dirs, files = self._list_contents(
-            remote_path, connection, dir_pattern, file_pattern
-        )
+        dirs, files = self._list_contents(remote_path, connection, dir_pattern, file_pattern)
 
         if download:
             self.get_files(files_to_download=files)

--- a/parsons/sftp/sftp.py
+++ b/parsons/sftp/sftp.py
@@ -220,8 +220,15 @@ class SFTP(object):
                 Optional. Size in bytes to iteratively export from the remote server.
         """
 
+        logger.info(
+            f"Reading from {remote_path} to {local_path} in {export_chunk_size}B chunks"
+        )
+
         with connection.open(remote_path, "rb") as _remote_file:
-            with open(local_path, "rb") as _local_file:
+            with open(local_path, "wb") as _local_file:
+                # This disables paramiko's prefetching behavior
+                _remote_file.set_pipelined(False)
+
                 while True:
                     # Read in desired number of rows from the server
                     response = _remote_file.read(export_chunk_size)
@@ -232,7 +239,7 @@ class SFTP(object):
 
                     # Write to the destination file
                     _local_file.write(response)
-                    logger.info(
+                    logger.debug(
                         f"Successfully read {export_chunk_size} rows to {local_path}"
                     )
 

--- a/test/test_catalist/test_catalist.py
+++ b/test/test_catalist/test_catalist.py
@@ -152,4 +152,7 @@ class TestCatalist:
 
         assert second_called_method == "get_file"
 
-        assert second_mocked_call.kwargs == {"remote_path": "/myDownloads/example_12345"}
+        assert second_mocked_call.kwargs == {
+            "remote_path": "/myDownloads/example_12345",
+            "export_chunk_size": 52428800,
+        }

--- a/test/test_catalist/test_catalist.py
+++ b/test/test_catalist/test_catalist.py
@@ -94,7 +94,9 @@ class TestCatalist:
         assert requested_base_url == "api.catalist.us"
         assert set(requested_queries.keys()) == set(["token"])
         assert requested_queries["token"] == ["tokenexample"]
-        assert requested_endpoint.startswith("/mapi/upload/template/48827/action/publish/url/")
+        assert requested_endpoint.startswith(
+            "/mapi/upload/template/48827/action/publish/url/"
+        )
 
     def test_upload_with_options(self, mock_requests) -> None:
         """Mock use of upload() method with options, check API calls."""
@@ -148,4 +150,4 @@ class TestCatalist:
         second_mocked_call = match.sftp.mock_calls[1]
         second_called_method = str(second_mocked_call).split("(")[0].split(".")[1]
         assert second_called_method == "get_file"
-        assert set(second_mocked_call.args) == set(["/myDownloads/example_12345"])
+        assert set(second_mocked_call.args) == set(["/myDownloads/example_12345", None])

--- a/test/test_catalist/test_catalist.py
+++ b/test/test_catalist/test_catalist.py
@@ -94,9 +94,7 @@ class TestCatalist:
         assert requested_base_url == "api.catalist.us"
         assert set(requested_queries.keys()) == set(["token"])
         assert requested_queries["token"] == ["tokenexample"]
-        assert requested_endpoint.startswith(
-            "/mapi/upload/template/48827/action/publish/url/"
-        )
+        assert requested_endpoint.startswith("/mapi/upload/template/48827/action/publish/url/")
 
     def test_upload_with_options(self, mock_requests) -> None:
         """Mock use of upload() method with options, check API calls."""

--- a/test/test_catalist/test_catalist.py
+++ b/test/test_catalist/test_catalist.py
@@ -155,6 +155,6 @@ class TestCatalist:
         assert second_called_method == "get_file"
 
         assert second_mocked_call.kwargs == {
-            "remote_filepath": "/myDownloads/example_12345",
+            "remote_path": "/myDownloads/example_12345",
             "export_chunk_size": 100000,
         }

--- a/test/test_catalist/test_catalist.py
+++ b/test/test_catalist/test_catalist.py
@@ -138,16 +138,23 @@ class TestCatalist:
 
         # Execute download
         match.sftp.list_directory = MagicMock(return_value=["example_12345"])
-        match.load_matches("12345")
+        match.load_matches("12345", 100_000)
 
         # We expect two calls to the SFTP client to list the directory and get the file
         assert len(match.sftp.mock_calls) == 2
+
         first_mocked_call = match.sftp.mock_calls[0]
         first_called_method = str(first_mocked_call).split("(")[0].split(".")[1]
+
         assert first_called_method == "list_directory"
         assert set(first_mocked_call.args) == set(["/myDownloads/"])
 
         second_mocked_call = match.sftp.mock_calls[1]
         second_called_method = str(second_mocked_call).split("(")[0].split(".")[1]
+
         assert second_called_method == "get_file"
-        assert set(second_mocked_call.args) == set(["/myDownloads/example_12345", None])
+
+        assert second_mocked_call.kwargs == {
+            "remote_filepath": "/myDownloads/example_12345",
+            "export_chunk_size": 100000,
+        }

--- a/test/test_catalist/test_catalist.py
+++ b/test/test_catalist/test_catalist.py
@@ -136,7 +136,7 @@ class TestCatalist:
 
         # Execute download
         match.sftp.list_directory = MagicMock(return_value=["example_12345"])
-        match.load_matches("12345", 100_000)
+        match.load_matches("12345")
 
         # We expect two calls to the SFTP client to list the directory and get the file
         assert len(match.sftp.mock_calls) == 2
@@ -152,7 +152,4 @@ class TestCatalist:
 
         assert second_called_method == "get_file"
 
-        assert second_mocked_call.kwargs == {
-            "remote_path": "/myDownloads/example_12345",
-            "export_chunk_size": 100000,
-        }
+        assert second_mocked_call.kwargs == {"remote_path": "/myDownloads/example_12345"}


### PR DESCRIPTION
This PR adds logic to optionally chunk the exporting of a flat file from Catalist's SFTP server to the local filesystem (though technically this will provide chunking functionality to any connection using the Parsons `SFTP` class)