### PR TITLE
Bump ruff in .pre-commit-config.yaml and requirements-dev.txt from 0.11.2 to 0.11.7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,6 @@ updates:
       interval: weekly
 
   - package-ecosystem: pip
-    directory: /docs
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: pip
     directory: /
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: ruff
+      - dependency-name: bandit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.11.5'
+    rev: 'v0.11.7'
     hooks:
       - id: ruff
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.11.2'
+    rev: 'v0.11.5'
     hooks:
       - id: ruff
       - id: ruff-format

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pytest-mock==3.14.0
 pytest-xdist==3.6.1
 pytest==8.3.5
 requests-mock==1.12.1
-ruff==0.11.5
+ruff==0.11.7
 testfixtures==8.3.0
 
 # Docs Requirements


### PR DESCRIPTION
When ruff is bumped by dependabot, the versions in pre-commit-config get out of sync which could lead to conflicts.
This could also happen with bandit, but that doesn't have such frequent updates.

## What's Changed
- Bump ruff in requirements-dev.txt from 0.11.5 to 0.11.7
- Bump ruff in pre-commit-config to match requirements-dev.txt version
- Blacklist ruff from dependabot update scanning
- Blacklist bandit from dependabot update scanning
- Remove old /docs config from dependabot.yml now that docs/requirements.txt have been combined into requirements-dev.txt