### PR TITLE
Update some docs with column names

### DIFF
--- a/parsons/actblue/actblue.py
+++ b/parsons/actblue/actblue.py
@@ -169,7 +169,32 @@ class ActBlue(object):
                 Any additional arguments will be passed to Table.from_csv as keyword arguments.
 
         `Returns:`
-            Contents of the generated contribution CSV as a Parsons table.
+            Parsons Table
+                Contents of the generated contribution CSV. List of columns:
+
+                Receipt ID, Date, Amount, Recurring Total Months, Recurrence Number, Recipient,
+                Fundraising Page, Fundraising Partner, Reference Code 2, Reference Code,
+                Donor First Name, Donor Last Name, Donor Addr1, Donor Addr2, Donor City,
+                Donor State, Donor ZIP, Donor Country, Donor Occupation, Donor Employer,
+                Donor Email, Donor Phone, New Express Signup, Comments, Check Number, Check Date,
+                Employer Addr1, Employer Addr2, Employer City, Employer State, Employer ZIP,
+                Employer Country, Donor ID, Fundraiser ID, Fundraiser Recipient ID,
+                Fundraiser Contact Email, Fundraiser Contact First Name,
+                Fundraiser Contact Last Name, Partner ID, Partner Contact Email,
+                Partner Contact First Name, Partner Contact Last Name, Reserved, Lineitem ID,
+                AB Test Name, AB Variation, Recipient Committee, Recipient ID, Recipient Gov ID,
+                Recipient Election, Reserved, Payment ID, Payment Date, Disbursement ID,
+                Disbursement Date, Recovery ID, Recovery Date, Refund ID, Refund Date,
+                Fee, Recur Weekly, ActBlue Express Lane, Reserved, Card Type, Reserved, Reserved,
+                Reserved, Reserved, Mobile, Recurring Upsell Shown, Recurring Upsell Succeeded,
+                Double Down, Smart Recurring, Monthly Recurring Amount, Apple Pay,
+                Card Replaced by Account Updater, ActBlue Express Donor, Custom Field 1 Label,
+                Custom Field 1 Value, Donor US Passport Number, Text Message Opt In,
+                Gift Identifier, Gift Declined, Shipping Addr1, Shipping City, Shipping State,
+                Shipping Zip, Shipping Country, Weekly Recurring Amount, Smart Boost Amount,
+                Smart Boost Shown, Bump Recurring Seen, Bump Recurring Succeeded,
+                Weekly to Monthly Rollover Date, Weekly Recurring Sunset, Recurring Type,
+                Recurring Pledged, Paypal, Kind, Managed Entity Name, Managed Entity Committee Name
         """
 
         post_request_response = self.post_request(csv_type, date_range_start, date_range_end)

--- a/parsons/ngpvan/email.py
+++ b/parsons/ngpvan/email.py
@@ -27,7 +27,10 @@ class Email(object):
 
         `Returns:`
             Parsons Table
-                See :ref:`parsons-table` for output options.
+                Data from the email/messages endpoint. List of columns:
+
+                foreignMessageId, name, createdBy, dateCreated, dateScheduled, campaignID,
+                dateModified, emailMessageContent
         """
         if ascending:
             params = {
@@ -84,7 +87,12 @@ class Email(object):
 
         `Returns:`
             Parsons Table
-                See :ref:`parsons-table` for output options.
+                All statistics returned from the get_email added to get_emails. Columns:
+
+                name, createdBy, dateCreated, dateModified, dateScheduled, foreignMessageId,
+                recipientCount, bounceCount, contributionCount, contributionTotal,
+                formSubmissionCount, linksClickedCount, machineOpenCount, openCount,
+                unsubscribeCount, subject
         """
 
         email_list = []


### PR DESCRIPTION
## What is this change?
- Adding some documentation about the columns you get back for methods in `actblue/actblue.py` and `ngpvan/email.py`.
- An initial effort on #1475 - these are the modules I ingest data with, so I decided to document the outputs here first.

## Considerations for discussion
- We discussed a bit about how we wanted to document columns during a prior Parsons meeting and decided that following whatever we had in #1475 was fine for now. Maybe at some point we'd want to make some kind of type hint that specifies the columns in a Parsons table, but for now docs are plenty. There's a lot to start filling out.

## How to test the changes (if needed)
- Do the docs build? Do they look okay?