### PR TITLE
Workflow Concurrency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,19 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     ignore:
       - dependency-name: python
 
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     ignore:
       - dependency-name: bandit
       - dependency-name: ruff

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,23 +1,23 @@
 documentation:
-- changed-files:
-  - any-glob-to-any-file: ['**/*.md', '**/*.rst', 'docs/**']
+  - changed-files:
+      - any-glob-to-any-file: ["**/*.md", "**/*.rst", "docs/**"]
 
 dependencies:
-- changed-files:
-  - any-glob-to-any-file: ['setup.py', 'requirements.txt']
+  - changed-files:
+      - any-glob-to-any-file: ["setup.py", "requirements.txt"]
 
 testing:
-- changed-files:
-  - any-glob-to-any-file: 'test/**'
+  - changed-files:
+      - any-glob-to-any-file: "test/**"
 
 docker:
-- changed-files:
-  - any-glob-to-any-file: '**/Dockerfile'
+  - changed-files:
+      - any-glob-to-any-file: "**/Dockerfile"
 
 github_actions:
-- changed-files:
-  - any-glob-to-any-file: '.github/workflows/*.yml'
+  - changed-files:
+      - any-glob-to-any-file: ".github/workflows/*.yml"
 
 python:
-- changed-files:
-  - any-glob-to-any-file: '**/*.py'
+  - changed-files:
+      - any-glob-to-any-file: "**/*.py"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,42 +1,42 @@
 name: Post coverage comment
 
 on:
-    workflow_run:
-        workflows: ['Python checks']
-        types:
-            - completed
+  workflow_run:
+    workflows: ["Python checks"]
+    types:
+      - completed
 
 permissions:
-    contents: read
+  contents: read
 
 jobs:
-    test:
-        name: Run tests & display coverage
+  test:
+    name: Run tests & display coverage
 
-        runs-on: ubuntu-latest
-        if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
 
-        permissions:
-            # Gives the action the necessary permissions for publishing new
-            # comments in pull requests.
-            pull-requests: write
-            # Gives the action the necessary permissions for editing existing
-            # comments (to avoid publishing multiple comments in the same PR)
-            contents: write
-            # Gives the action the necessary permissions for looking up the
-            # workflow that launched this workflow, and download the related
-            # artifact that contains the comment to be published
-            actions: read
+    permissions:
+      # Gives the action the necessary permissions for publishing new
+      # comments in pull requests.
+      pull-requests: write
+      # Gives the action the necessary permissions for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      contents: write
+      # Gives the action the necessary permissions for looking up the
+      # workflow that launched this workflow, and download the related
+      # artifact that contains the comment to be published
+      actions: read
 
-        steps:
-            # DO NOT run actions/checkout here, for security reasons
-            # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-            - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40
-              with:
-                disable-sudo: false
-                egress-policy: audit
+    steps:
+      # DO NOT run actions/checkout here, for security reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40
+        with:
+          disable-sudo: false
+          egress-policy: audit
 
-            - uses: py-cov-action/python-coverage-comment-action@63f52f4fbbffada6e8dee8ec432de7e01df9ba79  # v3.35
-              with:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+      - uses: py-cov-action/python-coverage-comment-action@63f52f4fbbffada6e8dee8ec432de7e01df9ba79 # v3.35
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 permissions: read-all
 
 jobs:
-   dependency-review:
+  dependency-review:
     name: Dependency review
 
     runs-on: ubuntu-latest
@@ -16,10 +16,10 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
-              api.deps.dev:443
-              api.github.com:443
-              api.securityscorecards.dev:443
-              github.com:443
+            api.deps.dev:443
+            api.github.com:443
+            api.securityscorecards.dev:443
+            github.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,7 +8,7 @@ on:
       - main
       - major-release
     tags:
-      - 'v*'
+      - "v*"
 permissions: read-all
 
 env:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,6 +28,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40
         with:

--- a/.github/workflows/pr-label-checks.yml
+++ b/.github/workflows/pr-label-checks.yml
@@ -15,6 +15,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   label-from-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-label-checks.yml
+++ b/.github/workflows/pr-label-checks.yml
@@ -3,15 +3,13 @@ name: PR label checking
 on:
   pull_request_target:
     types:
-      [
-        opened,
-        edited,
-        reopened,
-        ready_for_review,
-        labeled,
-        unlabeled,
-        synchronize,
-      ]
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
+      - synchronize
 
 permissions: read-all
 

--- a/.github/workflows/pr-label-checks.yml
+++ b/.github/workflows/pr-label-checks.yml
@@ -2,7 +2,16 @@ name: PR label checking
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, ready_for_review, labeled, unlabeled, synchronize]
+    types:
+      [
+        opened,
+        edited,
+        reopened,
+        ready_for_review,
+        labeled,
+        unlabeled,
+        synchronize,
+      ]
 
 permissions: read-all
 

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -48,6 +48,10 @@ jobs:
     permissions:
       contents: write
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40
         with:

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -49,7 +49,12 @@ jobs:
       contents: write
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      group: >-
+        ${{ github.workflow }}
+        -${{ github.event.pull_request.number || github.ref }}
+        -${{ matrix.os }}
+        -${{ matrix.python-version }}
+        -${{ matrix.resolution }}
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -33,10 +33,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.10'
-          - '3.11'
-          - '3.12'
-          - '3.13'
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
         os:
           - ubuntu-latest
           - windows-latest
@@ -157,9 +157,9 @@ jobs:
       fail-fast: false
       matrix:
         extra: ${{ fromJson(needs.pytest-extras-config.outputs.extras) }}
-        python-version: ['3.13']
-        os: ['ubuntu-latest']
-        resolution: ['highest']
+        python-version: ["3.13"]
+        os: ["ubuntu-latest"]
+        resolution: ["highest"]
 
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+
     env:
       CACHE_GLOBS: |
         **/pyproject.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.10'
-          - '3.11'
-          - '3.12'
-          - '3.13'
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
         os:
           - ubuntu-latest
           - windows-latest
@@ -97,8 +97,8 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
-            python-version: ${{ matrix.python-version }}
-            cache: pip
+          python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: install parsons from file
         shell: bash

--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -11,9 +11,9 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   pull_request:
-    branches: [ 'main', 'major-release' ]
+    branches: ["main", "major-release"]
   schedule:
-    - cron: '45 16 * * 2'
+    - cron: "45 16 * * 2"
 
 permissions: read-all
 


### PR DESCRIPTION
## What is this change?

- Limit concurrency of pytest, build, and docs-build workflow jobs and entire PR label checker workflow.

## Considerations for discussion

- We have been having random intermittent test failures which seem to be most common when we have a lot of concurrently-running runners.
- There are also a lot of runs occurring which may not be necessary (we generally care about the state of the most recent commit to a branch or pr). This change would cancel any earlier iterations of a job on a workflow/branch. Do we think there is utility in having the earlier commits tested individually as well, even if later commits are pushed in quick succession?
- Downside: old commits get a red X if there were skipped jobs, but no failures

## How to test the changes (if needed)

- Check that CI jobs run as usual

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
