### PR TITLE
skip "Coverage comment" step if triggered by pull request

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -139,6 +139,7 @@ jobs:
             - name: Coverage comment
               id: coverage_comment
               uses: py-cov-action/python-coverage-comment-action@b2eb38dd175bf053189b35f738f9207278b00925  # v3.29
+              if: github.event.workflow_run.event != 'pull_request'
               with:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   MERGE_COVERAGE_FILES: true


### PR DESCRIPTION
Should fix failing coverage job as in https://github.com/move-coop/parsons/pull/1290 for commits pushed to PRs on branches within the move-coop/parsons repo. 

It still posts the comments fine for PRs from forks, because that is handled by the coverage.yml workflow.