### PR TITLE
allow setting a job config on BigQuery queries

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -12,7 +12,7 @@ import petl
 from google.api_core import exceptions
 from google.cloud import bigquery
 from google.cloud.bigquery import dbapi, job
-from google.cloud.bigquery.job import ExtractJobConfig, LoadJobConfig
+from google.cloud.bigquery.job import ExtractJobConfig, LoadJobConfig, QueryJobConfig
 from google.oauth2.credentials import Credentials
 
 from parsons.databases.database_connector import DatabaseConnector
@@ -249,6 +249,7 @@ class GoogleBigQuery(DatabaseConnector):
         sql: str,
         parameters: Optional[Union[list, dict]] = None,
         return_values: bool = True,
+        job_config: Optional[QueryJobConfig] = None,
     ) -> Optional[Table]:
         """
         Run a BigQuery query and return the results as a Parsons table.
@@ -277,6 +278,8 @@ class GoogleBigQuery(DatabaseConnector):
                 A valid BigTable statement
             parameters: dict
                 A dictionary of query parameters for BigQuery.
+            job_config: QueryJobConfig or None
+                An optional QueryJobConfig object for custom behavior. See https://cloud.google.com/python/docs/reference/bigquery/latest#google.cloud.bigquery.job.QueryJobConfig
 
         `Returns:`
             Parsons Table
@@ -285,11 +288,21 @@ class GoogleBigQuery(DatabaseConnector):
 
         with self.connection() as connection:
             return self.query_with_connection(
-                sql, connection, parameters=parameters, return_values=return_values
+                sql,
+                connection,
+                parameters=parameters,
+                return_values=return_values,
+                job_config=job_config,
             )
 
     def query_with_connection(
-        self, sql, connection, parameters=None, commit=True, return_values: bool = True
+        self,
+        sql,
+        connection,
+        parameters=None,
+        commit=True,
+        return_values: bool = True,
+        job_config: Optional[QueryJobConfig] = None,
     ):
         """
         Execute a query against the BigQuery database, with an existing connection.
@@ -305,6 +318,8 @@ class GoogleBigQuery(DatabaseConnector):
                 A list of python variables to be converted into SQL values in your query
             commit: boolean
                 Must be true. BigQuery
+            job_config: QueryJobConfig or None
+                An optional QueryJobConfig object for custom behavior. See https://cloud.google.com/python/docs/reference/bigquery/latest#google.cloud.bigquery.job.QueryJobConfig
 
         `Returns:`
             Parsons Table
@@ -325,7 +340,7 @@ class GoogleBigQuery(DatabaseConnector):
         # get our connection and cursor
         with self.cursor(connection) as cursor:
             # Run the query
-            cursor.execute(sql, parameters)
+            cursor.execute(sql, parameters, job_config=job_config)
 
             if not return_values:
                 return None


### PR DESCRIPTION
## What is this change?
The google BigQuery python SDK allows setting custom job configs on individual queries. This change allows passing a QueryJobConfig object through the BigQuery().query() connector method

