### PR TITLE
Comment out requirements instructions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Requirements are no longer in this file.
-Run `pip install -e .[all]` to install all dependencies.
+# Requirements are no longer in this file.
+# Run `pip install -e .[all]` to install all dependencies.


### PR DESCRIPTION
dependabot doesn't like that we have a requirements.txt file with invalid syntax.

## What is this change?

- Comment out contents of requirements.txt file.

## Considerations for discussion

- Should we just delete the file? We left it hoping that the error people would get when trying to install it would alert people to the new install method.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>