### PR TITLE
Replace dependency suds-py3 with suds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ EXTRA_DEPENDENCIES = {
         "sqlalchemy >= 1.4",
     ],
     "newmode": ["newmode >= 0.1.6"],
-    "ngpvan": ["suds-py3 >= 1.4"],
+    "ngpvan": ["suds >= 1"],
     "mobilecommons": ["beautifulsoup4 >= 4", "xmltodict >= 1"],
     "pandas": ["pandas >= 2.3.3"],
     "postgres": [


### PR DESCRIPTION
## What is this change?

- Replace [suds-py3](https://pypi.org/project/suds-py3/) with suds as [suds](https://pypi.org/project/suds/) is once again maintained

## Considerations for discussion

- Lightweight SOAP client (community fork) was released on pypi in 2009 based on [suds-jurko](https://pypi.org/project/suds-jurko/) which was based on [the initial work](https://github.com/jortel/suds) of jortel. It was not updated for python 3 for some years, so our NGPVAN connector is using a fork called suds-py3.
- Recently, the official suds package was transferred to lightweight SOAP client (community fork), so it is maintained again. suds-py3 hasn't had an update since 2021.

## How to test the changes (if needed)

- CI tests should be adequate.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
