### PR TITLE
Added includes to targetsmart.rst so api and automation workflows docs are more findable

### DIFF
--- a/docs/targetsmart.rst
+++ b/docs/targetsmart.rst
@@ -1,28 +1,16 @@
 TargetSmart
 ===========
 
+********
 Overview
 ********
 
 `TargetSmart <https://targetsmart.com/>`_ provides access to voter and consumer data for the progressive community.
 
-TargetSmart Developer API
--------------------------
+Parsons provides two integrations with TargetSmart:
 
-Parsons provides methods to consume the data services provided by the
-TargetSmart Developer API. These services include both low latency search and asynchronous list matching.
-
-* :doc:`Interacting with the TargetSmart Developer API <../targetsmart_api>`
-
-TargetSmart Automation Workflows
---------------------------------
-
-Parsons provides methods for interacting with TargetSmart Automation Workflows,
-a solution for executing custom file processing workflows programmatically. In
-some cases, TargetSmart will provide custom list matching solutions using
-Automation Workflows.
-
-* :doc:`Interacting with TargetSmart Automation Workflows <../targetsmart_automation_workflows>`
+* **TargetSmart Developer API** — Methods to consume the data services provided by the TargetSmart Developer API, including low latency search and asynchronous list matching.
+* **TargetSmart Automation Workflows** — Methods for interacting with TargetSmart Automation Workflows, a solution for executing custom file processing workflows programmatically. In some cases, TargetSmart will provide custom list matching solutions using Automation Workflows.
 
 .. note::
 
@@ -39,3 +27,18 @@ Automation Workflows.
 
     - `TargetSmart Developer API docs on docs.targetsmart.com  <https://docs.targetsmart.com/developers/tsapis/v2/index.html>`_
     - `TargetSmart Automation docs on docs.targetsmart.com <https://docs.targetsmart.com/my_tsmart/automation/overview.html>`_
+
+****************
+TargetSmart API
+****************
+
+.. include:: targetsmart_api.rst
+   :start-line: 7
+
+
+*******************************
+TargetSmart Automation Workflows
+*******************************
+
+.. include:: targetsmart_automation_workflows.rst
+   :start-line: 5

--- a/docs/targetsmart_api.rst
+++ b/docs/targetsmart_api.rst
@@ -21,7 +21,7 @@ Some TargetSmart API services have not yet been implemented in Parsons. For more
 
 
 Authentication
-..............
+~~~~~~~~~~~~~~
 
 Log in to `My TargetSmart <https://my.targetsmart.com/>`_ to access authentication credentials. You will need an API key to use the ``TargetSmartAPI`` class.
 
@@ -33,7 +33,7 @@ Log in to `My TargetSmart <https://my.targetsmart.com/>`_ to access authenticati
 
 
 Data Enrichment
-...............
+~~~~~~~~~~~~~~~
 
 Most TargetSmart API services append a set of enrichment data fields as part of
 a matching or search request. The presence of these fields are provisioned by
@@ -43,7 +43,7 @@ adjustments.
 
 
 Quickstart
-==========
+----------
 
 To instantiate ``TargetSmartAPI``, you can either store your API Key as the environmental variable
 ``TS_API_KEY``, or pass it in as an argument:
@@ -70,7 +70,7 @@ You can then call various methods that correspond to TargetSmart endpoints:
 
 
 API
-===
+---
 
 .. autoclass:: parsons.targetsmart.targetsmart_api.TargetSmartAPI
    :inherited-members:

--- a/docs/targetsmart_automation_workflows.rst
+++ b/docs/targetsmart_automation_workflows.rst
@@ -17,7 +17,7 @@ queuing.
     TargetSmart Automation workflows use SFTP. You will need to obtain SFTP credentials from TargetSmart to utilize the ``TargetSmartAutomation`` class.
 
 Quickstart
-==========
+----------
 
 To instantiate ``TargetSmartAutomation``, you can either store your SFTP username and password
 as the environmental variables ``TS_SFTP_USERNAME`` and ``TS_SFTP_PASSWORD``, or pass them in as
@@ -72,7 +72,7 @@ You can then call these methods:
     ts_auto.remove_files(job_name='my_job_name')
 
 API
-===
+---
 
 .. autoclass:: parsons.targetsmart.targetsmart_automation.TargetSmartAutomation
    :inherited-members:


### PR DESCRIPTION
Addresses #804

## What is this change?

Docs only change. Doesn't remove old pages (so any web links to them won't break) but instead includes them in the main landing page to make them more findable.

## How to test the changes (if needed)

Build & view the docs. I have done this locally.

## Breaking Changes

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [X] label: Non-breaking change — This PR does not introduce one or more breaking changes.

