### PR TITLE
Fix BigQuery API (and others) not showing in Parsons Documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -51,6 +51,7 @@ jobs:
           --upgrade
           --no-default-groups
           --group docs
+          --all-extras
 
       - name: configure git
         run: |

--- a/docs/google.rst
+++ b/docs/google.rst
@@ -5,8 +5,6 @@ Google Cloud services allow you to upload and manipulate Tables as spreadsheets 
 
 For all of these services you will need to enable the APIs for your Google Cloud account and obtain authentication tokens or other credentials to access them from your scripts. If you are the administrator of your Google Cloud account, you can do both of these at `Google Cloud Console APIs and Services - Dashboard <https://console.cloud.google.com/apis/dashboard>`_. The connectors below have more specific information about how to authenticate.
 
-.. _gbq:
-
 *************
 Google Admin
 *************
@@ -51,6 +49,8 @@ API
 .. autoclass:: parsons.google.google_admin.GoogleAdmin
    :inherited-members:
    :members:
+
+.. _gbq:
 
 ********
 BigQuery

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -124,19 +124,19 @@ class GoogleBigQuery(DatabaseConnector):
     This class requires application credentials in the form of a json. It can be passed
     in the following ways:
 
-    * Set an environmental variable named `GOOGLE_APPLICATION_CREDENTIALS` with the
+    * Set an environmental variable named ``GOOGLE_APPLICATION_CREDENTIALS`` with the
       local path to the credentials json.
 
-      Example: `GOOGLE_APPLICATION_CREDENTALS='path/to/creds.json'`
+      Example: ``GOOGLE_APPLICATION_CREDENTALS='path/to/creds.json'``
 
-    * Pass in the path to the credentials using the `app_creds` argument.
+    * Pass in the path to the credentials using the ``app_creds`` argument.
 
-    * Pass in a json string using the `app_creds` argument.
+    * Pass in a json string using the ``app_creds`` argument.
 
     Args:
         app_creds: str, optional
             A credentials json string or a path to a json file. Not required
-            if `GOOGLE_APPLICATION_CREDENTIALS` env variable set.
+            if ``GOOGLE_APPLICATION_CREDENTIALS`` env variable set.
         project: str, optional
             The project which the client is acting on behalf of. If not passed
             then will use the default inferred environment.
@@ -149,7 +149,7 @@ class GoogleBigQuery(DatabaseConnector):
         tmp_gcs_bucket: str, optional
             Name of the GCS bucket that will be used for storing data during bulk transfers.
             Required if you intend to perform bulk data transfers (eg. the copy_from_gcs method),
-            and env variable `GCS_TEMP_BUCKET` is not populated.
+            and env variable ``GCS_TEMP_BUCKET`` is not populated.
 
     """
 

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -903,6 +903,7 @@ class GoogleBigQuery(DatabaseConnector):
                 tmpfile,
                 destination=self.get_table_ref(table_name=table_name),
                 job_config=job_config,
+                **load_kwargs,
             )
 
             try:

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -124,14 +124,14 @@ class GoogleBigQuery(DatabaseConnector):
     This class requires application credentials in the form of a json. It can be passed
     in the following ways:
 
-    * Set an environmental variable named ``GOOGLE_APPLICATION_CREDENTIALS`` with the
+    * Set an environmental variable named `GOOGLE_APPLICATION_CREDENTIALS` with the
       local path to the credentials json.
 
-      Example: ``GOOGLE_APPLICATION_CREDENTALS='path/to/creds.json'``
+      Example: `GOOGLE_APPLICATION_CREDENTALS='path/to/creds.json'`
 
-    * Pass in the path to the credentials using the ``app_creds`` argument.
+    * Pass in the path to the credentials using the `app_creds` argument.
 
-    * Pass in a json string using the ``app_creds`` argument.
+    * Pass in a json string using the `app_creds` argument.
 
     Args:
         app_creds: str
@@ -149,7 +149,7 @@ class GoogleBigQuery(DatabaseConnector):
         gcs_temp_bucket: str
             Name of the GCS bucket that will be used for storing data during bulk transfers.
             Required if you intend to perform bulk data transfers (eg. the copy_from_gcs method),
-            and env variable ``GCS_TEMP_BUCKET`` is not populated.
+            and env variable `GCS_TEMP_BUCKET` is not populated.
 
     """
 

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1795,13 +1795,14 @@ class GoogleBigQuery(DatabaseConnector):
             if if_table_exists == "overwrite":  # if it exists
                 job_config = bigquery.CopyJobConfig()
                 job_config.write_disposition = "WRITE_TRUNCATE"
-                job = self.client.copy_table(
+                copy_job = self.client.copy_table(
                     source_table_id,
                     destination_table_id,
                     location="US",
                     job_config=job_config,
                 )
-                result = job.result()
+                result = copy_job.result()
+                logger.info(result)
             else:
                 logger.error(
                     f"BigQuery copy failed, Table {destination_table} exists and if_table_exists set to {if_table_exists}"
@@ -1809,13 +1810,13 @@ class GoogleBigQuery(DatabaseConnector):
 
         except NotFound:
             # destination table doesn't exist, so we can create one
-            job = self.client.copy_table(
+            copy_job = self.client.copy_table(
                 source_table_id,
                 destination_table_id,
                 location="US",
                 job_config=job_config,
             )
-            result = job.result()
+            result = copy_job.result()
             logger.info(result)
 
 

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -134,19 +134,19 @@ class GoogleBigQuery(DatabaseConnector):
     * Pass in a json string using the `app_creds` argument.
 
     Args:
-        app_creds: str
+        app_creds: str, optional
             A credentials json string or a path to a json file. Not required
-            if ``GOOGLE_APPLICATION_CREDENTIALS`` env variable set.
-        project: str
+            if `GOOGLE_APPLICATION_CREDENTIALS` env variable set.
+        project: str, optional
             The project which the client is acting on behalf of. If not passed
             then will use the default inferred environment.
-        location: str
+        location: str, optional
             Default geographic location for tables
-        client_options: dict
+        client_options: dict, optional
             A dictionary containing any requested client options. Defaults to the required
             scopes for making API calls against External tables stored in Google Drive.
             Can be set to None if these permissions are not desired
-        gcs_temp_bucket: str
+        tmp_gcs_bucket: str, optional
             Name of the GCS bucket that will be used for storing data during bulk transfers.
             Required if you intend to perform bulk data transfers (eg. the copy_from_gcs method),
             and env variable `GCS_TEMP_BUCKET` is not populated.
@@ -383,8 +383,6 @@ class GoogleBigQuery(DatabaseConnector):
         Args:
             job_id: str
                 ID of job to fetch
-            location: str
-                Location where the job was run
             `**job_kwargs`: kwargs
                 Other arguments to pass to the underlying get_job
                 call on the BigQuery client.
@@ -1698,8 +1696,7 @@ class GoogleBigQuery(DatabaseConnector):
                 The Google Cloud project ID.
                 If not provided, the default project of the client is used.
             gzip: bool
-                If True, the exported file will be compressed using GZIP.
-                Defaults to False.
+                Not implemented
 
         """
         if not job_config:

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -1021,7 +1021,8 @@ class GoogleBigQuery(DatabaseConnector):
             if not keep_gcs_file:
                 gcs_client.delete_blob(tmp_gcs_bucket, temp_blob_name)
 
-    def _stringify_records(self, tbl):
+    @staticmethod
+    def _stringify_records(tbl):
         # Convert dict columns to JSON strings
         for field in tbl.get_columns_type_stats():
             if "dict" in field["type"] or "list" in field["type"]:
@@ -1596,7 +1597,8 @@ class GoogleBigQuery(DatabaseConnector):
 
         return job_config
 
-    def _fetch_query_results(self, cursor) -> Table:
+    @staticmethod
+    def _fetch_query_results(cursor) -> Table:
         # We will use a temp file to cache the results so that they are not all living
         # in memory. We'll use pickle to serialize the results to file in order to maintain
         # the proper data types (e.g. integer).
@@ -1618,8 +1620,8 @@ class GoogleBigQuery(DatabaseConnector):
         ptable = petl.frompickle(temp_filename)
         return Table(ptable)
 
+    @staticmethod
     def _validate_copy_inputs(
-        self,
         if_exists: Literal["append", "drop", "truncate", "fail"],
         data_type: Literal["csv", "json"],
         accepted_data_types: list[str],

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -49,37 +49,30 @@ BIGQUERY_TYPE_MAP = {
 QUERY_BATCH_SIZE = 100000
 
 
-def _parse_table_name(table_name):
-    # Helper function to parse out the different components of a table ID
+def parse_table_name(table_name: str):
+    """Parse a table name into its project, dataset, and table components."""
     parts = table_name.split(".")
     parts.reverse()
-    parsed = {
-        "project": None,
-        "dataset": None,
-        "table": None,
+    return {
+        "table": parts[0] if len(parts) > 0 else None,
+        "dataset": parts[1] if len(parts) > 1 else None,
+        "project": parts[2] if len(parts) > 2 else None,
     }
-    if len(parts) > 0:
-        parsed["table"] = parts[0]
-    if len(parts) > 1:
-        parsed["dataset"] = parts[1]
-    if len(parts) > 2:
-        parsed["project"] = parts[2]
-    return parsed
 
 
-def _ends_with_semicolon(query: str) -> str:
+def ends_with_semicolon(query: str) -> str:
+    """Ensure a query ends with a semicolon append a semicolon, if not."""
     query = query.strip()
     if query[-1] == ";":
         return query
     return query + ";"
 
 
-def _map_column_headers_to_schema_field(schema_definition: list) -> list:
+def map_column_headers_to_schema_field(schema_definition: list) -> list:
     """
-    Loops through a list of dictionaries and instantiates
-    google.cloud.bigquery.SchemaField objects. Useful docs
-    from Google's API can be found here:
-        https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.schema.SchemaField
+    Loops through a list of dictionaries and instantiates google.cloud.bigquery.SchemaField objects.
+    Useful docs from Google's API can be found here:
+    https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.schema.SchemaField
 
     Args:
         schema_definition: list
@@ -284,7 +277,8 @@ class GoogleBigQuery(DatabaseConnector):
             parameters: dict
                 A dictionary of query parameters for BigQuery.
             job_config: QueryJobConfig or None
-                An optional QueryJobConfig object for custom behavior. See https://cloud.google.com/python/docs/reference/bigquery/latest#google.cloud.bigquery.job.QueryJobConfig
+                An optional QueryJobConfig object for custom behavior.
+                See https://cloud.google.com/python/docs/reference/bigquery/latest#google.cloud.bigquery.job.QueryJobConfig
 
         Returns:
             Parsons Table
@@ -325,7 +319,8 @@ class GoogleBigQuery(DatabaseConnector):
             commit: boolean
                 Must be true. BigQuery
             job_config: QueryJobConfig or None
-                An optional QueryJobConfig object for custom behavior. See https://cloud.google.com/python/docs/reference/bigquery/latest#google.cloud.bigquery.job.QueryJobConfig
+                An optional QueryJobConfig object for custom behavior.
+                See https://cloud.google.com/python/docs/reference/bigquery/latest#google.cloud.bigquery.job.QueryJobConfig
 
         Returns:
             Parsons Table
@@ -363,7 +358,7 @@ class GoogleBigQuery(DatabaseConnector):
             return final_table
 
     def query_with_transaction(self, queries, parameters=None):
-        queries_with_semicolons = [_ends_with_semicolon(q) for q in queries]
+        queries_with_semicolons = [ends_with_semicolon(q) for q in queries]
         queries_on_newlines = "\n".join(queries_with_semicolons)
         queries_wrapped = f"""
         BEGIN
@@ -983,7 +978,9 @@ class GoogleBigQuery(DatabaseConnector):
         )
         if not tmp_gcs_bucket:
             raise ValueError(
-                "Must set GCS_TEMP_BUCKET environment variable or pass in tmp_gcs_bucket parameter. If you have smaller data, you can use the `copy_direct` method to upload the data without needing to use CloudStorage. This alternate method will not work well with larger data."
+                "Must set GCS_TEMP_BUCKET environment variable or pass in tmp_gcs_bucket parameter. "
+                "If you have smaller data, you can use the `copy_direct` method to upload the data without needing to use CloudStorage. "
+                "This alternate method will not work well with larger data."
             )
 
         if convert_dict_list_columns_to_json:
@@ -1416,7 +1413,7 @@ class GoogleBigQuery(DatabaseConnector):
 
     def get_table_ref(self, table_name):
         # Helper function to build a TableReference for our table
-        parsed = _parse_table_name(table_name)
+        parsed = parse_table_name(table_name)
         dataset_ref = self.client.dataset(parsed["dataset"])
         return dataset_ref.table(parsed["table"])
 
@@ -1434,7 +1431,7 @@ class GoogleBigQuery(DatabaseConnector):
             return job_config.schema
         # if schema specified by user, convert to schema type and use that
         if custom_schema:
-            return _map_column_headers_to_schema_field(custom_schema)
+            return map_column_headers_to_schema_field(custom_schema)
         # if template_table specified by user, use that
         # otherwise, if loading into existing table, infer destination table as template table
         if not template_table and if_exists in ("append", "truncate"):

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -49,7 +49,7 @@ BIGQUERY_TYPE_MAP = {
 QUERY_BATCH_SIZE = 100000
 
 
-def parse_table_name(table_name):
+def _parse_table_name(table_name):
     # Helper function to parse out the different components of a table ID
     parts = table_name.split(".")
     parts.reverse()
@@ -67,14 +67,14 @@ def parse_table_name(table_name):
     return parsed
 
 
-def ends_with_semicolon(query: str) -> str:
+def _ends_with_semicolon(query: str) -> str:
     query = query.strip()
     if query[-1] == ";":
         return query
     return query + ";"
 
 
-def map_column_headers_to_schema_field(schema_definition: list) -> list:
+def _map_column_headers_to_schema_field(schema_definition: list) -> list:
     """
     Loops through a list of dictionaries and instantiates
     google.cloud.bigquery.SchemaField objects. Useful docs
@@ -363,7 +363,7 @@ class GoogleBigQuery(DatabaseConnector):
             return final_table
 
     def query_with_transaction(self, queries, parameters=None):
-        queries_with_semicolons = [ends_with_semicolon(q) for q in queries]
+        queries_with_semicolons = [_ends_with_semicolon(q) for q in queries]
         queries_on_newlines = "\n".join(queries_with_semicolons)
         queries_wrapped = f"""
         BEGIN
@@ -1417,7 +1417,7 @@ class GoogleBigQuery(DatabaseConnector):
 
     def get_table_ref(self, table_name):
         # Helper function to build a TableReference for our table
-        parsed = parse_table_name(table_name)
+        parsed = _parse_table_name(table_name)
         dataset_ref = self.client.dataset(parsed["dataset"])
         return dataset_ref.table(parsed["table"])
 
@@ -1435,7 +1435,7 @@ class GoogleBigQuery(DatabaseConnector):
             return job_config.schema
         # if schema specified by user, convert to schema type and use that
         if custom_schema:
-            return map_column_headers_to_schema_field(custom_schema)
+            return _map_column_headers_to_schema_field(custom_schema)
         # if template_table specified by user, use that
         # otherwise, if loading into existing table, infer destination table as template table
         if not template_table and if_exists in ("append", "truncate"):

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -408,7 +408,7 @@ class GoogleBigQuery(DatabaseConnector):
         schema: list[dict] | None = None,
         job_config: LoadJobConfig | None = None,
         force_unzip_blobs: bool = False,
-        compression_type: str = "gzip",
+        compression_type: Literal["zip", "gzip"] = "gzip",
         new_file_extension: str = "csv",
         template_table: str | None = None,
         max_timeout: int = 21600,
@@ -593,7 +593,7 @@ class GoogleBigQuery(DatabaseConnector):
         quote: str | None = None,
         schema: list[dict] | None = None,
         job_config: LoadJobConfig | None = None,
-        compression_type: str = "gzip",
+        compression_type: Literal["zip", "gzip"] = "gzip",
         new_file_extension: str = "csv",
         template_table: str | None = None,
         max_timeout: int = 21600,
@@ -1053,7 +1053,7 @@ class GoogleBigQuery(DatabaseConnector):
         quote,
         schema,
     ):
-        data_type = "csv"
+        data_type: Literal["csv", "json"] = "csv"
 
         self._validate_copy_inputs(
             if_exists=if_exists, data_type=data_type, accepted_data_types=["csv"]

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -12,7 +12,7 @@ import google
 import petl
 from google.api_core import exceptions
 from google.cloud import bigquery
-from google.cloud.bigquery import dbapi, job
+from google.cloud.bigquery import ExtractJob, dbapi, job
 from google.cloud.bigquery.job import ExtractJobConfig, LoadJobConfig, QueryJobConfig
 from google.oauth2.credentials import Credentials
 
@@ -156,8 +156,8 @@ class GoogleBigQuery(DatabaseConnector):
     def __init__(
         self,
         app_creds: str | dict | Credentials | None = None,
-        project=None,
-        location=None,
+        project: str | None = None,
+        location: str | None = None,
         client_options: dict | None = None,
         tmp_gcs_bucket: str | None = None,
     ):
@@ -1679,7 +1679,7 @@ class GoogleBigQuery(DatabaseConnector):
         job_config: ExtractJobConfig = None,
         wait_for_job_to_complete: bool = True,
         **export_kwargs,
-    ) -> None:
+    ) -> ExtractJob:
         """
         Extracts a BigQuery table to a Google Cloud Storage bucket.
 

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -796,7 +796,7 @@ class GoogleBigQuery(DatabaseConnector):
             or check_env.check("GCS_TEMP_BUCKET", tmp_gcs_bucket)
         )
         gcs_client = gcs_client or GoogleCloudStorage()
-        temp_blob_uri = gcs_client.copy_s3_to_gcs(
+        gcs_client.copy_s3_to_gcs(
             aws_source_bucket=bucket,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
@@ -1708,7 +1708,6 @@ class GoogleBigQuery(DatabaseConnector):
             )
         source = f"{dataset}.{table_name}"
         gs_destination = f"gs://{gcs_bucket}/{gcs_blob_name}"
-        compression = "GZIP" if gzip else compression
         logger.info(f"Project (parsons): {project}")
         extract_job = self.client.extract_table(
             source=source,
@@ -1780,7 +1779,7 @@ class GoogleBigQuery(DatabaseConnector):
             # if it doesn't exist: check if it's ok to create it
             if if_dataset_not_exists == "create":  # create a new dataset in the destination
                 dataset = bigquery.Dataset(dataset_id)
-                dataset = self.client.create_dataset(dataset, timeout=30)
+                self.client.create_dataset(dataset, timeout=30)
             else:  # if it doesn't exist and it's not ok to create it, fail
                 logger.error("BigQuery copy failed")
                 logger.error(


### PR DESCRIPTION
#1721 broke our documentation build, which needs access to all our dependencies.

## What is this change?

- Install parsons with all extras during build job of documentation workflow
- Improve type hints
- Improve docstrings
- Remove unused variables
- Pass `**load_kwargs` to load_table_from_file() as described in docstring
- Mark static methods with @staticmethod

## How to test the changes (if needed)

- CI tests should be adequate

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- 
