### PR TITLE
Bump slackclient from v1.3.0 to v1.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ requests_oauthlib==2.0.0
 setuptools==75.6.0
 simple-salesforce==1.12.6
 simplejson==3.19.3
-slackclient==1.3.0
+slackclient==1.3.1
 sqlalchemy >= 1.4.22, != 1.4.33, < 3.0.0 # Prefect does not work with 1.4.33 and >=2.0.0 has breaking changes
 suds-py3==1.4.5.0
 surveygizmo==1.2.3


### PR DESCRIPTION
Changelog:
https://github.com/slackapi/python-slack-sdk/releases/tag/1.3.1

Reasoning:
slackclient's v1 to v2 migration guide [recommends](https://github.com/slackapi/python-slack-sdk/wiki/Migrating-to-2.x) pinning to v1.3.1 if not upgrading to v2+.