### PR TITLE
test dev version of python 3.14 but allow for failure

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -11,13 +11,14 @@ permissions:
 
 jobs:
     test:
+        continue-on-error: ${{ matrix.python-version == '3.14-dev' }}
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
                 os: ["ubuntu-latest", "windows-latest", "macos-latest"]
                 limited-dependencies: ["", "TRUE"]
-
+ 
         runs-on: ${{ matrix.os }}
 
         permissions:


### PR DESCRIPTION
This adds the preview version of the next version of python to the testing matrix, but if it fails but the other versions succeed the whole job will succeed.

relates to #1515 