### PR TITLE
add client_credential auth method for salesforce

### DIFF
--- a/parsons/salesforce/salesforce.py
+++ b/parsons/salesforce/salesforce.py
@@ -12,7 +12,7 @@ class Salesforce:
     """
     Instantiate the Salesforce class
 
-    Supports the passwor and client_credentials authentication_methods
+    Supports the password and client_credentials authentication_methods
 
     `Args:`
         username: str
@@ -261,6 +261,6 @@ class Salesforce:
                     domain=self.domain,
                 )
             else:
-                raise Exception("Shoudl not be possible to reach this code")
+                raise Exception("Should not be possible to reach this code")
 
         return self._client

--- a/parsons/salesforce/salesforce.py
+++ b/parsons/salesforce/salesforce.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 
 from simple_salesforce import Salesforce as _Salesforce
 
@@ -12,7 +13,7 @@ class Salesforce:
     """
     Instantiate the Salesforce class
 
-    Supports the password and client_credentials authentication_methods
+    Supports the password and `client_credentials <https://help.salesforce.com/s/articleView?id=xcloud.connected_app_client_credentials_setup.htm&type=5>`_ authentication methods.
 
     `Args:`
         username: str
@@ -50,15 +51,14 @@ class Salesforce:
         consumer_key=None,
         consumer_secret=None,
         domain=None,
-        authentication_method="password",
+        authentication_method=None,
     ):
-        try:
-            self.authentication_method = check_env.check("SALESFORCE_AUTHENTICATION_METHOD", None)
-        except KeyError:
-            if authentication_method is not None:
-                self.authentication_method = authentication_method
-            else:
-                raise
+        if authentication_method:
+            self.authentication_method = authentication_method
+        elif env_authentication_method := os.environ.get("SALESFORCE_AUTHENTICATION_METHOD"):
+            self.authentication_method = env_authentication_method
+        else:
+            self.authentication_method = "password"
 
         if self.authentication_method == "password":
             self.username = check_env.check("SALESFORCE_USERNAME", username)

--- a/parsons/salesforce/salesforce.py
+++ b/parsons/salesforce/salesforce.py
@@ -75,7 +75,7 @@ class Salesforce:
             self.domain = check_env.check("SALESFORCE_DOMAIN", domain)
 
         else:
-            raise ValueError(
+            raise NotImplementedError(
                 f"{self.authentication_method} is not a supported method. Parsons currently supports 'password' and 'client_credentials'"
             )
 


### PR DESCRIPTION
this PR adds the ability to connect with the [client_credential method](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&language=en_US&type=5) to salesforce.

this is a much safer auth method than the password flow. 

there are a number of other auth methods, so we might want to take a beat and think about a design that can grow more gracefully. 