### PR TITLE
Close file in ActionKit.bulk_upload_csv

### DIFF
--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -1395,12 +1395,13 @@ class ActionKit:
         """
         # self.conn defaults to JSON, but this has to be form/multi-part....
         upload_client = self._conn({"accepts": "application/json"})
-        # TODO: use context manager or close file when done
+
         if isinstance(csv_file, str):
-            csv_file = Path(csv_file).open(mode="rb")  # noqa SIM115 open-file-with-context-handler
+            csv_file = Path(csv_file)
+        csv_buffer = csv_file.open(mode="rb") if isinstance(csv_file, Path) else csv_file
 
         url = self._base_endpoint("upload")
-        files = {"upload": csv_file}
+        files = {"upload": csv_buffer}
         data = {
             "page": import_page,
             "autocreate_user_fields": int(autocreate_user_fields),
@@ -1414,6 +1415,9 @@ class ActionKit:
                 "id": progress_url.split("/")[-2] if progress_url else None,
                 "progress_url": progress_url,
             }
+
+        if isinstance(csv_file, Path):
+            csv_buffer.close()
 
         return rv
 

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -1,3 +1,4 @@
+import io
 import json
 import logging
 import math
@@ -1356,11 +1357,11 @@ class ActionKit:
 
     def bulk_upload_csv(
         self,
-        csv_file,
-        import_page,
-        autocreate_user_fields=False,
-        user_fields_only=False,
-    ):
+        csv_file: Path | str | io.BytesIO,
+        import_page: str,
+        autocreate_user_fields: bool = False,
+        user_fields_only: bool = False,
+    ) -> dict[str, bool | str | requests.Response]:
         """
         Bulk upload a csv file of new users or user updates.
         If you are uploading a table object, use bulk_upload_table instead.
@@ -1371,26 +1372,25 @@ class ActionKit:
         which is more likely to return the proper 400 with a useful error message
 
         Args:
-            import_page: str
+            import_page:
                 The page to post the action. The page short name.
-            csv_file: str or buffer
+            csv_file:
                 The csv (optionally zip'd) file path or a file buffer object
                 A user_id or email column is required.
                 ActionKit rejects files that are larger than 128M
-            autocreate_user_fields: bool
+            autocreate_user_fields:
                 When True columns starting with ``user_`` will be uploaded as user fields.
                 See the `autocreate_user_fields documentation
                 <https://roboticdogs.actionkit.com/docs/manual/api/rest/uploads.html#create-a-multipart-post-request>`__.
-            user_fields_only: bool
+            user_fields_only:
                 When uploading only an email/user_id column and ``user_`` user fields,
                 ActionKit has a fast processing path.
                 This doesn't work, if you upload a zipped csv though.
 
         Returns:
-            dict[str, bool | str | requests.Response]
-                success: whether upload was successful
-                progress_url: an API URL to get progress on upload processing
-                res: requests http response object
+            success: whether upload was successful
+            progress_url: an API URL to get progress on upload processing
+            res: requests http response object
 
         """
         # self.conn defaults to JSON, but this has to be form/multi-part....

--- a/test/test_action_kit.py
+++ b/test/test_action_kit.py
@@ -1,6 +1,7 @@
 import json
 import os
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from parsons import ActionKit, Table
@@ -792,7 +793,7 @@ class TestActionKit(unittest.TestCase):
             "autocreate_user_fields": 0,
             "user_fields_only": 0,
         }
-        upload_data = kwargs["files"]["upload"].read()
+        upload_data = Path(kwargs["files"]["upload"].name).read_bytes()
         assert (
             upload_data.decode() == "user_id,user_customfield1,action_foo\r\n5,yes,123 Main St\r\n"
         )
@@ -811,7 +812,8 @@ class TestActionKit(unittest.TestCase):
             "autocreate_user_fields": 0,
             "user_fields_only": 1,
         }
-        assert kwargs["files"]["upload"].read().decode() == "user_id,user_customfield1\r\n5,yes\r\n"
+        upload_data = Path(kwargs["files"]["upload"].name).read_bytes()
+        assert upload_data.decode() == "user_id,user_customfield1\r\n5,yes\r\n"
 
     def test_table_split(self):
         test1 = Table([("x", "y", "z"), ("a", "b", ""), ("1", "", "3"), ("4", "", "6")])


### PR DESCRIPTION
## What is this change?

- If file is provided as Path or str, close the file after we're done with it.
- Moved type hints from docstring to function signature.

## Considerations for discussion

- There was a TODO comment saying this was needed.
- Closing the file [is good practice](https://realpython.com/why-close-file-python/).
- Slight refactoring now also allows file to be passed in as Path, not just str.  

## How to test the changes (if needed)

- Our test suite will trigger this code.
- What is not tested: passing in a buffer, passing in a Path 

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)