### PR TITLE
Add pre-commit test to ci

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -118,7 +118,53 @@ jobs:
 
             - name: Run bandit scan
               run: |
-                bandit -c pyproject.toml -r . -ll -ii
+                bandit --confidence-level=high --severity-level=high -c pyproject.toml -r .
+
+    pre-commit:
+        runs-on: ubuntu-latest
+        needs:
+            - ruff-format
+            - ruff-check
+            - bandit
+
+        permissions:
+            contents: write
+
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481  # v2.11.0
+              with:
+                  egress-policy: audit
+
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+            - name: Set up Python 3.13
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
+              with:
+                  python-version: 3.13
+                  cache: pip
+
+            - name: Install uv
+              uses: install-pinned/uv@cdd7153ace885f698b54dcd2ae4ce134afa2ac05  # 0.4.12
+
+            - name: Install module and dependencies
+              run: |
+                  uv pip install --system -r requirements.txt
+                  uv pip install --system -r requirements-dev.txt
+                  uv pip install --system -e .
+
+            - id: cache-pre-commit
+              uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
+              with:
+                  path: .pre-commit-cache
+                  key: ubuntu-latest-pre-commit-3.13
+
+            - name: Run pre-commit
+              run: |
+                  pre-commit install
+                  pre-commit run --all-files
+              env:
+                  PRE_COMMIT_HOME: .pre-commit-cache
 
     coverage:
         runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,6 @@ repos:
   - repo: https://github.com/PyCQA/bandit
     rev: '1.8.3'
     hooks:
-    - id: bandit
+      - id: bandit
+        args: ['--confidence-level=high', '--severity-level=high', '-c', 'pyproject.toml']
+        additional_dependencies: ['bandit[toml]']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 include = [
-    "parsons/**/*.py",
-    "test/**/*.py",
-    "useful_resources/**/*.py"
+    "**/*.py",
 ]
 exclude = [
     ".bzr",
@@ -116,7 +114,7 @@ profile = "hug"
 src_paths = [
     "parsons/",
     "test/",
-    "useful_resources/"
+    "useful_resources/",
 ]
 
 [tool.coverage.run]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # Testing Requirements
 bandit[toml]==1.8.3
 coverage==7.6.12
+pre-commit==4.2.0
 pytest-cov==6.0.0
 pytest-datadir==1.6.1
 pytest-mock==3.14.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 from distutils.core import setup
 from pathlib import Path
+
 from setuptools import find_packages
 
 


### PR DESCRIPTION
Since there have been a few issues with our pre-commit workflow lately I wrote a CI test which should help catch them before they hit main in the future.

How it works:
Since there isn't a good way to test pre-commit independently of the tests it runs, I have configured this only to run when ruff check, ruff format, and bandit ci jobs all pass. If they pass, then the pre-commit workflow will run. If it fails, there must be an issue with pre-commit.