### PR TITLE
Cleanup TODO Comments

### DIFF
--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -455,6 +455,7 @@ class ActionKit:
 
     def update_campaign(self) -> None:
         """Update a campaign (NOT IMPLEMENTED)"""
+        # TODO: Add functionality
         err_msg = "ActionKit.update_campaign() is not implemented"
         raise NotImplementedError(err_msg)
 

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -455,7 +455,9 @@ class ActionKit:
 
     def update_campaign(self) -> None:
         """Update a campaign (NOT IMPLEMENTED)"""
-        # TODO(jburchard): Add functionality
+        # TODO(jburchard): Add functionality.
+        # This method was referenced in the docstring for get_campaign_fields in the initial commit, but never existed.
+        # https://github.com/move-coop/parsons/blob/9784f8bc1deb751531acfba7c0ae496e69fb5b61/parsons/action_kit/action_kit.py#L161
         err_msg = "ActionKit.update_campaign() is not implemented"
         raise NotImplementedError(err_msg)
 

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -455,7 +455,7 @@ class ActionKit:
 
     def update_campaign(self) -> None:
         """Update a campaign (NOT IMPLEMENTED)"""
-        # TODO: Add functionality
+        # TODO(jburchard): Add functionality
         err_msg = "ActionKit.update_campaign() is not implemented"
         raise NotImplementedError(err_msg)
 
@@ -1396,7 +1396,7 @@ class ActionKit:
         """
         # self.conn defaults to JSON, but this has to be form/multi-part....
         upload_client = self._conn({"accepts": "application/json"})
-        # TODO: use context manager or close file when done
+        # TODO(bmos): use context manager or close file when done
         if isinstance(csv_file, str):
             csv_file = Path(csv_file).open(mode="rb")  # noqa SIM115 open-file-with-context-handler
 

--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -36,7 +36,7 @@ class RedshiftTableUtilities:
         sql = f"""select count(*) from pg_tables where schemaname='{table_name[0]}' and
                  tablename='{table_name[1]}';"""
 
-        # TODO maybe convert these queries to use self.query_with_connection
+        # TODO: maybe convert these queries to use self.query_with_connection
 
         with self.cursor(connection) as cursor:
             cursor.execute(sql)

--- a/parsons/databases/redshift/rs_table_utilities.py
+++ b/parsons/databases/redshift/rs_table_utilities.py
@@ -36,7 +36,7 @@ class RedshiftTableUtilities:
         sql = f"""select count(*) from pg_tables where schemaname='{table_name[0]}' and
                  tablename='{table_name[1]}';"""
 
-        # TODO: maybe convert these queries to use self.query_with_connection
+        # TODO(jburchard): maybe convert these queries to use self.query_with_connection
 
         with self.cursor(connection) as cursor:
             cursor.execute(sql)

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -1046,7 +1046,7 @@ class ToFrom:
 
         tbls = []
         for key in s3_keys:
-            # TODO handle urls that end with '/', i.e. urls that point to "folders"
+            # TODO: handle urls that end with '/', i.e. urls that point to "folders"
             _, _, bucket_, key_ = key.split("/", 3)
             file_ = s3.get_file(bucket_, key_)
             if files.compression_type_for_path(key_) == "zip":

--- a/parsons/etl/tofrom.py
+++ b/parsons/etl/tofrom.py
@@ -1046,7 +1046,7 @@ class ToFrom:
 
         tbls = []
         for key in s3_keys:
-            # TODO: handle urls that end with '/', i.e. urls that point to "folders"
+            # TODO(dannyboy15): handle urls that end with '/', i.e. urls that point to "folders"
             _, _, bucket_, key_ = key.split("/", 3)
             file_ = s3.get_file(bucket_, key_)
             if files.compression_type_for_path(key_) == "zip":
@@ -1078,7 +1078,7 @@ class ToFrom:
                 See :ref:`Table` for output options.
 
         """
-        # TODO: Should users be able to pass in kwargs here? For parameters?
+        # TODO(willyraedy): Should users be able to pass in kwargs here? For parameters? See PR #875
 
         from parsons import GoogleBigQuery as BigQuery
 

--- a/parsons/facebook_ads/facebook_ads.py
+++ b/parsons/facebook_ads/facebook_ads.py
@@ -41,7 +41,7 @@ class FacebookAds:
     # unambiguous.
     # IMPORTANT - Keep these maps in sync with the comments in the ``add_users_to_custom_audience``
     # method!
-    # TODO add support for parsing full names from one column
+    # TODO: add support for parsing full names from one column
     KeyMatchMap = {
         FBKeySchema.email: ["email", "email address", "voterbase_email"],
         FBKeySchema.fn: ["fn", "first", "first name", "vb_tsmart_first_name"],
@@ -113,7 +113,7 @@ class FacebookAds:
     @staticmethod
     def _preprocess_dob_column(table, column):
         # Parse the DOB column into 3 new columns, and remove the original column
-        # TODO Throw an error if the values are not 6 characters long?
+        # TODO: Throw an error if the values are not 6 characters long?
 
         table.add_column(FBKeySchema.doby, lambda row: row[column][:4] if row[column] else None)
         table.add_column(FBKeySchema.dobm, lambda row: row[column][4:6] if row[column] else None)

--- a/parsons/facebook_ads/facebook_ads.py
+++ b/parsons/facebook_ads/facebook_ads.py
@@ -41,7 +41,7 @@ class FacebookAds:
     # unambiguous.
     # IMPORTANT - Keep these maps in sync with the comments in the ``add_users_to_custom_audience``
     # method!
-    # TODO: add support for parsing full names from one column
+    # TODO(jburchard): add support for parsing full names from one column
     KeyMatchMap = {
         FBKeySchema.email: ["email", "email address", "voterbase_email"],
         FBKeySchema.fn: ["fn", "first", "first name", "vb_tsmart_first_name"],
@@ -113,7 +113,7 @@ class FacebookAds:
     @staticmethod
     def _preprocess_dob_column(table, column):
         # Parse the DOB column into 3 new columns, and remove the original column
-        # TODO: Throw an error if the values are not 6 characters long?
+        # TODO(jburchard): Throw an error if the values are not 6 characters long?
 
         table.add_column(FBKeySchema.doby, lambda row: row[column][:4] if row[column] else None)
         table.add_column(FBKeySchema.dobm, lambda row: row[column][4:6] if row[column] else None)

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -101,7 +101,7 @@ def map_column_headers_to_schema_field(schema_definition: list) -> list:
         List of instantiated `SchemaField` objects
 
     """
-    # TODO: - Better way to test for this
+    # TODO(willyraedy): - Better way to test for this
     if isinstance(schema_definition[0], bigquery.SchemaField):
         logger.debug("User supplied list of SchemaField objects")
         return schema_definition
@@ -676,7 +676,7 @@ class GoogleBigQuery(DatabaseConnector):
             template_table=template_table,
         )
 
-        # TODO: - See if this inheritance is happening in other places
+        # TODO(willyraedy): - See if this inheritance is happening in other places
         gcs = GoogleCloudStorage(app_creds=self.app_creds, project=self.project)
         old_bucket_name, old_blob_name = gcs.split_uri(gcs_uri=gcs_blob_uri)
 

--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -101,7 +101,7 @@ def map_column_headers_to_schema_field(schema_definition: list) -> list:
         List of instantiated `SchemaField` objects
 
     """
-    # TODO - Better way to test for this
+    # TODO: - Better way to test for this
     if isinstance(schema_definition[0], bigquery.SchemaField):
         logger.debug("User supplied list of SchemaField objects")
         return schema_definition
@@ -676,7 +676,7 @@ class GoogleBigQuery(DatabaseConnector):
             template_table=template_table,
         )
 
-        # TODO - See if this inheritance is happening in other places
+        # TODO: - See if this inheritance is happening in other places
         gcs = GoogleCloudStorage(app_creds=self.app_creds, project=self.project)
         old_bucket_name, old_blob_name = gcs.split_uri(gcs_uri=gcs_blob_uri)
 

--- a/parsons/google/google_cloud_storage.py
+++ b/parsons/google/google_cloud_storage.py
@@ -143,7 +143,7 @@ class GoogleCloudStorage:
                 A globally unique name for the bucket.
 
         """
-        # TODO: Allow user to set all of the bucket parameters
+        # TODO(jburchard): Allow user to set all of the bucket parameters
 
         self.client.create_bucket(bucket_name)
         logger.info(f"Created {bucket_name} bucket.")
@@ -577,7 +577,7 @@ class GoogleCloudStorage:
             Tuple of strings with bucket_name and blob_name
 
         """
-        # TODO: make this more robust with regex?
+        # TODO(willyraedy): make this more robust with regex?
         remove_protocol = gcs_uri.replace("gs://", "")
         uri_parts = remove_protocol.split("/")
         bucket_name = uri_parts[0]

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -285,7 +285,7 @@ class GoogleSheets:
         sheet = self._get_worksheet(spreadsheet_id, worksheet)
 
         # Grab the existing data, so we can figure out where to start adding new data as a batch.
-        # TODO: Figure out a way to do a batch append without having to read the whole sheet first.
+        # TODO(jburchard): Figure out a way to do a batch append without having to read the whole sheet first.
         # Maybe use gspread's low-level batch_update().
         existing_table = self.get_worksheet(spreadsheet_id, worksheet)
 

--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -285,7 +285,7 @@ class GoogleSheets:
         sheet = self._get_worksheet(spreadsheet_id, worksheet)
 
         # Grab the existing data, so we can figure out where to start adding new data as a batch.
-        # TODO Figure out a way to do a batch append without having to read the whole sheet first.
+        # TODO: Figure out a way to do a batch append without having to read the whole sheet first.
         # Maybe use gspread's low-level batch_update().
         existing_table = self.get_worksheet(spreadsheet_id, worksheet)
 

--- a/parsons/newmode/newmode.py
+++ b/parsons/newmode/newmode.py
@@ -440,7 +440,7 @@ class NewmodeV1:
 
 
 class NewmodeV2:
-    # TODO: Add param definition and requirements once official Newmode docs are published
+    # TODO(sharinetmc): Add param definition and requirements once official Newmode docs are published
     def __init__(
         self,
         client_id: str | None = None,

--- a/parsons/pdi/contacts.py
+++ b/parsons/pdi/contacts.py
@@ -117,7 +117,7 @@ class Contacts:
             Table
 
         """
-        # todo not working quite right
+        # TODO: not working quite right
         return self._request(f"{self.url_contacts}/{id}")
 
     def update_contact(

--- a/parsons/pdi/contacts.py
+++ b/parsons/pdi/contacts.py
@@ -117,7 +117,7 @@ class Contacts:
             Table
 
         """
-        # TODO: not working quite right
+        # TODO(salice): not working quite right
         return self._request(f"{self.url_contacts}/{id}")
 
     def update_contact(

--- a/parsons/utilities/api_connector.py
+++ b/parsons/utilities/api_connector.py
@@ -459,7 +459,7 @@ class APIConnector:
         while others might return only a single record.
 
         """
-        # TODO: Some response jsons are enclosed in a list.
+        # TODO(jburchard): Some response jsons are enclosed in a list.
         # Need to deal with unpacking and/or not assuming that it is going to be a dict.
 
         # In some instances responses are just lists.

--- a/parsons/utilities/files.py
+++ b/parsons/utilities/files.py
@@ -81,7 +81,7 @@ def create_temp_file_for_path(path):
     """
     # Add the appropriate compression suffix to the file, so other libraries that check the
     # file's extension will know that it is compressed.
-    # TODO: Make this more robust, maybe even using the entire remote file name as the suffix.
+    # TODO(jburchard): Make this more robust, maybe even using the entire remote file name as the suffix.
     suffix = ".gz" if is_gzip_path(path) else None
     return create_temp_file(suffix=suffix)
 

--- a/parsons/utilities/files.py
+++ b/parsons/utilities/files.py
@@ -81,7 +81,7 @@ def create_temp_file_for_path(path):
     """
     # Add the appropriate compression suffix to the file, so other libraries that check the
     # file's extension will know that it is compressed.
-    # TODO Make this more robust, maybe even using the entire remote file name as the suffix.
+    # TODO: Make this more robust, maybe even using the entire remote file name as the suffix.
     suffix = ".gz" if is_gzip_path(path) else None
     return create_temp_file(suffix=suffix)
 

--- a/parsons/zoom/zoom.py
+++ b/parsons/zoom/zoom.py
@@ -63,7 +63,7 @@ class ZoomV1:
         **kwargs,
     ) -> Table:
         """
-        TODO: Consider increasing default page size.
+        Handle zoom GET requests.
 
         Args:
             endpoint: str
@@ -78,6 +78,7 @@ class ZoomV1:
             Parsons Table of API responses
 
         """
+        # TODO: Consider increasing default page size.
         logger.warning("This version of the Zoom connector uses a deprecated pagination method.")
         logger.info("Consider switching to V2!")
         logger.info(

--- a/parsons/zoom/zoom.py
+++ b/parsons/zoom/zoom.py
@@ -78,7 +78,7 @@ class ZoomV1:
             Parsons Table of API responses
 
         """
-        # TODO: Consider increasing default page size.
+        # TODO(jburchard): Consider increasing default page size.
         logger.warning("This version of the Zoom connector uses a deprecated pagination method.")
         logger.info("Consider switching to V2!")
         logger.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,6 +275,7 @@ select = [
     "UP", # pyupgrade (UP)
     "I", # isort (I)
     "TID", # flake8-tidy-imports (TID)
+    "TD", # flake8-todos (TD)
     "ICN", # flake8-import-conventions (ICN)
     "Q", # flake8-quotes (Q)
     "TC", # flake8-type-checking (TC)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,7 @@ select = [
 ]
 ignore = [
     "E501", # line-too-long
-    # pathlib
+    # flake8-use-pathlib
     "PTH116", # os-stat
     "PTH118", # os-path-join
     "PTH122", # os-path-splitext
@@ -304,6 +304,9 @@ ignore = [
     "D406", # missing-new-line-after-section-name
     "D407", # missing-dashed-underline-after-section
     "D408", # missing-section-underline-after-name
+    # flake8-todos
+    "TD002", # missing-todo-author
+    "TD003", # missing-todo-link
 ]
 fixable = ["ALL"]
 unfixable = []

--- a/test/test_facebook/test_facebook_ads.py
+++ b/test/test_facebook/test_facebook_ads.py
@@ -52,7 +52,7 @@ class TestFacebookAdsIntegration(unittest.TestCase):
     def test_add_users_to_custom_audience(self):
         # Note we don't actually check the results of adding these users, eg. how many were
         # matched by FB. This test just ensures the method doesn't error.
-        # TODO See if we can do a more effective test.
+        # TODO: See if we can do a more effective test.
         self.fb_ads.add_users_to_custom_audience(self.audience_id, users_table)
 
     def test_add_users_to_custom_audience_no_valid_columns(self):

--- a/test/test_gmail/test_gmail.py
+++ b/test/test_gmail/test_gmail.py
@@ -522,4 +522,4 @@ class TestGmail(unittest.TestCase):
                 with pytest.raises(EmailSyntaxError):
                     self.gmail._validate_email_string(e["email"])
 
-    # TODO test sending emails
+    # TODO: test sending emails

--- a/test/test_pdi/test_events.py
+++ b/test/test_pdi/test_events.py
@@ -9,8 +9,7 @@ END_DATE = "2022-12-31"
 EXPAND = True
 LOWER_LIMIT = 1
 
-# TODO: Invoke this, it should fail as 2000 is the max limit for
-# all of the relevant events functions
+# TODO: Invoke this, it should fail as 2000 is the max limit for all of the relevant events functions
 UPPER_LIMIT = 2001
 
 

--- a/test/test_s3/test_s3.py
+++ b/test/test_s3/test_s3.py
@@ -148,7 +148,7 @@ class TestS3(unittest.TestCase):
 
     def test_transfer_bucket(self):
         # Create a destination bucket
-        # TODO maybe pull this from an env var as well
+        # TODO: maybe pull this from an env var as well
         destination_bucket = f"{self.test_bucket}-test"
         self.s3.create_bucket(destination_bucket)
 

--- a/useful_resources/sample_code/apply_activist_code.py
+++ b/useful_resources/sample_code/apply_activist_code.py
@@ -66,6 +66,6 @@ for state, key in myv_keys.items():
     if len(state_set) > 0:
         logger.info("Applying %s Activist Codes in %s...", str(len(state_set)), state)
         for _vanid in state_set:
-            # TODO: row undefined, select row form record?
+            # TODO(dannyboy15): row undefined, select row form record?
             row = None
             key.toggle_activist_code(row["vb_smartvan_id"], row["activist_code_id"], "apply")


### PR DESCRIPTION
## What is this change?

- Reformat instances of `TODO` as `TODO:`.
- Move any docstring TODO comments to inline code comments.
- Enable ruff TODO rules (except rules requiring issue link and author name)
- Add the original authors of each TODO comment

## Considerations for discussion

- It's easier to find things to work on in the codebase when TODO comments are written consistently.
- Keeping TODO comment consistent is enabled by ruff [flake8-todos ruleset](https://docs.astral.sh/ruff/rules/#flake8-todos-td). 

## How to test the changes (if needed)

- Ensure ruff CI job passes

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
