### PR TITLE
Fix link in convert docstring

### DIFF
--- a/parsons/etl/etl.py
+++ b/parsons/etl/etl.py
@@ -207,7 +207,7 @@ class ETL(object):
         """
         Transform values under one or more fields via arbitrary functions, method
         invocations or dictionary translations. This leverages the petl ``convert()``
-        method. Example usage can be found `here <https://petl.readthedocs.io/en/v0.24/transform.html#petl.convert>`_.
+        method. Example usage can be found `here <https://petl.readthedocs.io/latest/transform.html#petl.transform.conversions.convert>`_.
 
         `Args:`
             *column: str


### PR DESCRIPTION
I found that original link for this was no longer working, returning a 404 error.