### PR TITLE
Remove /docs from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,6 @@ updates:
       interval: weekly
 
   - package-ecosystem: pip
-    directory: /docs
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: pip
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
Since docs [requirements are now in requirements-dev.txt](https://github.com/move-coop/parsons/pull/1335), dependabot doesn't need to monitor that folder.