### PR TITLE
Update Documentation Workflow and Makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -68,10 +68,10 @@ instance/
 
 # documentation
 docs/html
-docs/_build/html
+docs/_build
 docs/dirhtml
-/site
-doctrees/
+site/
+.doctrees/
 
 # PyBuilder
 target/

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,6 +28,8 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
 
+    if: github.event_name != 'pull_request'
+    
     steps:
       - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,14 +25,14 @@ env:
     *.githubusercontent.com:443
 
 jobs:
-  build:
+  build-multiversion:
     runs-on: ubuntu-latest
 
     steps:
       - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
         with:
           disable-sudo: true
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: ${{ env.ENDPOINT_WHITELIST}}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: docs/html
-          key: sphinx-${{ hashFiles('pyproject.toml', 'setup.py', 'requirements-dev.txt', 'docs/make.py', 'docs/conf.py') }}
+          key: sphinx-${{ hashFiles('docs/make.py', 'docs/conf.py') }}
 
       - run: make build_docs
         working-directory: docs
@@ -71,8 +71,8 @@ jobs:
           path: docs/html/
 
   deploy:
-    needs: build
-    # Don't run this job on pull requests
+    needs: build-multiversion
+
     if: github.event_name != 'pull_request'
 
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,6 +25,35 @@ env:
     *.githubusercontent.com:443
 
 jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        with:
+          disable-sudo: true
+          egress-policy: audit
+          allowed-endpoints: ${{ env.ENDPOINT_WHITELIST}}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          python-version: 3.13
+          activate-environment: true
+          cache-dependency-glob: ${{ env.CACHE_GLOBS }}
+
+      - run: >-
+          uv sync
+          --upgrade
+          --no-default-groups
+          --group docs
+          --all-extras
+
+      - run: make linkcheck ${{ runner.debug == '1' && '--verbose' || '' }}
+        working-directory: docs
+        continue-on-error: true
+
   build-multiversion:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     if: github.event_name != 'pull_request'
-    
+
     steps:
       - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -65,10 +65,10 @@ instance/
 
 # documentation
 docs/html
-docs/_build/html
+docs/_build
 docs/dirhtml
-/site
-doctrees/
+site/
+.doctrees/
 
 # PyBuilder
 target/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 Parsons: a Python library of connectors for the progressive community.
 
-Copyright 2019-2022 The Movement Cooperative
+Copyright 2019-2026 The Movement Cooperative
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this library except in compliance with the License,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parsons
 
-[![Documentation - Latest Version](https://img.shields.io/github/v/tag/move-coop/parsons?sort=semver&filter=v*&label=Documentation)](https://move-coop.github.io/parsons/index.html/)
+[![Documentation - Latest Version](https://img.shields.io/github/v/tag/move-coop/parsons?sort=semver&filter=v*&label=Documentation)](https://move-coop.github.io/parsons/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/parsons?label=Python)](https://pypi.org/project/parsons/)
 
 [![PyPI - Latest Version](https://img.shields.io/pypi/v/parsons?label=PyPI)](https://pypi.org/project/parsons/)
@@ -42,7 +42,7 @@ a [modified Apache License with author attribution statement](https://github.com
 ## Documentation
 
 To gain a full understanding of all of the features of Parsons, please review the
-Parsons [documentation](https://move-coop.github.io/parsons/index.html).
+Parsons [documentation](https://move-coop.github.io/parsons/).
 
 ## Installation
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path("../").absolute()))
 
 project = "Parsons"
-copyright = "2025, The Movement Cooperative"
+copyright = "2019-2026, The Movement Cooperative"
 author = "The Movement Cooperative"
 release = ""
 
@@ -26,11 +26,11 @@ source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "_template.rst"]
 templates_path = ["_templates"]
 autodoc_member_order = "bysource"
+googleanalytics_id = "G-L2YB7WHTRG"
 
 # -- HTML Output (Furo Theme) ------------------------------------------------
 html_theme = "furo"
 html_static_path = ["_static"]
-googleanalytics_id = "G-L2YB7WHTRG"
 html_favicon = "_static/favicon.ico"
 
 html_sidebars = {
@@ -45,7 +45,7 @@ html_sidebars = {
 }
 
 
-# -- Sphinx-Multiversion Logic -----------------------------------------------
+# -- Sphinx Multiversion Tag Creation ----------------------------------------
 def get_git_tags() -> list[str]:
     try:
         tags = subprocess.check_output(

--- a/docs/make.py
+++ b/docs/make.py
@@ -18,36 +18,42 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 
-def check_dependencies():
+def check_dependencies() -> None:
     """Verify that the required CLI tools are installed and available in the system PATH."""
     tools = ["git", SPHINXBUILD, "sphinx-multiversion"]
     for tool in tools:
+        logger.debug("Checking PATH for %s.", tool)
         if not shutil.which(tool):
             logger.error("Required tool '%s' not found in PATH.", tool)
             sys.exit(1)
+    logger.debug("All required tools found in PATH.")
 
 
-def run_command(command: list[str | Path], cwd: Path = ROOT_DIR) -> subprocess.CompletedProcess:
+def run_command(
+    command: list[str | Path], cwd: Path = ROOT_DIR, *, verbose: bool = False
+) -> subprocess.CompletedProcess:
     """Execute a shell command with error handling and output capture."""
     cmd_str = [str(arg) for arg in command]
     try:
-        return subprocess.run(cmd_str, cwd=cwd, check=True, capture_output=True, text=True)
+        return subprocess.run(cmd_str, cwd=cwd, check=True, capture_output=not verbose, text=True)
     except subprocess.CalledProcessError as e:
         logger.error("Command failed: %s", " ".join(cmd_str))
-        if e.stderr:
+        if not verbose and e.stderr:
             logger.error("Details: %s", e.stderr.strip())
         sys.exit(e.returncode)
 
 
-def reuse_builds_old_versions():
-    """Remove folders not starting with 'v' or with a version >= v5.0.0."""
+def reuse_builds_old_versions(keep_older_than: str | None = None) -> None:
+    """Remove folders not starting with 'v' or with a version >= ``keep_older_than``, if provided."""
     if not HTMLDIR.exists():
         return
 
-    generate_after = version.parse("5.0.0")
+    generate_after = version.parse(keep_older_than) if keep_older_than else None
 
     for item in HTMLDIR.iterdir():
         if not item.is_dir():
+            logger.info("Removing non-directory file %s.", item)
+            item.unlink()
             continue
 
         if not item.name.startswith("v"):
@@ -57,23 +63,50 @@ def reuse_builds_old_versions():
 
         try:
             item_ver = version.parse(item.name.lstrip("v"))
-            if item_ver >= generate_after:
+            if not generate_after or item_ver >= generate_after:
                 logger.info("Removing build files for version: %s", item.name)
                 shutil.rmtree(item)
         except version.InvalidVersion:
-            logger.warning("Skipping invalid version format: %s", item.name)
+            logger.warning("Removing build files for invalid version: %s", item.name)
             shutil.rmtree(item)
 
 
-def build_docs():
+def clean(extra_args: list[str]) -> None:
+    """Delete the '_build' and 'html' directories if they exist."""
+    if extra_args:
+        logger.warning("Clean does not accept extra args: %s", extra_args)
+    for d in [BUILDDIR, HTMLDIR]:
+        if d.exists():
+            logger.info("Deleting build files from %s...", d)
+            shutil.rmtree(d)
+        logger.debug("Directory %s not found.", d)
+
+
+def linkcheck(extra_args: list[str]) -> None:
+    """Build sphinx documentation, checking for broken links."""
+    check_dependencies()
+
+    extra_log_info = " with extra command-line args: " + " ".join(extra_args) if extra_args else ""
+    logger.info("Building single-version docs, checking all links for validity%s.", extra_log_info)
+
+    verbose = ("--verbose" in extra_args) or any(arg.__contains__("-v") for arg in extra_args)
+
+    run_command(
+        [SPHINXBUILD, "--builder", "linkcheck"] + extra_args + [SOURCEDIR, BUILDDIR / "linkcheck"],
+        verbose=verbose,
+    )
+
+
+def build(extra_args: list[str]) -> None:
     """Build multi-version sphinx documentation."""
     check_dependencies()
 
-    reuse_builds_old_versions()
+    logger.info("Re-using any existing builds with versions before v5.0.0.")
+    reuse_builds_old_versions(keep_older_than="v5.0.0")
 
-    git_base = ["git", "-C", str(ROOT_DIR)]
+    git_base = ["git", "-C", ROOT_DIR]
 
-    logger.info("Updating local branch references...")
+    logger.info("Mapping `latest` to current directory...")
     run_command([*git_base, "branch", "-f", "latest"])
 
     tag_proc = run_command([*git_base, "tag", "-l", "--sort=-v:refname"])
@@ -81,47 +114,43 @@ def build_docs():
 
     if tags and tags[0]:
         stable_tag = tags[0]
-        logger.info("Stable version identified: %s", stable_tag)
+        logger.info("Mapping 'stable' to %s", stable_tag)
         run_command([*git_base, "branch", "-f", "stable", stable_tag])
     else:
-        logger.info("No tags found. Mapping 'stable' to 'latest'.")
+        logger.warning("No tags found. Mapping 'stable' to 'latest'.")
         run_command([*git_base, "branch", "-f", "stable", "latest"])
 
-    logger.info("Building multiversion documentation...")
-    run_command(["sphinx-multiversion", str(SOURCEDIR), str(HTMLDIR)])
+    extra_log_info = " with extra command-line args: " + " ".join(extra_args) if extra_args else ""
+    logger.info("Building multiversion documentation%s...", extra_log_info)
+    run_command(["sphinx-multiversion"] + extra_args + [SOURCEDIR, HTMLDIR])
 
     src_redirect = SOURCEDIR / "index-redirect.html"
     if src_redirect.exists():
         shutil.copy2(src_redirect, HTMLDIR / "index.html")
-        logger.info("Static redirect applied to root index.")
+        logger.info("Static redirect applied to root.")
 
     src_404 = SOURCEDIR / "404.html"
     if src_404.exists():
         shutil.copy2(src_404, HTMLDIR / "404.html")
-        logger.info("404 page added to root.")
-
-
-def clean():
-    """Delete the '_build' and 'html' directories if they exist."""
-    for d in [BUILDDIR, HTMLDIR]:
-        if d.exists():
-            logger.info("Cleaning %s...", d)
-            shutil.rmtree(d)
+        logger.info("404 page applied to root.")
 
 
 if __name__ == "__main__":
     targets = {
-        "build_docs": build_docs,
         "clean": clean,
-        "linkcheck": lambda: run_command(
-            [SPHINXBUILD, "-b", "linkcheck", SOURCEDIR, BUILDDIR / "linkcheck"]
-        ),
-        "help": lambda: run_command([SPHINXBUILD, "-M", "help", SOURCEDIR, BUILDDIR]),
+        "linkcheck": linkcheck,
+        "build_docs": build,
+        "help": lambda: run_command([SPHINXBUILD, "--help"]),
     }
 
     target = sys.argv[1] if len(sys.argv) > 1 else "help"
+    extra_args = sys.argv[2:] if len(sys.argv) > 2 else []
+    verbose = ("--verbose" in extra_args) or any(arg.__contains__("-v") for arg in extra_args)
 
     if target in targets:
-        targets[target]()
+        targets[target](extra_args)
     else:
-        run_command([SPHINXBUILD, "-M", target, SOURCEDIR, BUILDDIR])
+        run_command(
+            [SPHINXBUILD, "-M", target, SOURCEDIR, BUILDDIR] + extra_args,
+            verbose=verbose,
+        )

--- a/docs/make.py
+++ b/docs/make.py
@@ -82,6 +82,34 @@ def clean(extra_args: list[str]) -> None:
         logger.debug("Directory %s not found.", d)
 
 
+def test(extra_args: list[str]) -> None:
+    """Build sphinx documentation from latest code failing if there are syntax issues."""
+    check_dependencies()
+
+    extra_log_info = " with extra command-line args: " + " ".join(extra_args) if extra_args else ""
+    logger.info(
+        "Building single-version docs with strict syntax and reference checks%s.", extra_log_info
+    )
+
+    verbose = ("--verbose" in extra_args) or any(arg.__contains__("-v") for arg in extra_args)
+
+    run_command(
+        [
+            SPHINXBUILD,
+            "--jobs=auto",
+            "--fail-on-warning",
+            "--nitpicky",
+            "--fresh-env",
+        ]
+        + extra_args
+        + [
+            SOURCEDIR,
+            BUILDDIR / "html_test",
+        ],
+        verbose=verbose,
+    )
+
+
 def linkcheck(extra_args: list[str]) -> None:
     """Build sphinx documentation, checking for broken links."""
     check_dependencies()
@@ -138,6 +166,7 @@ def build(extra_args: list[str]) -> None:
 if __name__ == "__main__":
     targets = {
         "clean": clean,
+        "test": test,
         "linkcheck": linkcheck,
         "build_docs": build,
         "help": lambda: run_command([SPHINXBUILD, "--help"]),

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ EXTRA_DEPENDENCIES = {
         "validate-email >= 1",
     ],
     "mysql": [
-        "mysql-connector-python >= 7",
+        "mysql-connector-python >= 7, != 9.7.0",
         "sqlalchemy >= 1.4",
     ],
     "newmode": ["newmode >= 0.1.6"],


### PR DESCRIPTION
## What is this change?

- Add (non-failing) job to display broken links in documentation (doesn't run on PRs)
- Allow makefile to pass args to make targets
- Add make target `test` to find issues in sphinx documentation by building just the latest version
- Improve debug logging in makefile
- Maintain cache for documentation builds across more runs

## Considerations for discussion

- `Test` make target can be added to workflow once all the issues are fixed.
   See #1831

## How to test the changes (if needed)

- CI tests are adequate

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
