### PR TITLE
Eventually Fail Actblue

### DIFF
--- a/parsons/actblue/actblue.py
+++ b/parsons/actblue/actblue.py
@@ -27,7 +27,10 @@ class ActBlue(object):
                 https://secure.actblue.com/api/v1. You can set an ``ACTBLUE_URI`` env variable or
                 use this URI parameter if a different endpoint is necessary - for example, when
                 running this code in a test environment where you don't want to hit the actual API.
-
+            max_retries: int
+                The maximum number of times to poll the API for a download URL. Not required, default
+                is None, which means it will poll indefinitely until a download URL is returned.
+                ```ACTBLUE_MAX_RETRIES``` env variable can be set, which will override this parameter.
         For instructions on how to generate a Client UUID and Client Secret set,
         visit https://secure.actblue.com/docs/csv_api#authentication.
     """
@@ -134,7 +137,7 @@ class ActBlue(object):
             tries += 1
 
         if download_url is None:
-            raise TimeoutError("CSV generation timed out. Increase retries and try again.")
+            raise TimeoutError("CSV generation timed out. Increase max_retries and try again.")
 
         logger.info("Completed data generation.")
         logger.info("Beginning conversion to Parsons Table.")

--- a/parsons/actblue/actblue.py
+++ b/parsons/actblue/actblue.py
@@ -52,9 +52,8 @@ class ActBlue(object):
             auth=(self.actblue_client_uuid, self.actblue_client_secret),
             headers=self.headers,
         )
-        self.max_retries = int(
-            check_env.check("ACTBLUE_MAX_RETRIES", max_retries, optional=True)
-        ) or float("inf")
+        self.max_retries = check_env.check("ACTBLUE_MAX_RETRIES", max_retries, optional=True)
+        self.max_retries = int(self.max_retries) if self.max_retries else None
 
     def post_request(self, csv_type=None, date_range_start=None, date_range_end=None):
         """
@@ -129,7 +128,7 @@ class ActBlue(object):
         logger.info("Request received. Please wait while ActBlue generates this data.")
         download_url = None
         tries = 0
-        while download_url is None and tries < self.max_retries:
+        while download_url is None and (self.max_retries is None or tries < self.max_retries):
             download_url = self.get_download_url(csv_id)
             time.sleep(POLLING_DELAY)
             tries += 1

--- a/test/test_actblue/test_actblue.py
+++ b/test/test_actblue/test_actblue.py
@@ -113,4 +113,4 @@ class TestActBlue(unittest.TestCase):
 
         m.get(f"{TEST_URI}/csvs/{TEST_ID}", json=mocked_get_response_no_url)
 
-        self.ab.get_download_url(csv_id=TEST_ID)
+        assert self.ab.get_download_url(csv_id=TEST_ID) == "www.actblue.com"

--- a/test/test_actblue/test_actblue.py
+++ b/test/test_actblue/test_actblue.py
@@ -1,10 +1,10 @@
 import unittest
-from test.test_actblue import test_columns_data
 from unittest.mock import MagicMock
 
 import requests_mock
 
 from parsons import ActBlue, Table
+from test.test_actblue import test_columns_data
 
 TEST_CLIENT_UUID = "someuuid"
 TEST_CLIENT_SECRET = "somesecret"
@@ -89,3 +89,28 @@ class TestActBlue(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             self.ab.get_download_url(csv_id=TEST_ID)
+
+    @requests_mock.Mocker()
+    def test_error_on_unexpected_status(self, m):
+        mocked_get_response_no_url = {
+            "id": TEST_ID,
+            "download_url": None,
+            "status": "error",
+        }
+
+        m.get(f"{TEST_URI}/csvs/{TEST_ID}", json=mocked_get_response_no_url)
+
+        with self.assertRaises(ValueError):
+            self.ab.get_download_url(csv_id=TEST_ID)
+
+    @requests_mock.Mocker()
+    def test_no_error_on_expected_status(self, m):
+        mocked_get_response_no_url = {
+            "id": TEST_ID,
+            "download_url": "www.actblue.com",
+            "status": "complete",
+        }
+
+        m.get(f"{TEST_URI}/csvs/{TEST_ID}", json=mocked_get_response_no_url)
+
+        self.ab.get_download_url(csv_id=TEST_ID)

--- a/test/test_actblue/test_actblue.py
+++ b/test/test_actblue/test_actblue.py
@@ -1,10 +1,10 @@
 import unittest
+from test.test_actblue import test_columns_data
 from unittest.mock import MagicMock
 
 import requests_mock
 
 from parsons import ActBlue, Table
-from test.test_actblue import test_columns_data
 
 TEST_CLIENT_UUID = "someuuid"
 TEST_CLIENT_SECRET = "somesecret"
@@ -76,3 +76,16 @@ class TestActBlue(unittest.TestCase):
 
         table = self.ab.get_contributions(TEST_CSV_TYPE, TEST_DATE_RANGE_START, TEST_DATE_RANGE_END)
         assert test_columns_data.expected_table_columns == table.columns
+
+    @requests_mock.Mocker()
+    def test_error_on_complete_without_download_url(self, m):
+        mocked_get_response_no_url = {
+            "id": TEST_ID,
+            "download_url": None,
+            "status": "complete",
+        }
+
+        m.get(f"{TEST_URI}/csvs/{TEST_ID}", json=mocked_get_response_no_url)
+
+        with self.assertRaises(ValueError):
+            self.ab.get_download_url(csv_id=TEST_ID)


### PR DESCRIPTION
For context: we've had some issues with ActBlue CSV exports for which the export runs indefinitely without any sort of failure message. I have requested to them that they eventually add a new status that will indicate when these have failed and we should give up, but in the meantime it would be nice not to have jobs that run infinitely long.

This PR:
1.) Makes it so that if AB do eventually add a new status like "error" we will respect it and quit retrying
2.) Adds an optional maximum number of retries to the ActBlue endpoint so that we can eventually abandon hope and raise an error (rather than having a process that runs forever)

Firsts Parsons PR for me, so let me know what I do wrong here! Would a PR template be helpful for me to add?