### PR TITLE
Add Google Analytics integration to Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "myst_parser",
     "sphinx_multiversion",
+    "sphinxcontrib.googleanalytics",
 ]
 
 # Sorting of attributes
@@ -93,10 +94,6 @@ html_theme = "sphinx_rtd_theme"
 #
 html_theme_options = {
     "display_version": True,
-}
-
-html_theme_options["analytics"] = {
-    "google_analytics_id": "G-L2YB7WHTRG",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -195,3 +192,6 @@ smv_branch_whitelist = r"^stable|latest$"  # creates version for latest master/m
 
 # Get tags to whitelist from DOCUMENTED_VERSIONS const
 smv_tag_whitelist = "|".join(["^" + version + "$" for version in DOCUMENTED_VERSIONS])
+
+# Adds Google Analytics tracking code to the HTML output
+googleanalytics_id = "G-L2YB7WHTRG"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,4 @@ sphinx-rtd-theme==3.0.2
 myst-parser==4.0.1;python_version>='3.10'
 myst-parser==3.0.1;python_version<'3.10'
 sphinx-multiversion
+sphinxcontrib-googleanalytics


### PR DESCRIPTION
Integrate Google Analytics into the Sphinx documentation to enable tracking of user interactions. This includes adding the necessary package and configuration for the analytics ID.