### PR TITLE
Add Introspection class for API key profiles with tests

### DIFF
--- a/parsons/ngpvan/introspection.py
+++ b/parsons/ngpvan/introspection.py
@@ -1,0 +1,21 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Introspection(object):
+    def __init__(self, van_connection):
+        self.connection = van_connection
+
+    def get_apikeyprofiles(self):
+        """
+        Get API key profiles.
+
+        `Args:`
+            None
+        `Returns:`
+            JSON response
+        """
+
+        response = self.connection.get_request("apiKeyProfiles")
+        return response[0]

--- a/parsons/ngpvan/van.py
+++ b/parsons/ngpvan/van.py
@@ -18,6 +18,7 @@ from parsons.ngpvan.contact_notes import ContactNotes
 from parsons.ngpvan.custom_fields import CustomFields
 from parsons.ngpvan.targets import Targets
 from parsons.ngpvan.printed_lists import PrintedLists
+from parsons.ngpvan.introspection import Introspection
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,7 @@ class VAN(
     ContactNotes,
     CustomFields,
     Targets,
+    Introspection,
 ):
     """
     Returns the VAN class

--- a/test/test_van/test_introspection.py
+++ b/test/test_van/test_introspection.py
@@ -1,0 +1,49 @@
+import unittest
+import os
+import requests_mock
+from parsons import VAN
+
+
+os.environ["VAN_API_KEY"] = "SOME_KEY"
+
+
+class TestNGPVAN(unittest.TestCase):
+    def setUp(self):
+        self.van = VAN(os.environ["VAN_API_KEY"], db="MyVoters")
+
+    def tearDown(self):
+        pass
+
+    @requests_mock.Mocker()
+    def test_get_apikeyprofiles(self, m):
+        json = {
+            "items": [
+                {
+                    "databaseName": "SmartVAN Massachusetts",
+                    "hasMyVoters": True,
+                    "hasMyCampaign": True,
+                    "committeeName": "People for Good",
+                    "apiKeyTypeName": "Custom Integration",
+                    "keyReference": "1234",
+                    "userFirstName": "peopleforgood",
+                    "userLastName": "api",
+                    "username": "peopleforgood.api",
+                    "userId": 4321,
+                }
+            ],
+            "nextPageLink": None,
+            "count": 1,
+        }
+
+        m.get(self.van.connection.uri + "apiKeyProfiles", json=json)
+
+        # # Call the method that makes the API request
+        response = self.van.get_apikeyprofiles()
+
+        # Assert that the response is a dictionary (JSON object)
+        self.assertIsInstance(response, dict)
+
+        # Assert that the response matches the expected JSON
+        # I have to access a part of the json because the response is a list of dictionaries
+        # and the VAN Connector handles the pagination and unpacks the list of dictionaries
+        self.assertEqual(response, json["items"][0])


### PR DESCRIPTION
Introduce an Introspection class to handle API key profiles and implement corresponding unit tests to validate functionality.

Issue #1180