### PR TITLE
Exclude ruff Pathlib rules that don't autofix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,14 @@ select = [
 ]
 ignore = [
     "E501", # line-too-long (E501)
+    # Pathlib stuff that isn't autofixable
+    "PTH116", # os-stat (PTH116)
+    "PTH118", # os-path-join (PTH118)
+    "PTH122", # os-path-splitext (PTH122)
+    "PTH124", # py-path (PTH124)
+    "PTH206", # os-sep-split (PTH206)
+    "PTH207", # glob (PTH207)
+    "PTH208", # os-listdir (PTH208)
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
Some Pathlib ruff rules don't have autofixes available.
This removes them to reduce workload when people submit PRs.

https://docs.astral.sh/ruff/rules/os-stat/
https://docs.astral.sh/ruff/rules/os-path-join/
https://docs.astral.sh/ruff/rules/os-path-splitext/#os-path-splitext-pth122
https://docs.astral.sh/ruff/rules/py-path/#py-path-pth124
https://docs.astral.sh/ruff/rules/os-sep-split/
https://docs.astral.sh/ruff/rules/glob/#glob-pth207
https://docs.astral.sh/ruff/rules/os-listdir/