### PR TITLE
Add ruff Implicit String Concatenation Rules

### DIFF
--- a/parsons/donorbox/donorbox.py
+++ b/parsons/donorbox/donorbox.py
@@ -221,5 +221,5 @@ class Donorbox(object):
                 continue
         raise ValueError(
             f"The date you supplied, {date_string}, is not a valid Donorbox format."
-            + "Try the following formats: YYYY-mm-dd YYYY/mm/dd YYYYmmdd dd-mm-YYYY"
+            "Try the following formats: YYYY-mm-dd YYYY/mm/dd YYYYmmdd dd-mm-YYYY"
         )

--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -109,7 +109,7 @@ class CensusGeocoder(object):
         if set(table.columns) != {"id", "street", "city", "state", "zip"}:
             msg = (
                 "Table must ONLY include `['id', 'street', 'city', 'state', 'zip']` as"
-                + "columns. Tip: try using `table.cut()`"
+                "columns. Tip: try using `table.cut()`"
             )
             raise ValueError(msg)
 

--- a/parsons/scytl/scytl.py
+++ b/parsons/scytl/scytl.py
@@ -29,7 +29,7 @@ ELECTION_SETTINGS_JSON_URL_TEMPLATE = (
 
 BROWSER_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) "
-    + "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36"
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36"
 }
 
 TZ_INFO = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ select = [
     "ICN", # flake8-import-conventions (ICN)
     "Q", # flake8-quotes (Q)
     "TC", # flake8-type-checking (TC)
+    "ISC", # flake8-implicit-str-concat (ISC)
 ]
 ignore = [
     "E501", # line-too-long (E501)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ select = [
     "TID", # flake8-tidy-imports (TID)
     "ICN", # flake8-import-conventions (ICN)
     "Q", # flake8-quotes (Q)
+    "TC", # flake8-type-checking (TC)
 ]
 ignore = [
     "E501", # line-too-long (E501)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ select = [
     "E", # pycodestyle errors
     "F", # Pyflakes (F)
     "I", # isort (I)
+    "TID", # flake8-tidy-imports (TID)
 ]
 ignore = [
     "E501", # line-too-long (E501)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,13 @@ target-version = "py39"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "I"]
-ignore = []
+select = [
+    "E4", "E7", "E9",  # subset of pycodestyle errors
+    "F", # Pyflakes (F)
+    "I", # isort (I)
+]
+ignore = [
+]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ select = [
     "F", # Pyflakes (F)
     "I", # isort (I)
     "TID", # flake8-tidy-imports (TID)
+    "ICN", # flake8-import-conventions (ICN)
 ]
 ignore = [
     "E501", # line-too-long (E501)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,12 @@ target-version = "py39"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = [
-    "E4", "E7", "E9",  # subset of pycodestyle errors
+    "E", # pycodestyle errors
     "F", # Pyflakes (F)
     "I", # isort (I)
 ]
 ignore = [
+    "E501", # line-too-long (E501)
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ select = [
     "I", # isort (I)
     "TID", # flake8-tidy-imports (TID)
     "ICN", # flake8-import-conventions (ICN)
+    "Q", # flake8-quotes (Q)
 ]
 ignore = [
     "E501", # line-too-long (E501)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,0 @@
-import pytest
-
-# raise ValueError
-xfail_value_error = pytest.mark.xfail(raises=ValueError, strict=True)

--- a/test/test_airmeet.py
+++ b/test/test_airmeet.py
@@ -276,7 +276,7 @@ class TestAirmeet(unittest.TestCase):
             return_value={
                 "statusCode": 202,
                 "statusMessage": "Preparing your results. Try after 5 minutes"
-                + "to get the updated results",
+                "to get the updated results",
             }
         )
 

--- a/test/test_shopify.py
+++ b/test/test_shopify.py
@@ -120,23 +120,23 @@ class TestShopify(unittest.TestCase):
         self.assertEqual(
             self.shopify.get_query_url(None, None, "orders", True),
             f"https://{SUBDOMAIN}.myshopify.com/admin/api/{API_VERSION}/orders/"
-            + "count.json?limit=250&status=any",
+            "count.json?limit=250&status=any",
         )
         self.assertEqual(
             self.shopify.get_query_url("2020-10-20", None, "orders", True),
             f"https://{SUBDOMAIN}.myshopify.com/admin/api/{API_VERSION}/orders/"
-            + "count.json?limit=250&status=any&created_at_min=2020-10-20T00:00:00&"
-            + "created_at_max=2020-10-21T00:00:00",
+            "count.json?limit=250&status=any&created_at_min=2020-10-20T00:00:00&"
+            "created_at_max=2020-10-21T00:00:00",
         )
         self.assertEqual(
             self.shopify.get_query_url(None, 2, "orders", True),
             f"https://{SUBDOMAIN}.myshopify.com/admin/api/{API_VERSION}/orders/"
-            + "count.json?limit=250&status=any&since_id=2",
+            "count.json?limit=250&status=any&since_id=2",
         )
         self.assertEqual(
             self.shopify.get_query_url(None, None, "orders", False),
             f"https://{SUBDOMAIN}.myshopify.com/admin/api/{API_VERSION}/orders.json?"
-            + "limit=250&status=any",
+            "limit=250&status=any",
         )
 
     @requests_mock.Mocker()

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -11,7 +11,6 @@ import pytest
 from parsons import Table
 from parsons.utilities import check_env, files, json_format, sql_helpers
 from parsons.utilities.datetime import date_to_timestamp, parse_date
-from test.conftest import xfail_value_error
 
 
 @pytest.mark.parametrize(
@@ -20,7 +19,9 @@ from test.conftest import xfail_value_error
         pytest.param("2018-12-13", 1544659200),
         pytest.param("2018-12-13T00:00:00-08:00", 1544688000),
         pytest.param("", None),
-        pytest.param("2018-12-13 PST", None, marks=[xfail_value_error]),
+        pytest.param(
+            "2018-12-13 PST", None, marks=[pytest.mark.xfail(raises=ValueError, strict=True)]
+        ),
     ],
 )
 def test_date_to_timestamp(date, exp_ts):


### PR DESCRIPTION
Built on top of #1324, this PR adds flake8-implicit-string-concat rules which ask contributors to use implicit multi-line string concatenation rather than explicit multi-line concatenation.

It also contains code changes to resolve all resulting errors.
No changes to code behavior.