### PR TITLE
move project definitions to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,45 @@
+[build-system]
+requires = [ "setuptools" ]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "parsons"
+version = "4.0.0"
+description = "A python library of connectors for the progressive community."
+readme = { file = "README.md", content-type = "text/markdown" }
+requires-python = ">=3.9,<3.14"
+license-files = [ "LICENSE.md" ]
+authors = [
+    { name = "The Movement Cooperative", email = "info@movementcooperative.org" },
+]
+maintainers = [
+    { name = "Shauna Gordon-McKeon" },
+]
+keywords = [ "PROGRESSIVE", "API", "ETL" ]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+dynamic = [
+    "dependencies",
+    "optional-dependencies",
+]
+
+[project.urls]
+"Home Page" = "https://www.parsonsproject.org/"
+DOCUMENTATION = "https://move-coop.github.io/parsons/html/stable/index.html"
+Repository = "https://github.com/move-coop/parsons.git"
+GitHub = "https://github.com/move-coop/parsons"
+
+[tool.setuptools.packages.find]
+where = ["parsons"]
+namespaces = false
+
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,8 @@ DOCUMENTATION = "https://move-coop.github.io/parsons/html/stable/index.html"
 Repository = "https://github.com/move-coop/parsons.git"
 GitHub = "https://github.com/move-coop/parsons"
 
-[tool.setuptools.packages.find]
-where = ["parsons"]
-namespaces = false
+[tool.setuptools]
+packages = ["parsons"]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ simple-salesforce==1.12.6
 simplejson==3.20.1
 slackclient==1.3.1
 sqlalchemy >= 1.4.22, != 1.4.33, < 3.0.0 # Prefect does not work with 1.4.33 and >=2.0.0 has breaking changes
+sshtunnel==0.4.0
 suds-py3==1.4.5.0
 surveygizmo==1.2.3
 twilio==9.6.0
@@ -50,5 +51,3 @@ xmltodict==0.14.2
 jinja2>=3.0.2
 selenium==3.141.0
 us==3.2.0
-sshtunnel==0.4.0
-

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from setuptools import setup
 
+
 def main():
     limited_deps = os.environ.get("PARSONS_LIMITED_DEPENDENCIES", "")
     if limited_deps.strip().upper() in ("1", "YES", "TRUE", "ON"):

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 import os
-from distutils.core import setup
 from pathlib import Path
 
-from setuptools import find_packages
-
+from setuptools import setup
 
 def main():
     limited_deps = os.environ.get("PARSONS_LIMITED_DEPENDENCIES", "")
@@ -76,37 +74,13 @@ def main():
         }
         extras_require["all"] = sorted({lib for libs in extras_require.values() for lib in libs})
     else:
-        THIS_DIR = os.path.abspath(os.path.dirname(__file__))
-        with open(os.path.join(THIS_DIR, "requirements.txt")) as reqs:
-            install_requires = reqs.read().strip().split("\n")
-        # No op for forward-compatibility
-        extras_require = {"all": []}
-
-    this_directory = Path(__file__).parent
-    long_description = (this_directory / "README.md").read_text()
+        pyproject_path = Path(__file__).parent / "requirements.txt"
+        install_requires = pyproject_path.read_text().strip().split("\n")
+        extras_require = {"all": []}  # No op for forward-compatibility
 
     setup(
-        name="parsons",
-        version="4.0.0",  # ensure this version number is in format of n.n.n, not n or n.n
-        author="The Movement Cooperative",
-        author_email="info@movementcooperative.org",
-        url="https://github.com/move-coop/parsons",
-        keywords=["PROGRESSIVE", "API", "ETL"],
-        packages=find_packages(),
         install_requires=install_requires,
         extras_require=extras_require,
-        classifiers=[
-            "Development Status :: 3 - Alpha",
-            "Intended Audience :: Developers",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3.11",
-            "Programming Language :: Python :: 3.12",
-            "Programming Language :: Python :: 3.13",
-        ],
-        python_requires=">=3.9,<3.14",
-        long_description=long_description,
-        long_description_content_type="text/markdown",
     )
 
 


### PR DESCRIPTION
My previous pass at this in #1015 got stuck because it removed the LIMITED_DEPENDENCIES / friendly dependencies feature and I was not confident enough to reimplement it, so I closed it.

Here is a more limited scope-approach that leaves the requirements.txt, requirements-dev.txt, and setup.py files handing dependencies, but moves project data and package selection to pyproject.toml