### PR TITLE
convert both list and dict columns to json

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -794,7 +794,7 @@ class GoogleBigQuery(DatabaseConnector):
         quote: Optional[str] = None,
         schema: Optional[List[dict]] = None,
         max_timeout: int = 21600,
-        convert_dict_columns_to_json: bool = True,
+        convert_dict_list_columns_to_json: bool = True,
         **load_kwargs,
     ):
         """
@@ -827,8 +827,8 @@ class GoogleBigQuery(DatabaseConnector):
                 columns and data types as the template table.
             max_timeout: int
                 The maximum number of seconds to wait for a request before the job fails.
-            convert_dict_columns_to_json: bool
-                If set to True, will convert any dict columns (which cannot by default be successfully loaded to BigQuery to JSON strings)
+            convert_dict_list_columns_to_json: bool
+                If set to True, will convert any dict or list columns (which cannot by default be successfully loaded to BigQuery to JSON strings)
             **load_kwargs: kwargs
                 Arguments to pass to the underlying load_table_from_uri call on the BigQuery
                 client.
@@ -855,10 +855,10 @@ class GoogleBigQuery(DatabaseConnector):
         else:
             csv_delimiter = ","
 
-        if convert_dict_columns_to_json:
+        if convert_dict_list_columns_to_json:
             # Convert dict columns to JSON strings
             for field in tbl.get_columns_type_stats():
-                if "dict" in field["type"]:
+                if "dict" in field["type"] or "list" in field["type"]:
                     new_petl = tbl.table.addfield(
                         field["name"] + "_replace",
                         lambda row: json.dumps(row[field["name"]]),


### PR DESCRIPTION
In #1143, an update was made that enabled the BigQuery connector to automatically load dict columns as JSON strings rather than fail to load and error out.

List columns need the same fix - they cannot load by default into BigQuery and need to be converted to a JSON string. This PR makes that update.