### PR TITLE
Add bandit to pre-commit

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -74,7 +74,7 @@ jobs:
 
             - name: Run ruff format
               run: |
-                ruff format --diff --target-version=py39 .
+                ruff format --diff .
 
     ruff-check:
         runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,8 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 'v0.9.10'
     hooks:
-      # Run the linter.
       - id: ruff
-        args: [ --fix ]
-      # Run the formatter.
       - id: ruff-format
-        args: [ --target-version=py39 ]
 -   repo: https://github.com/PyCQA/bandit
     rev: '1.8.3'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
         args: [ --target-version=py39 ]
+-   repo: https://github.com/PyCQA/bandit
+    rev: '1.8.3'
+    hooks:
+    - id: bandit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.9.9'
+    rev: 'v0.9.10'
     hooks:
       # Run the linter.
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,10 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.4
+    rev: 'v0.9.9'
     hooks:
       # Run the linter.
       - id: ruff
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+        args: [ --target-version=py39 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Testing Requirements
-bandit[toml]==1.8.2
+bandit[toml]==1.8.3
 coverage==7.6.12
 pytest-cov==6.0.0
 pytest-datadir==1.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,10 @@
 # Testing Requirements
 bandit[toml]==1.8.3
 coverage==7.6.12
-pytest-cov==6.0.0
-pytest-datadir==1.5.0
+pytest-datadir==1.6.1
 pytest-mock==3.14.0
 pytest-xdist==3.6.1
-pytest==8.3.4
+pytest==8.3.5
 requests-mock==1.12.1
-ruff==0.9.9
+ruff==0.9.10
 testfixtures==8.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,5 @@ pytest-mock==3.14.0
 pytest-xdist==3.6.1
 pytest==8.3.4
 requests-mock==1.12.1
-ruff==0.9.4
+ruff==0.9.9
 testfixtures==8.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # Testing Requirements
 bandit[toml]==1.8.3
 coverage==7.6.12
+pytest-cov==6.0.0
 pytest-datadir==1.6.1
 pytest-mock==3.14.0
 pytest-xdist==3.6.1


### PR DESCRIPTION
Bandit has a pre-commit hook that will allow it to run before people commit code.
This should reduce the number of revision commits needed in PRs to satisfy CI warnings and errors.

This also updates ruff, bandit, and all the dev requirements