### PR TITLE
Kasiah/zoom single row tables

### DIFF
--- a/parsons/zoom/zoom.py
+++ b/parsons/zoom/zoom.py
@@ -79,7 +79,9 @@ class Zoom:
                 data.extend(self.client.data_parse(r))
             return Table(data)
 
-    def __handle_nested_json(self, table: Table, column: str) -> Table:
+    def __handle_nested_json(
+        self, table: Table, column: str, version_2: bool = False
+    ) -> Table:
         """
         This function unpacks JSON values from Zoom's API, which are often
         objects nested in lists
@@ -94,6 +96,8 @@ class Zoom:
         `Returns`:
             Parsons Table
         """
+        if version_2:
+            return Table(table.unpack_list(column=column))
 
         return Table(table.unpack_list(column=column)).unpack_dict(
             column=f"{column}_0", prepend_value=f"{column}_"
@@ -126,7 +130,9 @@ class Zoom:
         tbl.remove_column("question_details")
 
         # Unpack question values
-        tbl = tbl.unpack_dict("question_details_value", include_original=True, prepend=False)
+        tbl = tbl.unpack_dict(
+            "question_details_value", include_original=True, prepend=False
+        )
 
         # Remove column from API response
         tbl.remove_column("question_details_value")
@@ -219,7 +225,9 @@ class Zoom:
                 See :ref:`parsons-table` for output options.
         """
 
-        tbl = self._get_request(f"report/meetings/{meeting_id}/participants", "participants")
+        tbl = self._get_request(
+            f"report/meetings/{meeting_id}/participants", "participants"
+        )
         logger.info(f"Retrieved {tbl.num_rows} participants.")
         return tbl
 
@@ -284,7 +292,9 @@ class Zoom:
                 See :ref:`parsons-table` for output options.
         """
 
-        tbl = self._get_request(f"report/webinars/{webinar_id}/participants", "participants")
+        tbl = self._get_request(
+            f"report/webinars/{webinar_id}/participants", "participants"
+        )
         logger.info(f"Retrieved {tbl.num_rows} webinar participants.")
         return tbl
 
@@ -304,7 +314,9 @@ class Zoom:
         logger.info(f"Retrieved {tbl.num_rows} webinar registrants.")
         return tbl
 
-    def get_meeting_poll_metadata(self, meeting_id, poll_id) -> Table:
+    def get_meeting_poll_metadata(
+        self, meeting_id, poll_id, version_2: bool = False
+    ) -> Table:
         """
         Get metadata about a specific poll for a given meeting ID
 
@@ -323,9 +335,6 @@ class Zoom:
         endpoint = f"meetings/{meeting_id}/polls/{poll_id}"
         tbl = self._get_request(endpoint=endpoint, data_key="questions")
 
-        if isinstance(tbl, dict):
-            logger.debug(f"No poll data returned for poll ID {poll_id}")
-            return Table(tbl)
         if tbl.num_rows == 0:
             logger.debug(f"No poll data returned for poll ID {poll_id}")
             return tbl
@@ -335,12 +344,18 @@ class Zoom:
         )
 
         if "prompts" in tbl.columns:
-            logger.info(f"Unnesting columns 'prompts' from existing table columns: {tbl.columns}")
-            return self.__handle_nested_json(table=tbl, column="prompts")
+            logger.info(
+                f"Unnesting columns 'prompts' from existing table columns: {tbl.columns}"
+            )
+            return self.__handle_nested_json(
+                table=tbl, column="prompts", version_2=version_2
+            )
         else:
             return tbl
 
-    def get_meeting_all_polls_metadata(self, meeting_id) -> Table:
+    def get_meeting_all_polls_metadata(
+        self, meeting_id, version_2: bool = False
+    ) -> Table:
         """
         Get metadata for all polls for a given meeting ID
 
@@ -357,18 +372,19 @@ class Zoom:
         endpoint = f"meetings/{meeting_id}/polls"
         tbl = self._get_request(endpoint=endpoint, data_key="polls")
 
-        if isinstance(tbl, dict):
-            logger.debug(f"No poll data returned for meeting ID {meeting_id}")
-            return Table(tbl)
         if tbl.num_rows == 0:
             logger.debug(f"No poll data returned for meeting ID {meeting_id}")
             return tbl
 
         logger.info(f"Retrieved {tbl.num_rows} polls for meeting ID {meeting_id}")
 
-        return self.__handle_nested_json(table=tbl, column="questions")
+        return self.__handle_nested_json(
+            table=tbl, column="questions", version_2=version_2
+        )
 
-    def get_past_meeting_poll_metadata(self, meeting_id) -> Table:
+    def get_past_meeting_poll_metadata(
+        self, meeting_id, version_2: bool = False
+    ) -> Table:
         """
         List poll metadata of a past meeting.
 
@@ -385,9 +401,6 @@ class Zoom:
         endpoint = f"past_meetings/{meeting_id}/polls"
         tbl = self._get_request(endpoint=endpoint, data_key="questions")
 
-        if isinstance(tbl, dict):
-            logger.debug(f"No poll data returned for meeting ID {meeting_id}")
-            return Table(tbl)
         if tbl.num_rows == 0:
             logger.debug(f"No poll data returned for meeting ID {meeting_id}")
             return tbl
@@ -397,9 +410,13 @@ class Zoom:
             f"Unnesting columns 'question_details' from existing table columns: {tbl.columns}"
         )
 
-        return self.__handle_nested_json(table=tbl, column="question_details")
+        return self.__handle_nested_json(
+            table=tbl, column="question_details", version_2=version_2
+        )
 
-    def get_webinar_poll_metadata(self, webinar_id, poll_id) -> Table:
+    def get_webinar_poll_metadata(
+        self, webinar_id, poll_id, version_2: bool = False
+    ) -> Table:
         """
         Get metadata for a specific poll for a given webinar ID
 
@@ -418,9 +435,6 @@ class Zoom:
         endpoint = f"webinars/{webinar_id}/polls/{poll_id}"
         tbl = self._get_request(endpoint=endpoint, data_key="questions")
 
-        if isinstance(tbl, dict):
-            logger.debug(f"No poll data returned for poll ID {poll_id}")
-            return Table(tbl)
         if tbl.num_rows == 0:
             logger.debug(f"No poll data returned for poll ID {poll_id}")
             return tbl
@@ -429,9 +443,13 @@ class Zoom:
             f"Retrieved {tbl.num_rows} rows of metadata [meeting={webinar_id} poll={poll_id}]"
         )
 
-        return self.__handle_nested_json(table=tbl, column="prompts")
+        return self.__handle_nested_json(
+            table=tbl, column="prompts", version_2=version_2
+        )
 
-    def get_webinar_all_polls_metadata(self, webinar_id) -> Table:
+    def get_webinar_all_polls_metadata(
+        self, webinar_id, version_2: bool = False
+    ) -> Table:
         """
         Get metadata for all polls for a given webinar ID
 
@@ -448,18 +466,19 @@ class Zoom:
         endpoint = f"webinars/{webinar_id}/polls"
         tbl = self._get_request(endpoint=endpoint, data_key="polls")
 
-        if isinstance(tbl, dict):
-            logger.debug(f"No poll data returned for webinar ID {webinar_id}")
-            return Table(tbl)
         if tbl.num_rows == 0:
             logger.debug(f"No poll data returned for webinar ID {webinar_id}")
             return tbl
 
         logger.info(f"Retrieved {tbl.num_rows} polls for meeting ID {webinar_id}")
 
-        return self.__handle_nested_json(table=tbl, column="questions")
+        return self.__handle_nested_json(
+            table=tbl, column="questions", version_2=version_2
+        )
 
-    def get_past_webinar_poll_metadata(self, webinar_id) -> Table:
+    def get_past_webinar_poll_metadata(
+        self, webinar_id, version_2: bool = False
+    ) -> Table:
         """
         Retrieves the metadata for Webinar Polls of a specific Webinar
 
@@ -476,16 +495,15 @@ class Zoom:
         endpoint = f"past_webinars/{webinar_id}/polls"
         tbl = self._get_request(endpoint=endpoint, data_key="questions")
 
-        if isinstance(tbl, dict):
-            logger.debug(f"No poll data returned for webinar ID {webinar_id}")
-            return Table(tbl)
         if tbl.num_rows == 0:
             logger.debug(f"No poll data returned for webinar ID {webinar_id}")
             return tbl
 
         logger.info(f"Retrieved {tbl.num_rows} polls for meeting ID {webinar_id}")
 
-        return self.__handle_nested_json(table=tbl, column="prompts")
+        return self.__handle_nested_json(
+            table=tbl, column="prompts", version_2=version_2
+        )
 
     def get_meeting_poll_results(self, meeting_id) -> Table:
         """
@@ -497,9 +515,6 @@ class Zoom:
         endpoint = f"report/meetings/{meeting_id}/polls"
         tbl = self._get_request(endpoint=endpoint, data_key="questions")
 
-        if isinstance(tbl, dict):
-            logger.debug(f"No poll data returned for meeting ID {meeting_id}")
-            return Table(tbl)
         if tbl.num_rows == 0:
             logger.debug(f"No poll data returned for meeting ID {meeting_id}")
             return tbl
@@ -518,9 +533,6 @@ class Zoom:
         endpoint = f"report/webinars/{webinar_id}/polls"
         tbl = self._get_request(endpoint=endpoint, data_key="questions")
 
-        if isinstance(tbl, dict):
-            logger.debug(f"No poll data returned for webinar ID {webinar_id}")
-            return Table(tbl)
         if tbl.num_rows == 0:
             logger.debug(f"No poll data returned for webinar ID {webinar_id}")
             return tbl

--- a/parsons/zoom/zoom.py
+++ b/parsons/zoom/zoom.py
@@ -79,9 +79,7 @@ class Zoom:
                 data.extend(self.client.data_parse(r))
             return Table(data)
 
-    def __handle_nested_json(
-        self, table: Table, column: str, version_2: bool = False
-    ) -> Table:
+    def __handle_nested_json(self, table: Table, column: str, version_2: bool = False) -> Table:
         """
         This function unpacks JSON values from Zoom's API, which are often
         objects nested in lists
@@ -130,9 +128,7 @@ class Zoom:
         tbl.remove_column("question_details")
 
         # Unpack question values
-        tbl = tbl.unpack_dict(
-            "question_details_value", include_original=True, prepend=False
-        )
+        tbl = tbl.unpack_dict("question_details_value", include_original=True, prepend=False)
 
         # Remove column from API response
         tbl.remove_column("question_details_value")
@@ -225,9 +221,7 @@ class Zoom:
                 See :ref:`parsons-table` for output options.
         """
 
-        tbl = self._get_request(
-            f"report/meetings/{meeting_id}/participants", "participants"
-        )
+        tbl = self._get_request(f"report/meetings/{meeting_id}/participants", "participants")
         logger.info(f"Retrieved {tbl.num_rows} participants.")
         return tbl
 
@@ -292,9 +286,7 @@ class Zoom:
                 See :ref:`parsons-table` for output options.
         """
 
-        tbl = self._get_request(
-            f"report/webinars/{webinar_id}/participants", "participants"
-        )
+        tbl = self._get_request(f"report/webinars/{webinar_id}/participants", "participants")
         logger.info(f"Retrieved {tbl.num_rows} webinar participants.")
         return tbl
 
@@ -314,9 +306,7 @@ class Zoom:
         logger.info(f"Retrieved {tbl.num_rows} webinar registrants.")
         return tbl
 
-    def get_meeting_poll_metadata(
-        self, meeting_id, poll_id, version_2: bool = False
-    ) -> Table:
+    def get_meeting_poll_metadata(self, meeting_id, poll_id, version_2: bool = False) -> Table:
         """
         Get metadata about a specific poll for a given meeting ID
 
@@ -344,18 +334,12 @@ class Zoom:
         )
 
         if "prompts" in tbl.columns:
-            logger.info(
-                f"Unnesting columns 'prompts' from existing table columns: {tbl.columns}"
-            )
-            return self.__handle_nested_json(
-                table=tbl, column="prompts", version_2=version_2
-            )
+            logger.info(f"Unnesting columns 'prompts' from existing table columns: {tbl.columns}")
+            return self.__handle_nested_json(table=tbl, column="prompts", version_2=version_2)
         else:
             return tbl
 
-    def get_meeting_all_polls_metadata(
-        self, meeting_id, version_2: bool = False
-    ) -> Table:
+    def get_meeting_all_polls_metadata(self, meeting_id, version_2: bool = False) -> Table:
         """
         Get metadata for all polls for a given meeting ID
 
@@ -378,13 +362,9 @@ class Zoom:
 
         logger.info(f"Retrieved {tbl.num_rows} polls for meeting ID {meeting_id}")
 
-        return self.__handle_nested_json(
-            table=tbl, column="questions", version_2=version_2
-        )
+        return self.__handle_nested_json(table=tbl, column="questions", version_2=version_2)
 
-    def get_past_meeting_poll_metadata(
-        self, meeting_id, version_2: bool = False
-    ) -> Table:
+    def get_past_meeting_poll_metadata(self, meeting_id, version_2: bool = False) -> Table:
         """
         List poll metadata of a past meeting.
 
@@ -410,13 +390,9 @@ class Zoom:
             f"Unnesting columns 'question_details' from existing table columns: {tbl.columns}"
         )
 
-        return self.__handle_nested_json(
-            table=tbl, column="question_details", version_2=version_2
-        )
+        return self.__handle_nested_json(table=tbl, column="question_details", version_2=version_2)
 
-    def get_webinar_poll_metadata(
-        self, webinar_id, poll_id, version_2: bool = False
-    ) -> Table:
+    def get_webinar_poll_metadata(self, webinar_id, poll_id, version_2: bool = False) -> Table:
         """
         Get metadata for a specific poll for a given webinar ID
 
@@ -443,13 +419,9 @@ class Zoom:
             f"Retrieved {tbl.num_rows} rows of metadata [meeting={webinar_id} poll={poll_id}]"
         )
 
-        return self.__handle_nested_json(
-            table=tbl, column="prompts", version_2=version_2
-        )
+        return self.__handle_nested_json(table=tbl, column="prompts", version_2=version_2)
 
-    def get_webinar_all_polls_metadata(
-        self, webinar_id, version_2: bool = False
-    ) -> Table:
+    def get_webinar_all_polls_metadata(self, webinar_id, version_2: bool = False) -> Table:
         """
         Get metadata for all polls for a given webinar ID
 
@@ -472,13 +444,9 @@ class Zoom:
 
         logger.info(f"Retrieved {tbl.num_rows} polls for meeting ID {webinar_id}")
 
-        return self.__handle_nested_json(
-            table=tbl, column="questions", version_2=version_2
-        )
+        return self.__handle_nested_json(table=tbl, column="questions", version_2=version_2)
 
-    def get_past_webinar_poll_metadata(
-        self, webinar_id, version_2: bool = False
-    ) -> Table:
+    def get_past_webinar_poll_metadata(self, webinar_id, version_2: bool = False) -> Table:
         """
         Retrieves the metadata for Webinar Polls of a specific Webinar
 
@@ -501,9 +469,7 @@ class Zoom:
 
         logger.info(f"Retrieved {tbl.num_rows} polls for meeting ID {webinar_id}")
 
-        return self.__handle_nested_json(
-            table=tbl, column="prompts", version_2=version_2
-        )
+        return self.__handle_nested_json(table=tbl, column="prompts", version_2=version_2)
 
     def get_meeting_poll_results(self, meeting_id) -> Table:
         """


### PR DESCRIPTION
- If the results are a dict, it's not an empty table, it's a 1 row table
- _handle_nested_json was unpacking the first dict in a list of dicts, leaving the others unnested. Added a version 2 flag to avoid this behavior