### PR TITLE
Trigger documentation publishing alongside new releases

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,7 +7,8 @@ on:
     branches:
       - main
       - major-release
-
+    tags:
+      - 'v*'
 permissions: read-all
 
 env:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/parsons?label=Python)](https://pypi.org/project/parsons/)
 
 [![PyPI - Latest Version](https://img.shields.io/pypi/v/parsons?label=PyPI)](https://pypi.org/project/parsons/)
-[![PyPI - Total Downloads](https://static.pepy.tech/personalized-badge/parsons?period=total&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Total+DL)](https://pepy.tech/projects/parsons)
-[![PyPI - Monthly Downloads](https://static.pepy.tech/personalized-badge/parsons?period=monthly&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Monthly+DL)](https://pepy.tech/projects/parsons)
+[![PyPI - Total Downloads](https://static.pepy.tech/personalized-badge/parsons?period=total&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Total+Downloads)](https://pepy.tech/projects/parsons)
+[![PyPI - Monthly Downloads](https://static.pepy.tech/personalized-badge/parsons?period=monthly&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Monthly+Downloads)](https://pepy.tech/projects/parsons)
 
 [![Build, Test, & Publish](https://img.shields.io/github/actions/workflow/status/move-coop/parsons/release.yml?branch=main&label=Build%2C%20Test%2C%20%26%20Publish)](https://github.com/move-coop/parsons/actions/workflows/release.yml)
 [![Python Checks](https://img.shields.io/github/actions/workflow/status/move-coop/parsons/python-checks.yml?branch=main&label=Python%20Checks)](https://github.com/move-coop/parsons/actions/workflows/python-checks.yml)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![PyPI - Total Downloads](https://static.pepy.tech/personalized-badge/parsons?period=total&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Total+DL)](https://pepy.tech/projects/parsons)
 [![PyPI - Monthly Downloads](https://static.pepy.tech/personalized-badge/parsons?period=monthly&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Monthly+DL)](https://pepy.tech/projects/parsons)
 
-[![Build, test, & publish](https://github.com/move-coop/parsons/actions/workflows/release.yml/badge.svg)](https://github.com/move-coop/parsons/actions/workflows/release.yml)
-[![Python checks](https://github.com/move-coop/parsons/actions/workflows/python-checks.yml/badge.svg)](https://github.com/move-coop/parsons/actions/workflows/python-checks.yml)
+[![Build, Test, & Publish](https://img.shields.io/github/actions/workflow/status/move-coop/parsons/release.yml?branch=main&label=Build%2C%20Test%2C%20%26%20Publish)](https://github.com/move-coop/parsons/actions/workflows/release.yml)
+[![Python Checks](https://img.shields.io/github/actions/workflow/status/move-coop/parsons/python-checks.yml?branch=main&label=Python%20Checks)](https://github.com/move-coop/parsons/actions/workflows/python-checks.yml)
 [![Coverage](https://raw.githubusercontent.com/move-coop/parsons/python-coverage-comment-action-data/badge.svg)](https://htmlpreview.github.io/?https://github.com/move-coop/parsons/blob/python-coverage-comment-action-data/htmlcov/index.html)
 
 A Python package that provides a simple interface to a variety of utilities and tools frequently used by progressive

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ a [modified Apache License with author attribution statement](https://github.com
 ## Documentation
 
 To gain a full understanding of all of the features of Parsons, please review the
-Parsons [documentation](https://move-coop.github.io/parsons/html/index.html).
+Parsons [documentation](https://move-coop.github.io/parsons/index.html).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/parsons?label=Python)](https://pypi.org/project/parsons/)
 
 [![PyPI - Latest Version](https://img.shields.io/pypi/v/parsons?label=PyPI)](https://pypi.org/project/parsons/)
-[![PyPI - Total Downloads](https://static.pepy.tech/personalized-badge/parsons?period=total&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Total+Downloads)](https://pepy.tech/projects/parsons)
-[![PyPI - Monthly Downloads](https://static.pepy.tech/personalized-badge/parsons?period=monthly&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Monthly+Downloads)](https://pepy.tech/projects/parsons)
+[![PyPI - Total Downloads](https://static.pepy.tech/personalized-badge/parsons?period=total&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Total+PyPI+Downloads)](https://pepy.tech/projects/parsons)
+[![PyPI - Monthly Downloads](https://static.pepy.tech/personalized-badge/parsons?period=monthly&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Monthly+PyPI+Downloads)](https://pepy.tech/projects/parsons)
+
+[![Docker Image Version](https://img.shields.io/docker/v/movementcooperative/parsons?label=Docker)](https://hub.docker.com/r/movementcooperative/parsons)
+[![Total Docker Pulls](https://img.shields.io/docker/pulls/movementcooperative/parsons?label=Total%20Docker%20Pulls)](https://hub.docker.com/r/movementcooperative/parsons)
 
 [![Build, Test, & Publish](https://img.shields.io/github/actions/workflow/status/move-coop/parsons/release.yml?branch=main&label=Build%2C%20Test%2C%20%26%20Publish)](https://github.com/move-coop/parsons/actions/workflows/release.yml)
 [![Python Checks](https://img.shields.io/github/actions/workflow/status/move-coop/parsons/python-checks.yml?branch=main&label=Python%20Checks)](https://github.com/move-coop/parsons/actions/workflows/python-checks.yml)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Parsons
 
-[![Downloads](https://pepy.tech/badge/parsons)](https://pepy.tech/project/parsons)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/parsons)](https://pypi.org/project/parsons/)
-[![PyPI](https://img.shields.io/pypi/v/parsons?color=blue)](https://pypi.org/project/parsons/)
-[![CircleCI](https://circleci.com/gh/move-coop/parsons/tree/main.svg?style=shield)](https://circleci.com/gh/move-coop/parsons/tree/main)
-[![Coverage badge](https://raw.githubusercontent.com/move-coop/parsons/python-coverage-comment-action-data/badge.svg)](https://htmlpreview.github.io/?https://github.com/move-coop/parsons/blob/python-coverage-comment-action-data/htmlcov/index.html)
+[![Documentation - Latest Version](https://img.shields.io/github/v/tag/move-coop/parsons?sort=semver&filter=v*&label=Documentation)](https://move-coop.github.io/parsons/index.html/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/parsons?label=Python)](https://pypi.org/project/parsons/)
+
+[![PyPI - Latest Version](https://img.shields.io/pypi/v/parsons?label=PyPI)](https://pypi.org/project/parsons/)
+[![PyPI - Total Downloads](https://static.pepy.tech/personalized-badge/parsons?period=total&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Total+DL)](https://pepy.tech/projects/parsons)
+[![PyPI - Monthly Downloads](https://static.pepy.tech/personalized-badge/parsons?period=monthly&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=BLUE&left_text=Monthly+DL)](https://pepy.tech/projects/parsons)
+
+[![Build, test, & publish](https://github.com/move-coop/parsons/actions/workflows/release.yml/badge.svg)](https://github.com/move-coop/parsons/actions/workflows/release.yml)
+[![Python checks](https://github.com/move-coop/parsons/actions/workflows/python-checks.yml/badge.svg)](https://github.com/move-coop/parsons/actions/workflows/python-checks.yml)
+[![Coverage](https://raw.githubusercontent.com/move-coop/parsons/python-coverage-comment-action-data/badge.svg)](https://htmlpreview.github.io/?https://github.com/move-coop/parsons/blob/python-coverage-comment-action-data/htmlcov/index.html)
 
 A Python package that provides a simple interface to a variety of utilities and tools frequently used by progressive
 organizations, political and issue campaigns, activists, and other allied actors.


### PR DESCRIPTION
## What is this change?

- Build and publish documentation when new git tags are created.
- Remove `html/` segment from README documentation link so that clicking it doesn't rely on 404 redirect.
- Add badge for Documentation to README.md. ([preview](https://github.com/bmos/parsons/blob/patch-3/README.md))
- Update title and styling of other badges in README.md ([preview](https://github.com/bmos/parsons/blob/patch-3/README.md))

## Considerations for discussion

- Currently, documentation is only updated when commits are pushed to main, which means that our documentation is sometimes missing the latest tag (shortly after it's published). This is resolved when more things are merged to main, but sometimes that takes a while.

## How to test the changes (if needed)

- Merge, then publish a release.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>
