### PR TITLE
Update ruff order in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,11 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.15.14
     hooks:
-      - id: ruff-format
-        args: ['--diff']
       - id: ruff-check
         args: ['--fix']
+      - id: ruff-format
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.9.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,10 @@ docs = [
     "Sphinx~=8.2.3;python_version>='3.11'",
 ]
 lint = [
-    "ruff==0.15.10",
+    "ruff==0.15.14",
 ]
 pre-commit = [
-    "pre-commit>=4.5.1,<4.7.0",
+    "pre-commit~=4.6.0",
 ]
 security = [
     "bandit[sarif]==1.9.4",


### PR DESCRIPTION
## What is this change?

- Run `ruff check` before `ruff format`
- Allow pre-commit to apply formatting fixes, not just display them
- Update ruff

## Considerations for discussion

- `ruff check` sometimes has output that doesn't pass `ruff format`, which leads to a false-positive passing pre-commit

## How to test the changes (if needed)

- Ensure pre-commit and ruff workflows pass

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
