### PR TITLE
NewMode retries and pagination

### DIFF
--- a/parsons/newmode/newmode.py
+++ b/parsons/newmode/newmode.py
@@ -2,6 +2,7 @@ from typing import Optional, Dict, Any, List, Union
 import logging
 
 from Newmode import Client
+
 from parsons.etl import Table
 from parsons.utilities import check_env
 from parsons.utilities.oauth_api_connector import OAuth2APIConnector
@@ -62,7 +63,7 @@ class NewmodeV1:
 
         return table
 
-    def get_tools(self, params: Dict[str, Any] = {}) -> Table:
+    def get_tools(self, params: Dict[str, Any] = None) -> Table:
         """
         Get existing tools.
         Args:
@@ -71,6 +72,8 @@ class NewmodeV1:
         Returns:
             Tools information as table.
         """
+        if params is None:
+            params = {}
         tools = self.client.getTools(params=params)
         if tools:
             return self.convert_to_table(tools)

--- a/parsons/newmode/newmode.py
+++ b/parsons/newmode/newmode.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, List, Union
+from typing import Any, Dict, List, Optional, Union
 import logging
 
 from Newmode import Client

--- a/parsons/newmode/newmode.py
+++ b/parsons/newmode/newmode.py
@@ -1,5 +1,5 @@
-from typing import Any, Dict, List, Optional, Union
 import logging
+from typing import Any, Dict, List, Optional, Union
 
 from Newmode import Client
 

--- a/parsons/newmode/newmode.py
+++ b/parsons/newmode/newmode.py
@@ -1,7 +1,7 @@
+from typing import Optional, Dict, Any, List, Union
 import logging
 
 from Newmode import Client
-
 from parsons.etl import Table
 from parsons.utilities import check_env
 from parsons.utilities.oauth_api_connector import OAuth2APIConnector
@@ -18,9 +18,18 @@ V2_API_CAMPAIGNS_HEADERS = {
     "authorization": "Bearer 1234567890",
 }
 
+PAGINATION_NEXT = "next"
+RESPONSE_DATA_KEY = "data"
+RESPONSE_LINKS_KEY = "links"
+
 
 class NewmodeV1:
-    def __init__(self, api_user=None, api_password=None, api_version=None):
+    def __init__(
+        self,
+        api_user: Optional[str] = None,
+        api_password: Optional[str] = None,
+        api_version: Optional[str] = None,
+    ):
         """
         Args:
             api_user: str
@@ -38,12 +47,12 @@ class NewmodeV1:
         logger.warning(
             "Newmode V1 API will be sunset in Feburary 28th, 2025. To use V2, set api_version=v2.1"
         )
-        self.api_user = check_env.check("NEWMODE_API_USER", api_user)
-        self.api_password = check_env.check("NEWMODE_API_PASSWORD", api_password)
-        self.api_version = api_version
-        self.client = Client(api_user, api_password, api_version)
+        self.api_user: str = check_env.check("NEWMODE_API_USER", api_user)
+        self.api_password: str = check_env.check("NEWMODE_API_PASSWORD", api_password)
+        self.api_version: Optional[str] = api_version
+        self.client: Client = Client(api_user, api_password, api_version)
 
-    def convert_to_table(self, data):
+    def convert_to_table(self, data: Union[List[Dict[str, Any]], Dict[str, Any]]) -> Table:
         # Internal method to create a Parsons table from a data element.
         table = None
         if isinstance(data, list):
@@ -53,7 +62,7 @@ class NewmodeV1:
 
         return table
 
-    def get_tools(self, params=None):
+    def get_tools(self, params: Dict[str, Any] = {}) -> Table:
         """
         Get existing tools.
         Args:
@@ -62,8 +71,6 @@ class NewmodeV1:
         Returns:
             Tools information as table.
         """
-        if params is None:
-            params = {}
         tools = self.client.getTools(params=params)
         if tools:
             return self.convert_to_table(tools)
@@ -71,7 +78,9 @@ class NewmodeV1:
             logging.warning("Empty tools returned")
             return self.convert_to_table([])
 
-    def get_tool(self, tool_id, params=None):
+    def get_tool(
+        self, tool_id: Union[int, str], params: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
         """
         Get specific tool.
         Args:
@@ -91,7 +100,12 @@ class NewmodeV1:
             logging.warning("Empty tool returned")
             return None
 
-    def lookup_targets(self, tool_id, search=None, params=None):
+    def lookup_targets(
+        self,
+        tool_id: Union[int, str],
+        search: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Table:
         """
         Lookup targets for a given tool
         Args:
@@ -122,7 +136,9 @@ class NewmodeV1:
             logging.warning("Empty targets returned")
             return self.convert_to_table([])
 
-    def get_action(self, tool_id, params=None):
+    def get_action(
+        self, tool_id: Union[int, str], params: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
         """
         Get the action information for a given tool.
         Args:
@@ -142,7 +158,12 @@ class NewmodeV1:
             logging.warning("Empty action returned")
             return None
 
-    def run_action(self, tool_id, payload, params=None):
+    def run_action(
+        self,
+        tool_id: Union[int, str],
+        payload: Dict[str, Any],
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Union[str, int]]:
         """
         Run specific action with given payload.
         Args:
@@ -168,7 +189,9 @@ class NewmodeV1:
             logging.warning("Error in response")
             return None
 
-    def get_target(self, target_id, params=None):
+    def get_target(
+        self, target_id: Union[int, str], params: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
         """
         Get specific target.
         Args:
@@ -188,7 +211,7 @@ class NewmodeV1:
             logging.warning("Empty target returned")
             return None
 
-    def get_targets(self, params=None):
+    def get_targets(self, params: Optional[Dict[str, Any]] = None) -> Optional[Table]:
         """
         Get all targets
 
@@ -211,7 +234,7 @@ class NewmodeV1:
             logging.warning("No targets returned")
             return None
 
-    def get_campaigns(self, params=None):
+    def get_campaigns(self, params: Optional[Dict[str, Any]] = None) -> Table:
         """
         Get existing campaigns.
         Args:
@@ -229,7 +252,9 @@ class NewmodeV1:
             logging.warning("Empty campaigns returned")
             return self.convert_to_table([])
 
-    def get_campaign(self, campaign_id, params=None):
+    def get_campaign(
+        self, campaign_id: Union[int, str], params: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
         """
         Get specific campaign.
         Args:
@@ -249,7 +274,7 @@ class NewmodeV1:
             logging.warning("Empty campaign returned")
             return None
 
-    def get_organizations(self, params=None):
+    def get_organizations(self, params: Optional[Dict[str, Any]] = None) -> Table:
         """
         Get existing organizations.
         Args:
@@ -267,7 +292,9 @@ class NewmodeV1:
             logging.warning("Empty organizations returned")
             return self.convert_to_table([])
 
-    def get_organization(self, organization_id, params=None):
+    def get_organization(
+        self, organization_id: Union[int, str], params: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
         """
         Get specific organization.
         Args:
@@ -287,7 +314,7 @@ class NewmodeV1:
             logging.warning("Empty organization returned")
             return None
 
-    def get_services(self, params=None):
+    def get_services(self, params: Optional[Dict[str, Any]] = None) -> Table:
         """
         Get existing services.
         Args:
@@ -305,7 +332,9 @@ class NewmodeV1:
             logging.warning("Empty services returned")
             return self.convert_to_table([])
 
-    def get_service(self, service_id, params=None):
+    def get_service(
+        self, service_id: Union[int, str], params: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
         """
         Get specific service.
         Args:
@@ -325,7 +354,9 @@ class NewmodeV1:
             logging.warning("Empty service returned")
             return None
 
-    def get_outreaches(self, tool_id, params=None):
+    def get_outreaches(
+        self, tool_id: Union[int, str], params: Optional[Dict[str, Any]] = None
+    ) -> Table:
         """
         Get existing outreaches for a given tool.
         Args:
@@ -345,7 +376,9 @@ class NewmodeV1:
             logging.warning("Empty outreaches returned")
             return self.convert_to_table([])
 
-    def get_outreach(self, outreach_id, params=None):
+    def get_outreach(
+        self, outreach_id: Union[int, str], params: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
         """
         Get specific outreach.
         Args:
@@ -370,9 +403,9 @@ class NewmodeV2:
     # TODO: Add param definition and requirements once official Newmode docs are published
     def __init__(
         self,
-        client_id=None,
-        client_secret=None,
-        api_version="v2.1",
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        api_version: str = "v2.1",
     ):
         """
         Instantiate Class
@@ -388,12 +421,12 @@ class NewmodeV2:
         Returns:
             NewMode Class
         """
-        self.api_version = api_version
-        self.base_url = V2_API_URL
-        self.client_id = check_env.check("NEWMODE_API_CLIENT_ID", client_id)
-        self.client_secret = check_env.check("NEWMODE_API_CLIENT_SECRET", client_secret)
-        self.headers = {"content-type": "application/json"}
-        self.default_client = OAuth2APIConnector(
+        self.api_version: str = api_version
+        self.base_url: str = V2_API_URL
+        self.client_id: str = check_env.check("NEWMODE_API_CLIENT_ID", client_id)
+        self.client_secret: str = check_env.check("NEWMODE_API_CLIENT_SECRET", client_secret)
+        self.headers: Dict[str, str] = {"content-type": "application/json"}
+        self.default_client: OAuth2APIConnector = OAuth2APIConnector(
             uri=self.base_url,
             auto_refresh_url=V2_API_AUTH_URL,
             client_id=self.client_id,
@@ -403,66 +436,107 @@ class NewmodeV2:
             grant_type="client_credentials",
         )
 
+    def checked_response(
+        self, response: Any, client: OAuth2APIConnector
+    ) -> Optional[Dict[str, Any]]:
+        response.raise_for_status()
+        success_codes = [200, 201, 202, 204]
+        client.validate_response(response)
+        if response.status_code in success_codes:
+            return response.json() if client.json_check(response) else None
+
     def base_request(
         self,
-        method,
-        endpoint,
-        client,
-        data=None,
-        json=None,
-        data_key=None,
-        params=None,
-        supports_version=True,
-        override_api_version=None,
-        retries=2,
-    ):
+        method: str,
+        url: str,
+        client: OAuth2APIConnector,
+        data: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        retries: int = 2,
+    ) -> Optional[Union[Dict[str, Any], None]]:
         """
         Internal method to instantiate OAuth2APIConnector class,
-        make a call to Newmode API, and validate the response.
+        make a single call to Newmode API, and validate the response.
         """
         if params is None:
             params = {}
-        api_version = override_api_version if override_api_version else self.api_version
-        url = f"{api_version}/{endpoint}" if supports_version else endpoint
 
         for attempt in range(retries + 1):
             try:
                 response = client.request(
                     url=url, req_type=method, json=json, data=data, params=params
                 )
-                response.raise_for_status()
-                success_codes = [200, 201, 202, 204]
-                client.validate_response(response)
-                if response.status_code in success_codes:
-                    response_json = response.json() if client.json_check(response) else None
-                    return response_json[data_key] if data_key and response_json else response_json
+                return self.checked_response(response, client)
             except Exception as e:
                 if attempt < retries:
                     logger.warning(f"Request failed (attempt {attempt + 1}/{retries}). Retrying...")
                 else:
                     logger.error(f"Request failed after {retries} retries.")
                     raise e
-        raise Exception(f"Failed to retrieve data from {endpoint} after {retries} attempts.")
+        raise Exception(f"Failed to retrieve data from {url} after {retries} attempts.")
+
+    def paginate_request(
+        self,
+        method: str,
+        endpoint: str,
+        client: OAuth2APIConnector,
+        data_key: str = RESPONSE_DATA_KEY,
+        data: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        supports_version: bool = True,
+        override_api_version: Optional[str] = None,
+        retries: int = 2,
+    ) -> List[Dict[str, Any]]:
+        """
+        Wrapper method to handle pagination for API requests.
+        """
+        if params is None:
+            params = {}
+        results = []
+        api_version = override_api_version if override_api_version else self.api_version
+        url = f"{api_version}/{endpoint}" if supports_version else endpoint
+        while url:
+            response = self.base_request(
+                method=method,
+                url=url,
+                client=client,
+                data=data,
+                json=json,
+                params=params,
+                retries=retries,
+            )
+            if data_key and response:
+                data_to_add = response.get(data_key, [])
+                if not isinstance(data_to_add, list):
+                    data_to_add = [data_to_add]
+                results.extend(data_to_add)
+            else:
+                results.append(response)
+            # Check for pagination
+            url = response.get(RESPONSE_LINKS_KEY, {}).get(PAGINATION_NEXT) if response else None
+        return results
 
     def converted_request(
         self,
-        endpoint,
-        method,
-        supports_version=True,
-        data=None,
-        json=None,
-        params=None,
-        convert_to_table=True,
-        data_key=None,
-        client=None,
-        override_api_version=None,
-    ):
+        endpoint: str,
+        method: str,
+        supports_version: bool = True,
+        data: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        convert_to_table: bool = True,
+        data_key: Optional[str] = None,
+        client: Optional[OAuth2APIConnector] = None,
+        override_api_version: Optional[str] = None,
+    ) -> Union[Table, Dict[str, Any]]:
         """Internal method to make a call to the Newmode API and convert the result to a Parsons table."""
 
         if params is None:
             params = {}
         client = client if client else self.default_client
-        response = self.base_request(
+        response = self.paginate_request(
             method=method,
             json=json,
             data=data,
@@ -479,7 +553,7 @@ class NewmodeV2:
             else:
                 return response
 
-    def get_campaign(self, campaign_id, params=None):
+    def get_campaign(self, campaign_id: str, params: Optional[Dict[str, Any]] = None) -> Table:
         """
         Retrieve a specific campaign by ID.
 
@@ -502,7 +576,7 @@ class NewmodeV2:
         )
         return data
 
-    def get_campaign_ids(self, params=None):
+    def get_campaign_ids(self, params: Optional[Dict[str, Any]] = None) -> List[str]:
         """
         Retrieve all campaigns
         In v2, a campaign is equivalent to Tools or Actions in V1.
@@ -531,7 +605,7 @@ class NewmodeV2:
             endpoint=endpoint,
             method="GET",
             params=params,
-            data_key="data",
+            data_key=RESPONSE_DATA_KEY,
             client=campaigns_client,
             override_api_version=V2_API_CAMPAIGNS_VERSION,
         )
@@ -539,13 +613,13 @@ class NewmodeV2:
 
     def get_recipient(
         self,
-        campaign_id,
-        street_address=None,
-        city=None,
-        postal_code=None,
-        region=None,
-        params=None,
-    ):
+        campaign_id: str,
+        street_address: Optional[str] = None,
+        city: Optional[str] = None,
+        postal_code: Optional[str] = None,
+        region: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Table:
         """
         Retrieve a specific recipient by ID
         `Args:`
@@ -586,7 +660,13 @@ class NewmodeV2:
         )
         return response
 
-    def run_submit(self, campaign_id, json=None, data=None, params=None):
+    def run_submit(
+        self,
+        campaign_id: str,
+        json: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """
         Pass a submission from a supporter to a campaign
         that ultimately fills in a petition,
@@ -612,9 +692,9 @@ class NewmodeV2:
             params=params,
             convert_to_table=False,
         )
-        return response
+        return response[0]
 
-    def get_submissions(self, campaign_id, params=None):
+    def get_submissions(self, campaign_id: str, params: Optional[Dict[str, Any]] = None) -> Table:
         """
         Retrieve and sort submissions and contact data
         for a specified campaign using a range of filters
@@ -629,19 +709,21 @@ class NewmodeV2:
         if params is None:
             params = {}
         params = {"action": campaign_id}
-        response = self.converted_request(endpoint="submission", method="GET", params=params)
+        response = self.converted_request(
+            endpoint="submission", method="GET", params=params, data_key=RESPONSE_DATA_KEY
+        )
         return response
 
 
 class Newmode:
     def __new__(
         cls,
-        client_id=None,
-        client_secret=None,
-        api_user=None,
-        api_password=None,
-        api_version="v1.0",
-    ):
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        api_user: Optional[str] = None,
+        api_password: Optional[str] = None,
+        api_version: str = "v1.0",
+    ) -> Union[NewmodeV1, NewmodeV2]:
         """
         Create and return Newmode instance based on chosen version (V1 or V2)
 

--- a/parsons/newmode/newmode.py
+++ b/parsons/newmode/newmode.py
@@ -1,6 +1,7 @@
 import logging
 
 from Newmode import Client
+
 from parsons.etl import Table
 from parsons.utilities import check_env
 from parsons.utilities.oauth_api_connector import OAuth2APIConnector

--- a/parsons/newmode/newmode.py
+++ b/parsons/newmode/newmode.py
@@ -446,7 +446,12 @@ class NewmodeV2:
         success_codes = [200, 201, 202, 204]
         client.validate_response(response)
         if response.status_code in success_codes:
-            return response.json() if client.json_check(response) else None
+            try:
+                if client.json_check(response):
+                    return response.json()
+            except Exception:
+                logger.error("Response is not in JSON format.")
+        raise ValueError(f"API request encountered an error. Response: {response}")
 
     def base_request(
         self,

--- a/test/test_newmode/test_newmode.py
+++ b/test/test_newmode/test_newmode.py
@@ -4,6 +4,7 @@ import unittest.mock as mock
 from unittest.mock import call, patch
 
 import requests_mock
+from requests.exceptions import HTTPError
 
 from parsons import Newmode, Table
 from test.test_newmode import test_newmode_data
@@ -247,7 +248,7 @@ class TestNewmodeV2(unittest.TestCase):
             status_code=500,
         )
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(HTTPError):
             self.nm.base_request(
                 method="GET",
                 endpoint="test-endpoint",

--- a/test/test_newmode/test_newmode.py
+++ b/test/test_newmode/test_newmode.py
@@ -1,13 +1,13 @@
 import os
 import unittest
 import unittest.mock as mock
-from test.test_newmode import test_newmode_data
-from test.utils import assert_matching_tables
 from unittest.mock import call, patch
 
 import requests_mock
 
 from parsons import Newmode, Table
+from test.test_newmode import test_newmode_data
+from test.utils import assert_matching_tables
 
 CLIENT_ID = "fakeClientID"
 CLIENT_SECRET = "fakeClientSecret"


### PR DESCRIPTION
## What is this change?
- We've been seeing a good number of 5xx statuses back from NewMode. They seem to usually just clear on a retry so let's save people the trouble of running a manual retry
- We are also not paginating- so only the first 50 submissions are being synced for example, when there are hundreds of them
- I also added type hints because I was having a hard time following the various transformations we're doing on the Parsons Table

## Considerations for discussion
- I don't know that you would want the retry behavior by default on create requests- the only POST I see here though is to submit a job, where I would guess this is okay. Happy to update those assumptions though

## How to test the changes (if needed)
- `pytest test`
- or 
```
nm = Newmode(); subs = nm.get_submissions('4c18a593-75a3-4d61-aa87-200d7ed7a35f'); len(sub)
```
(obviously you'll need to add client id and secret to this and pick a campaign id that exists in that account)
