### PR TITLE
Use TableSchema in BigQuery Column List

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1194,9 +1194,9 @@ class GoogleBigQuery(DatabaseConnector):
             A list of column names
         """
 
-        first_row = self.query(f"SELECT * FROM {schema}.{table_name} LIMIT 1;")
+        table_ref = self.client.get_table(table=f"{schema}.{table_name}")
 
-        return [x for x in first_row.columns]
+        return [schema_ref.name for schema_ref in table_ref.schema]
 
     def get_row_count(self, schema: str, table_name: str) -> int:
         """

--- a/test/test_airmeet.py
+++ b/test/test_airmeet.py
@@ -202,9 +202,9 @@ class TestAirmeet(unittest.TestCase):
         assert isinstance(result["sessions"], Table), "The sessions should be a Table"
         assert isinstance(result["session_hosts"], Table), "The session hosts should be a Table"
         assert len(result["sessions"]) == 2, "Sessions Table should contain exactly two records"
-        assert len(result["session_hosts"]) == 1, (
-            "Session hosts Table should contain exactly one record"
-        )
+        assert (
+            len(result["session_hosts"]) == 1
+        ), "Session hosts Table should contain exactly one record"
 
     def test_fetch_airmeet_custom_registration_fields(self):
         # Test get the custom registration fields for an Airmeet.

--- a/test/test_airmeet.py
+++ b/test/test_airmeet.py
@@ -202,9 +202,9 @@ class TestAirmeet(unittest.TestCase):
         assert isinstance(result["sessions"], Table), "The sessions should be a Table"
         assert isinstance(result["session_hosts"], Table), "The session hosts should be a Table"
         assert len(result["sessions"]) == 2, "Sessions Table should contain exactly two records"
-        assert (
-            len(result["session_hosts"]) == 1
-        ), "Session hosts Table should contain exactly one record"
+        assert len(result["session_hosts"]) == 1, (
+            "Session hosts Table should contain exactly one record"
+        )
 
     def test_fetch_airmeet_custom_registration_fields(self):
         # Test get the custom registration fields for an Airmeet.


### PR DESCRIPTION
This fix patches an inefficiency in the `GoogleBigQuery.get_columns_list()` function ... writing a `SELECT * FROM {{ TABLE }} LIMIT 1` in BigQuery isn't recommended as the entire table will be scanned in the process. 

This PR updates the logic to leverage the underlying `schema` definition, rather than querying against the table.