### PR TITLE
Blacklist broken mysql-connector-python v9.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ EXTRA_DEPENDENCIES = {
         "validate-email >= 1",
     ],
     "mysql": [
-        "mysql-connector-python >= 7",
+        "mysql-connector-python >= 7, != 9.7.0",
         "sqlalchemy >= 1.4",
     ],
     "newmode": ["newmode >= 0.1.6"],


### PR DESCRIPTION
They didn't publish this version correctly, so it's only compatible with some versions of python. It also seems to only contain documentation updates, so it's very weird they pushed it as a minor version change.

## What is this change?

- Fix CI + installing from main by blacklisting broken dependency

## Considerations for discussion

- Here is [what changed](https://github.com/mysql/mysql-connector-python/compare/9.6.0...9.7.0) between v9.6 and v9.7.
- Here are [the files they published to pypi](https://pypi.org/project/mysql-connector-python/9.7.0/#files) for 9.7.0. You'll see it only supports 3.10 and 3.11.
- Here are [the files they published to pypi](https://pypi.org/project/mysql-connector-python/9.6.0/#files) for 9.6.0. You'll see there are many more files.

## How to test the changes (if needed)

- CI tests are adequate

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
