### PR TITLE
Only remove pr labels if checkbox is explicitly unchecked

### DIFF
--- a/.github/workflows/pr-label-checks.yml
+++ b/.github/workflows/pr-label-checks.yml
@@ -62,6 +62,7 @@ jobs:
             for (const { text, label } of mapping) {
               await core.group(`Processing label: ${label}`, async () => {
                 const isChecked = new RegExp(`- \\[x\\] ${text}`, 'i').test(body);
+                const isUnchecked = new RegExp(`- \\[ \\] ${text}`, 'i').test(body);
 
                 if (isChecked) {
                   console.log(`Adding label: ${label}`);
@@ -71,7 +72,7 @@ jobs:
                     issue_number: context.issue.number,
                     labels: [label]
                   });
-                } else {
+                } else if (isUnchecked) {
                   console.log(`Removing label: ${label} (if present)`);
                   try {
                     await github.rest.issues.removeLabel({
@@ -84,6 +85,8 @@ jobs:
                   } catch (e) {
                     if (e.status !== 404) throw e;
                   }
+                } else {
+                  console.log(`Checkbox for "${text}" not found in PR description. Skipping.`);
                 }
               });
             }


### PR DESCRIPTION
## What is this change?

- Do not remove labels if checkbox is not present

## Considerations for discussion

- As seen in #1283, the existing workflow was removing labels that were manually added

## How to test the changes (if needed)

- It has to be merged, as the label check workflow runs based on the workflow on main

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
