### PR TITLE
Fix Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN   wget -qO- https://dl.google.com/linux/linux_signing_key.pub \
   chmod 0644 /etc/apt/keyrings/google.gpg; \
   echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/google.gpg] https://dl.google.com/linux/chrome/deb/ stable main' \
     > /etc/apt/sources.list.d/google-chrome.list
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
 RUN apt-get -y update
 RUN apt-get install -y google-chrome-stable
 


### PR DESCRIPTION
## What is this change?
- apt-key is no longer available in recent debian distributions because it is insecure

## Considerations for discussion
- Kasia asked if we can we just rip this Chrome stuff out completely- I didn't do that because I am scared of what would break but we probably should eventually

## How to test the changes (if needed)
- `docker build  . -t movementcooperative/parsons:20250814` should work instead of complaining about apt-key missing
