### PR TITLE
Delay label-from-checkboxes until after label-from-files

### DIFF
--- a/.github/workflows/pr-label-checks.yml
+++ b/.github/workflows/pr-label-checks.yml
@@ -33,6 +33,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    needs: label-from-files
+
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-label-checks.yml
+++ b/.github/workflows/pr-label-checks.yml
@@ -109,6 +109,8 @@ jobs:
         with:
           script: |
             const labels = context.payload.pull_request.labels.map(l => l.name);
+            core.debug(`Detected labels: ${JSON.stringify(labels)}`);
+
             const hasBreaking = labels.includes('breaking-change');
             const hasNonBreaking = labels.includes('non-breaking-change');
 

--- a/.github/workflows/pr-label-checks.yml
+++ b/.github/workflows/pr-label-checks.yml
@@ -113,11 +113,10 @@ jobs:
 
             const hasBreaking = labels.includes('breaking-change');
             const hasNonBreaking = labels.includes('non-breaking-change');
-
             if (hasBreaking && hasNonBreaking) {
-              core.setFailed("PR has both 'breaking-change' and 'non-breaking-change' labels. Please remove one.");
+              core.setFailed("⛔ PR has both 'breaking-change' and 'non-breaking-change' labels. Please remove one.");
             } else if (!hasBreaking && !hasNonBreaking) {
-              core.setFailed("PR is missing a required label. Please add exactly one of: 'breaking-change' or 'non-breaking-change'.");
+              core.setFailed("⛔ PR is missing a required label. Please add exactly one of: 'breaking-change' or 'non-breaking-change'.");
             } else {
               console.log("✅ Label check passed.");
             }


### PR DESCRIPTION
## What is this change?

- Run the checkbox-based labeling job AFTER the file-based labeling job to avoid collisions.
- Add ⛔ emoji to check failure messages.
- Add debug logging of all detected labels.

## Considerations for discussion

- Running both label jobs simultaneous was causing them to sometimes interfere with each other ([example](https://github.com/move-coop/parsons/pull/1822)).
- Is this the right order? It was easier than doing the opposite because the other jobs don't run on dependabot PRs.

## How to test the changes (if needed)

- Merge and create a new PR. Unfortunately due to workflow permissions the workflow has to be on main to be run.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>
