### PR TITLE
Handle pending emails in NGPVAN without failing

### DIFF
--- a/parsons/ngpvan/email.py
+++ b/parsons/ngpvan/email.py
@@ -125,14 +125,20 @@ class Email(object):
                 outer = {field: email[field] for field in outer_fields}
                 inner = {field: 0 for field in inner_fields}
                 for i in email["emailMessageContent"]:
-                    try:
-                        for field in inner_fields:  # Aggregation of all inner values
-                            inner[field] += i["emailMessageContentDistributions"][field]
-                        # Just replacing subject to get the last one
-                        inner["subject"] = i["subject"]
-                    except KeyError as e:
-                        logger.info(str(e))
-                        pass
+                    # Pending emails don't have emailMessageContentDistributions, just have defaults
+                    if not i["emailMessageContentDistributions"]:
+                        logger.info(
+                            f"No emailMessageContentDistributions for email {i['name']}, defaulting values to 0"
+                        )
+                    else:
+                        try:
+                            for field in inner_fields:  # Aggregation of all inner values
+                                inner[field] += i["emailMessageContentDistributions"][field]
+                            # Just replacing subject to get the last one
+                            inner["subject"] = i["subject"]
+                        except KeyError as e:
+                            logger.info(str(e))
+                            pass
                 final_email_list.append({**outer, **inner})
         else:
             for email in email_list:
@@ -140,12 +146,17 @@ class Email(object):
                     # One row per foreignMessageId / emailMessageContent entry
                     outer = {field: email[field] for field in outer_fields}
                     inner = {field: 0 for field in inner_fields}
-                    try:
-                        for field in inner_fields:
-                            inner[field] = i["emailMessageContentDistributions"][field]
-                        inner["subject"] = i["subject"]
-                    except KeyError as e:
-                        logger.info(str(e))
+                    if not i["emailMessageContentDistributions"]:
+                        logger.info(
+                            f"No emailMessageContentDistributions for email {i['name']}, defaulting values to 0"
+                        )
+                    else:
+                        try:
+                            for field in inner_fields:
+                                inner[field] = i["emailMessageContentDistributions"][field]
+                            inner["subject"] = i["subject"]
+                        except KeyError as e:
+                            logger.info(str(e))
                     final_email_list.append({**outer, **inner})
 
         return Table(final_email_list)

--- a/test/test_van/test_email.py
+++ b/test/test_van/test_email.py
@@ -138,6 +138,18 @@ sample_content_single = [
     }
 ]
 
+sample_content_pending_email = [
+    {
+        "name": "I'm a pending email",
+        "senderDisplayName": None,
+        "senderEmailAddress": None,
+        "subject": None,
+        "createdBy": "Random Intern",
+        "dateCreated": "2023-05-17T15:04:00Z",
+        "emailMessageContentDistributions": None,
+    }
+]
+
 mock_response = [
     {
         "foreignMessageId": "oK2ahdAcEe6F-QAiSCI3lA2",
@@ -195,7 +207,7 @@ mock_response_enriched = deepcopy(mock_response)
 mock_response_enriched[0]["emailMessageContent"] = sample_content_single
 mock_response_enriched[1]["emailMessageContent"] = sample_content_single
 mock_response_enriched[2]["emailMessageContent"] = sample_content_single
-mock_response_enriched[3]["emailMessageContent"] = sample_content_single
+mock_response_enriched[3]["emailMessageContent"] = sample_content_pending_email
 mock_response_enriched[4]["emailMessageContent"] = sample_content_full
 
 


### PR DESCRIPTION
## What is this change?
- This handles the NGPVAN email object from failing `get_email_stats` when there is an email pending being sent. In this situation, the email response does not have any `emailMessageContentDistributions` data, which was initially causing a failure as we were trying to access keys of a `None` object.
- Fixes #1461

## Considerations for discussion
- Currently, this returns a pretty minimal row, with `name`, `createdBy`, `dateCreated`, `dateModified`, and `foreignMessageId` being filled in, but `dateScheduled` is `0001-01-01T00:00:00Z`, `subject` is `None`, and all of the things about number of sends, opens, etc is defaulted to zero. Weird that NGP doesn't provide the subject line or the scheduled date in the API call, but it is what it is. I assume we still want to include the pending email instead of filtering it out? Is this something worth calling out in the docstring for the method? CC @matthewkrausse @shaunagm 

## How to test the changes (if needed)
- I installed this locally with `pip install -e .` and ran a notebook against my own NGPVAN instance, where we currently have a pending email. It works.
