### PR TITLE
Adding statefileid to Catalist match columns

### DIFF
--- a/parsons/catalist/catalist.py
+++ b/parsons/catalist/catalist.py
@@ -403,6 +403,7 @@ class CatalistMatch:
             "dob",
             "dob_year",
             "matchbackid",
+            "statefileid"
         ]
 
         required_columns: list[str] = ["first_name", "last_name"]


### PR DESCRIPTION
## What is this change?
- I added `statefileid` to the list of columns in the `validate_table` function of CatalistMatch. This way, people can match on state file ID in addition to other personal info.

## Considerations for discussion
- There's a corresponding PR in Canales to add `statefileid` to the list of columns in the Python matching script.

## How to test the changes (if needed)
- I tested this change with a custom docker image in [this Civis script](https://platform.civisanalytics.com/spa/#/scripts/containers/326239819).
