### PR TITLE
Allow range of dependency versions

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -14,9 +14,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-                os: ["ubuntu-latest", "windows-latest", "macos-latest"]
                 limited-dependencies: ["", "TRUE"]
+                os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+                resolution: ["highest", "lowest"]
 
         runs-on: ${{ matrix.os }}
 
@@ -38,20 +39,20 @@ jobs:
               env:
                   PARSONS_LIMITED_DEPENDENCIES: ${{ matrix.limited-dependencies }}
               run: |
-                uv pip install --system -e .[all]
-                uv pip install --system -r requirements-dev.txt
+                uv pip install --system --resolution ${{ matrix.resolution }} -e .[all]
+                uv pip install --system --resolution ${{ matrix.resolution }} -r requirements-dev.txt
 
             - name: Test with pytest
               run: |
                 pytest
               env:
-                  COVERAGE_FILE: ".coverage.${{ matrix.os }}.${{ matrix.python-version }}${{ matrix.limited-dependencies }}"
+                  COVERAGE_FILE: ".coverage.${{ matrix.os }}.${{ matrix.python-version }}${{ matrix.limited-dependencies }}${{ matrix.resolution }}"
 
             - name: Store coverage file
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
-                  name: coverage-${{ matrix.os }}${{ matrix.python-version }}${{ matrix.limited-dependencies }}
-                  path: .coverage.${{ matrix.os }}.${{ matrix.python-version }}${{ matrix.limited-dependencies }}
+                  name: coverage-${{ matrix.os }}${{ matrix.python-version }}${{ matrix.limited-dependencies }}${{ matrix.resolution }}
+                  path: .coverage.${{ matrix.os }}.${{ matrix.python-version }}${{ matrix.limited-dependencies }}${{ matrix.resolution }}
                   include-hidden-files: true
 
     ruff-format:

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -10,14 +10,13 @@ permissions:
     contents: read
 
 jobs:
-    test:
+    pytest:
         strategy:
             fail-fast: false
             matrix:
-                limited-dependencies: ["", "TRUE"]
                 os: ["ubuntu-latest", "windows-latest", "macos-latest"]
                 python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-                resolution: ["highest", "lowest"]
+                resolution: ["highest", "lowest", "limited-dependencies"]
 
         runs-on: ${{ matrix.os }}
 
@@ -36,23 +35,30 @@ jobs:
               uses: install-pinned/uv@1c7d0f99e461f01263da2a57156b20090118ead3  # 0.4.12
 
             - name: Install dependencies
-              env:
-                  PARSONS_LIMITED_DEPENDENCIES: ${{ matrix.limited-dependencies }}
+              if: matrix.resolution != 'limited-dependencies'
               run: |
                 uv pip install --system --resolution ${{ matrix.resolution }} -e .[all]
                 uv pip install --system --resolution ${{ matrix.resolution }} -r requirements-dev.txt
+
+            - name: Install with limited dependencies
+              if: matrix.resolution == 'limited-dependencies'
+              env:
+                  PARSONS_LIMITED_DEPENDENCIES: 'TRUE'
+              run: |
+                uv pip install --system -e .[all]
+                uv pip install --system -r requirements-dev.txt
 
             - name: Test with pytest
               run: |
                 pytest
               env:
-                  COVERAGE_FILE: ".coverage.${{ matrix.os }}.${{ matrix.python-version }}${{ matrix.limited-dependencies }}${{ matrix.resolution }}"
+                  COVERAGE_FILE: ".coverage.${{ matrix.os }}.${{ matrix.python-version }}${{ matrix.resolution }}"
 
             - name: Store coverage file
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
-                  name: coverage-${{ matrix.os }}${{ matrix.python-version }}${{ matrix.limited-dependencies }}${{ matrix.resolution }}
-                  path: .coverage.${{ matrix.os }}.${{ matrix.python-version }}${{ matrix.limited-dependencies }}${{ matrix.resolution }}
+                  name: coverage-${{ matrix.os }}${{ matrix.python-version }}${{ matrix.resolution }}
+                  path: .coverage.${{ matrix.os }}.${{ matrix.python-version }}${{ matrix.resolution }}
                   include-hidden-files: true
 
     ruff-format:
@@ -169,7 +175,7 @@ jobs:
 
     coverage:
         runs-on: ubuntu-latest
-        needs: test
+        needs: pytest
 
         permissions:
             pull-requests: write
@@ -202,9 +208,9 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
                 os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-                limited-dependencies: ["", "TRUE"]
+                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+                resolution: ["highest", "limited-dependencies"]
 
         runs-on: ${{ matrix.os }}
 
@@ -223,8 +229,15 @@ jobs:
                   cache: pip
 
             - name: Install dependencies
+              if: matrix.resolution != 'limited-dependencies'
+              run: |
+                  pip install -r requirements-dev.txt
+                  pip install -e .[all]
+
+            - name: Install with limited dependencies
+              if: matrix.resolution == 'limited-dependencies'
               env:
-                  PARSONS_LIMITED_DEPENDENCIES: ${{ matrix.limited-dependencies }}
+                  PARSONS_LIMITED_DEPENDENCIES: 'TRUE'
               run: |
                   pip install -r requirements-dev.txt
                   pip install -e .[all]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.11.7'
+    rev: 'v0.11.9'
     hooks:
       - id: ruff
       - id: ruff-format

--- a/parsons/redash/redash.py
+++ b/parsons/redash/redash.py
@@ -45,8 +45,8 @@ class Redash(object):
     ):
         self.base_url = check("REDASH_BASE_URL", base_url)
         self.user_api_key = check("REDASH_USER_API_KEY", user_api_key, optional=True)
-        self.pause = int(check("REDASH_PAUSE_TIME", pause_time, optional=True))
-        self.timeout = int(check("REDASH_TIMEOUT", timeout, optional=True))
+        self.pause = int(check("REDASH_PAUSE_TIME", str(pause_time), optional=True))
+        self.timeout = int(check("REDASH_TIMEOUT", str(timeout), optional=True))
 
         self.verify = verify  # for https requests
         self.session = requests.Session()

--- a/parsons/utilities/check_env.py
+++ b/parsons/utilities/check_env.py
@@ -1,19 +1,20 @@
 import os
-from typing import NoReturn, Optional, Union
+from typing import Optional
 
 
-def check(env: str, field: Optional[str], optional: Optional[bool] = False) -> Union[str, NoReturn]:
+def check(env: str, field: Optional[str], optional: Optional[bool] = False) -> Optional[str]:
     """
     Check if an environment variable has been set. If it has not been set
     and the passed field or arguments have not been passed, then raise an
     error.
     """
-    if not field:
-        try:
-            return os.environ[env]
-        except KeyError:
-            if not optional:
-                raise KeyError(
-                    f"No {env} found. Store as environment variable or pass as an argument."
-                )
-    return field
+    if field:
+        return field
+    try:
+        return os.environ[env]
+    except KeyError as e:
+        if not optional:
+            raise KeyError(
+                f"No {env} found. Store as environment variable or pass as an argument."
+            ) from e
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ docstring-code-format = false
 docstring-code-line-length = "dynamic"
 
 [tool.pytest.ini_options]
-addopts = "-rf --cov=parsons -n auto"
+addopts = "-rf --cov=parsons --no-cov-on-fail -n auto"
 testpaths = [
     "test",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pytest-mock==3.14.0
 pytest-xdist==3.6.1
 pytest==8.3.5
 requests-mock==1.12.1
-ruff==0.11.7
+ruff==0.11.9
 testfixtures==8.3.0
 
 # Docs Requirements

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,4 +17,4 @@ Sphinx==7.4.7;python_version<'3.10'
 sphinx-rtd-theme==3.0.2
 myst-parser==4.0.1;python_version>='3.10'
 myst-parser==3.0.1;python_version<'3.10'
-sphinx-multiversion
+sphinx-multiversion==0.2.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,10 +11,18 @@ requests-mock==1.12.1
 ruff==0.11.9
 testfixtures==8.3.0
 
+# Unpinned transient dependencies
+future>=0.18
+iniconfig>=2
+rich>=13
+
+# Additional minimum versions for compatibility
+nodeenv>=1.4  # pre-commit depends on nodeenv>=0.11.1, but nodeenv requires pipes until 1.4
+
 # Docs Requirements
-Sphinx==8.1.3;python_version>='3.10'
-Sphinx==7.4.7;python_version<'3.10'
-sphinx-rtd-theme==3.0.2
-myst-parser==4.0.1;python_version>='3.10'
 myst-parser==3.0.1;python_version<'3.10'
+myst-parser==4.0.1;python_version>='3.10'
 sphinx-multiversion==0.2.4
+sphinx-rtd-theme==3.0.2
+Sphinx==7.4.7;python_version<'3.10'
+Sphinx==8.1.3;python_version>='3.10'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,54 +1,77 @@
-pyairtable==3.0.2
-azure-storage-blob==12.25.1
-boto3>=1.17.98
-boxsdk==3.13.0
-braintree==4.31.0
-bs4==0.0.2
-censusgeocode==0.5.2
-civis==1.16.1;python_version<"3.10"  # later Civis versions do not support Python 3.9
-civis==2.4.3;python_version>="3.10"  
-curlify==2.2.1
-dbt_core>=1.5.0
-defusedxml>=0.7.1, <=0.8.0
-facebook-business==22.0.2
-google-api-core==2.24.2
-google-api-python-client==2.163.0
-google-auth==2.38.0
-google-cloud-bigquery==3.31.0
-google-cloud-storage-transfer==1.16.0
-google-cloud-storage==3.1.0
-grpcio==1.68.1
-gspread==6.1.4
-httplib2==0.22.0
-joblib==1.2.0;python_version<"3.10"  # Civis 1.16.1, which runs on Python 3.9, requires an older joblib version
-joblib==1.4.2;python_version>="3.10"
-mysql-connector-python==9.2.0
-newmode==0.1.6
-oauth2client==4.1.3
-paramiko==3.5.1
-petl==1.7.15
-psycopg2-binary==2.9.9;python_version<"3.13"
-psycopg2-binary==2.9.10;python_version>="3.13"
-PyGitHub==2.6.0
-python-dateutil==2.9.0.post0
-requests==2.32.3
-requests_oauthlib==2.0.0
-setuptools==78.1.0
-simple-salesforce==1.12.6
-simplejson==3.20.1
-slackclient==1.3.1
-sqlalchemy >= 1.4.22, != 1.4.33, < 3.0.0 # Prefect does not work with 1.4.33 and >=2.0.0 has breaking changes
-suds-py3==1.4.5.0
-surveygizmo==1.2.3
-twilio==9.5.1
-urllib3==1.26.19
-validate-email==1.3
-xmltodict==0.14.2
+# Parsons Requirements
+azure-storage-blob>=12.25,<13
+beautifulsoup4>=4.10,<5
+boto3>=1.34,<2
+boxsdk>=3.13,<4
+braintree>=4.31,<5
+censusgeocode>=0.5,<1
+civis>=1.16,<2;python_version<"3.10"  # later Civis versions do not support Python 3.9
+civis>=2;python_version>="3.10"
+curlify>=2.2.1,<3
+dbt_core>=1.5,<2
+defusedxml>=0.7,<1
+facebook-business>=22.0,<23
+google-api-core>=2.24,<3
+google-api-python-client>=2.163,<3
+google-auth>=2.38,<3
+google-cloud-bigquery>=3.31,<4
+google-cloud-storage-transfer>=1.16,<2
+google-cloud-storage>=3.1,<4
+grpcio>=1.68,<2
+gspread>=6.1,<7
+httplib2>=0.22,<1
+jellyfish>=1.1.1,<2
+joblib>=1.2,<2
+mysql-connector-python>=9.2,<10
+newmode>=0.1.6,<2
+oauth2client>=4.1,<5
+paramiko>=3.5,<4
+petl>=1.7.10,<2;python_version<"3.11"
+petl>=1.7.15,<2;python_version>="3.11"
+psycopg2-binary>=2.9.7,<2.9.10;python_version<"3.13"
+psycopg2-binary>=2.9.10,<3;python_version>="3.13"
+pyairtable>=3.0,<4
+PyGitHub>=2.6,<3
+python-dateutil>=2.9,<3
+requests>=2.32,<3
+requests_oauthlib>=2,<3
+setuptools>=78.1, <79
+simple-salesforce>=1.12.4,<2
+simplejson>=3.20,<4
+slackclient>=1.3,<2
+sqlalchemy>=1.4,!=1.4.33,<3 # Prefect does not work with 1.4.33
+sshtunnel>=0.4,<1
+suds-py3>=1.4,<2
+surveygizmo>=1.2,<2
+twilio>=9.5,<10
+urllib3>=1.26.10,<2
+validate-email>=1.3,<2
+xmltodict>=0.14,<1
+
+# Unpinned transient dependencies
+deprecated>=1.2
+greenlet>=3.1
+inflection>=0.4
+pycparser>=2.20
+zeep>=4,<5
+
+# Additional minimum versions for compatibility
+aiohttp>=3.11  # facebook-business depends on aiohttp and there were c++ errors until 3.11
+cachetools>=4  # needed to resolve AttributeError: module 'collections' has no attribute 'MutableMapping'
+cloudpickle>2  # needed to resolve ModuleNotFoundError: No module named 'imp'
+cffi>=1.17  # dbt-core depends on cffi and there were c++ errors until 1.17
+frozenlist>=1.5  # aiohttp depends on frozenlist and there were c++ errors until 1.5
+lxml>=5.3  # zeep depends on lxml and there were c++ errors until 5.3
+pydantic-core>=2.19  # pyairtable depends on pydantic-core aqqnd there was a missing file error until 2.19
+pytz>=2021  # needed to resolve AttributeError: module 'collections' has no attribute 'MutableMapping'
+pyyaml>=6.0.1  # civis depends on pyyaml and there was an AttributeError until 6.0.2
+requests-toolbelt>=0.10  # needed to resolve ImportError: cannot import name 'Mapping' from 'collections'
+six>=1.16  # needed to resolve ModuleNotFoundError: No module named 'six.moves'
+wrapt>=1.14  # need to resolve ImportError: cannot import name 'formatargspec' from 'inspect'
+zeep>=4.3,<5;python_version>="3.13"  # python cgi package was deprecated in Python 3.11 and removed in 3.13
 
 # Stuff for TMC scripts
 # TODO Remove when we have a TMC-specific Docker image
-jinja2>=3.0.2
-selenium==3.141.0
-us==3.2.0
-sshtunnel==0.4.0
-
+jinja2>=3.0,<4
+selenium>=3.141,<4
+us>=3.2,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,6 +59,7 @@ zeep>=4,<5
 aiohttp>=3.11  # facebook-business depends on aiohttp and there were c++ errors until 3.11
 cachetools>=4  # needed to resolve AttributeError: module 'collections' has no attribute 'MutableMapping'
 cloudpickle>2  # needed to resolve ModuleNotFoundError: No module named 'imp'
+cryptography>37  # needed to resolve error: 'openssl/opensslv.h' file not found
 cffi>=1.17  # dbt-core depends on cffi and there were c++ errors until 1.17
 frozenlist>=1.5  # aiohttp depends on frozenlist and there were c++ errors until 1.5
 lxml>=5.3  # zeep depends on lxml and there were c++ errors until 5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,8 +28,8 @@ oauth2client>=4.1,<5
 paramiko>=3.5,<4
 petl>=1.7.10,<2;python_version<"3.11"
 petl>=1.7.15,<2;python_version>="3.11"
-psycopg2-binary>=2.9.7,<2.9.10;python_version<"3.13"
-psycopg2-binary>=2.9.10,<3;python_version>="3.13"
+psycopg2-binary>=2.9.7,<2.9.10;python_version<"3.12"
+psycopg2-binary>=2.9.10,<3;python_version>="3.12"
 pyairtable>=3.0,<4
 PyGitHub>=2.6,<3
 python-dateutil>=2.9,<3

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def main():
             "dbt-postgres": ["dbt-postgres>=1.5.0"],
             "dbt-snowflake": ["dbt-snowflake>=1.5.0"],
             "facebook": ["joblib", "facebook-business"],
-            "geocode": ["censusgeocode", "urllib3==1.26.19"],
+            "geocode": ["censusgeocode", "urllib3>=1.26.10,<2"],
             "github": ["PyGitHub"],
             "google": [
                 "apiclient",
@@ -43,7 +43,7 @@ def main():
             ],
             "mysql": [
                 "mysql-connector-python",
-                "sqlalchemy >= 1.4.22, != 1.4.33, < 3.0.0",
+                "sqlalchemy>=1.4.22,!=1.4.33,<3.0.0",
             ],
             "newmode": ["newmode"],
             "ngpvan": ["suds-py3"],
@@ -51,13 +51,13 @@ def main():
             "postgres": [
                 "psycopg2-binary<=2.9.9;python_version<'3.13'",
                 "psycopg2-binary>=2.9.10;python_version>='3.13'",
-                "sqlalchemy >= 1.4.22, != 1.4.33, < 3.0.0",
+                "sqlalchemy>=1.4.22,!=1.4.33,<3.0.0",
             ],
             "redshift": [
                 "boto3",
                 "psycopg2-binary<=2.9.9;python_version<'3.13'",
                 "psycopg2-binary>=2.9.10;python_version>='3.13'",
-                "sqlalchemy >= 1.4.22, != 1.4.33, < 3.0.0",
+                "sqlalchemy>=1.4.22,!=1.4.33,<3.0.0",
             ],
             "s3": ["boto3"],
             "salesforce": ["simple-salesforce"],
@@ -71,7 +71,7 @@ def main():
                 "sshtunnel",
                 "psycopg2-binary<=2.9.9;python_version<'3.13'",
                 "psycopg2-binary>=2.9.10;python_version>='3.13'",
-                "sqlalchemy >= 1.4.22, != 1.4.33, < 3.0.0",
+                "sqlalchemy>=1.4.22,!=1.4.33,<3.0.0",
             ],
         }
         extras_require["all"] = sorted({lib for libs in extras_require.values() for lib in libs})

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -1,6 +1,6 @@
 import pytest
 
-from parsons.etl import Table
+from parsons import Table
 
 """
 Simple Table

--- a/test/test_action_network/test_action_network.py
+++ b/test/test_action_network/test_action_network.py
@@ -3,8 +3,7 @@ import unittest
 
 import requests_mock
 
-from parsons import Table
-from parsons.action_network import ActionNetwork
+from parsons import ActionNetwork, Table
 from test.utils import assert_matching_tables
 
 

--- a/test/test_databases/fakes.py
+++ b/test/test_databases/fakes.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Optional, Union
 
+from parsons import Table
 from parsons.databases.database_connector import DatabaseConnector
-from parsons.etl.table import Table
 
 logger = logging.getLogger(__name__)
 

--- a/test/test_databases/test_bigquery.py
+++ b/test/test_databases/test_bigquery.py
@@ -9,8 +9,7 @@ from unittest.mock import Mock
 from google.cloud import bigquery, exceptions
 from testfixtures import log_capture
 
-from parsons import GoogleBigQuery, Table
-from parsons.google.google_cloud_storage import GoogleCloudStorage
+from parsons import GoogleBigQuery, GoogleCloudStorage, Table
 from test.test_google.test_utilities import FakeCredentialTest
 
 

--- a/test/test_databases/test_dbsync.py
+++ b/test/test_databases/test_dbsync.py
@@ -4,9 +4,7 @@ import unittest
 from abc import ABC
 from typing import Optional, Type
 
-from parsons import DBSync, Postgres, Redshift, Table
-from parsons.databases.database_connector import DatabaseConnector
-from parsons.databases.sqlite import Sqlite
+from parsons import DatabaseConnector, DBSync, Postgres, Redshift, Sqlite, Table
 from test.test_databases.fakes import FakeDatabase
 from test.utils import assert_matching_tables
 

--- a/test/test_databases/test_discover_database.py
+++ b/test/test_databases/test_discover_database.py
@@ -2,10 +2,8 @@ import unittest
 from unittest.mock import patch
 
 from parsons import GoogleBigQuery as BigQuery
+from parsons import MySQL, Postgres, Redshift
 from parsons.databases.discover_database import discover_database
-from parsons.databases.mysql import MySQL
-from parsons.databases.postgres import Postgres
-from parsons.databases.redshift import Redshift
 
 
 class TestDiscoverDatabase(unittest.TestCase):

--- a/test/test_databases/test_sqlite.py
+++ b/test/test_databases/test_sqlite.py
@@ -1,8 +1,7 @@
 import tempfile
 import unittest
 
-from parsons import Table
-from parsons.databases.sqlite import Sqlite
+from parsons import Sqlite, Table
 from test.utils import assert_matching_tables
 
 

--- a/test/test_formstack/test_formstack.py
+++ b/test/test_formstack/test_formstack.py
@@ -2,8 +2,8 @@ import unittest
 
 import requests_mock
 
-from parsons import Table
-from parsons.formstack.formstack import API_URI, Formstack
+from parsons import Formstack, Table
+from parsons.formstack.formstack import API_URI
 from test.test_formstack.formstack_json import (
     folder_json,
     form_fields_json,

--- a/test/test_geocoder/test_census_geocoder.py
+++ b/test/test_geocoder/test_census_geocoder.py
@@ -3,9 +3,14 @@ import unittest
 from unittest import mock
 
 import petl
-from test_responses import batch_resp, coord_resp, geographies_resp, locations_resp
 
 from parsons import CensusGeocoder, Table
+from test.test_geocoder.test_responses import (
+    batch_resp,
+    coord_resp,
+    geographies_resp,
+    locations_resp,
+)
 from test.utils import assert_matching_tables
 
 

--- a/test/test_google/test_google_admin.py
+++ b/test/test_google/test_google_admin.py
@@ -1,8 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from parsons.etl.table import Table
-from parsons.google.google_admin import GoogleAdmin
+from parsons import GoogleAdmin, Table
 from test.utils import assert_matching_tables
 
 

--- a/test/test_mobilecommons/test_mobilecommons.py
+++ b/test/test_mobilecommons/test_mobilecommons.py
@@ -7,8 +7,7 @@ from mobilecommons_responses import (
     post_profile_response,
 )
 
-from parsons.etl import Table
-from parsons.mobilecommons import MobileCommons
+from parsons import MobileCommons, Table
 
 MOBILECOMMONS_USERNAME = "MOBILECOMMONS_USERNAME"
 MOBILECOMMONS_PASSWORD = "MOBILECOMMONS_PASSWORD"

--- a/test/test_pdi/conftest.py
+++ b/test/test_pdi/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from parsons.pdi.pdi import PDI
+from parsons import PDI
 
 
 @pytest.fixture

--- a/test/test_quickbooks/test_quickbookstime.py
+++ b/test/test_quickbooks/test_quickbookstime.py
@@ -11,8 +11,7 @@ from test_quickbookstime_data import (
     mock_users_data,
 )
 
-from parsons.etl.table import Table
-from parsons.quickbooks.quickbookstime import QuickBooksTime
+from parsons import QuickBooksTime, Table
 
 
 class TestQuickBooksTime(unittest.TestCase):

--- a/test/test_targetsmart/test_targetsmart_smartmatch.py
+++ b/test/test_targetsmart/test_targetsmart_smartmatch.py
@@ -9,7 +9,7 @@ import petl
 import pytest
 from petl.util.base import TableWrapper
 
-from parsons.targetsmart.targetsmart_api import TargetSmartAPI
+from parsons import TargetSmartAPI
 
 
 @pytest.fixture

--- a/test/utils.py
+++ b/test/utils.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from parsons.etl.table import Table
+from parsons import Table
 
 """
 Use this as a marker before any tests that hit live services. That way they'll only run


### PR DESCRIPTION
## What's Changed
- Alphabetized dependencies
- Renamed test workflow job to pytest since other jobs used tool name (ruff, bandit, etc)
- Added pytest workflow matrix for installing oldest-supported versions of dependencies and integrated limited-deps testing into same matrix for more readable github action outputs
- Set min versions for some additional dependencies that wouldn't install (likely issues with upstreams being too permissive)
- Set all direct dependencies to allow a range of versions until the next major release
- Bumped ruff to 0.11.9
- Fixed a few miscellaneous typing issues
- Set coverage report to only post to console when pytest passes (to avoid having to scroll past it to see failures and errors)
- Changed all test_*.py files to import classes from parsons rather than from subfiles to avoid circular imports and test things as they will be used.