### PR TITLE
Only run python check workflow on pushes to main and major release

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -2,6 +2,7 @@ name: Python checks
 
 on:
     push:
+        branches: ["main", "major-release"]
     pull_request:
     workflow_dispatch:
 


### PR DESCRIPTION
Pushes to pull requests opened by dependabot were running every check twice (since it was a local push and a PR update).