### PR TITLE
add missing comma to pdi/contacts.py

### DIFF
--- a/parsons/pdi/contacts.py
+++ b/parsons/pdi/contacts.py
@@ -209,7 +209,7 @@ class Contacts:
             "phoneNumber": phone_number,
             "phoneType": phone_type,
             "isPrimary": primary,
-            "extension": extension
+            "extension": extension,
         }
 
         response = self._request(


### PR DESCRIPTION
It appears that #1417 was merged with a failed ruff format workflow.
This fixes it so the check passes.
It might make sense to enable a branch protection rule against merging PRs with failing checks!