### PR TITLE
Refactor label fetching in PR checks workflow

### DIFF
--- a/.github/workflows/pr-label-checks.yml
+++ b/.github/workflows/pr-label-checks.yml
@@ -108,7 +108,13 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
-            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const labels = pullRequest.labels.map(l => l.name);
             core.debug(`Detected labels: ${JSON.stringify(labels)}`);
 
             const hasBreaking = labels.includes('breaking-change');


### PR DESCRIPTION
## What is this change?

- Fetch latest label data during label check job as context.payload is static and does not capture changes that occurred in earlier jobs. #1823 actually made the situation worse as the context is always out of date.

## Considerations for discussion

- How can we test these things without having to merge a bunch of PRs? Ugh.

## How to test the changes (if needed)

- Merge it :\
- For security, the trigger used in this workflow only works if the changes are on main

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
