### PR TITLE
ngpvan: don't re-append params when following pagination links

### DIFF
--- a/parsons/ngpvan/van_connector.py
+++ b/parsons/ngpvan/van_connector.py
@@ -81,13 +81,19 @@ class VANConnector:
         r = self.api.get_request(url=(self.uri + endpoint), **kwargs)
         data = self.api.data_parse(r)
 
-        # Paginate
+        # Paginate. `nextPageLink` is a fully-formed URL that already encodes the
+        # original query parameters, so we must not re-pass `params` on
+        # subsequent pages -- requests would append them a second time. VAN
+        # returns each page's link with the prior params still attached, so they
+        # accumulate page over page and the URL eventually 404s (observed on the
+        # events endpoint around $skip=700).
+        page_kwargs = {k: v for k, v in kwargs.items() if k != "params"}
         while isinstance(r, dict) and self.api.next_page_check_url(r):
             if endpoint == "savedLists" and not r["items"]:
                 break
             if endpoint == "printedLists" and not r["items"]:
                 break
-            r = self.api.get_request(url=r[self.pagination_key], **kwargs)
+            r = self.api.get_request(url=r[self.pagination_key], **page_kwargs)
             data.extend(self.api.data_parse(r))
         return data
 

--- a/test/test_ngpvan/test_events.py
+++ b/test/test_ngpvan/test_events.py
@@ -76,6 +76,41 @@ class TestNGPVAN(unittest.TestCase):
         assert validate_list(expected, self.van.get_events())
 
     @requests_mock.Mocker()
+    def test_get_events_pagination_does_not_duplicate_params(self, m):
+        # VAN's `nextPageLink` is a fully-formed URL that already carries the
+        # original query params. The pagination loop must not re-pass `params`,
+        # or requests appends them a second time and they accumulate page over
+        # page until VAN 404s. Regression test for that bug.
+        base = self.van.connection.uri + "events"
+        next_link = base + "?startingAfter=2020-01-01&%24top=50&%24skip=50"
+
+        page_one = {
+            "count": 2,
+            "items": [{"eventId": 1}],
+            "nextPageLink": next_link,
+        }
+        page_two = {
+            "count": 2,
+            "items": [{"eventId": 2}],
+            "nextPageLink": None,
+        }
+
+        m.get(base, json=page_one)
+        m.get(next_link, json=page_two)
+
+        events = self.van.get_events(starting_after="2020-01-01")
+
+        # Both pages were collected.
+        assert events.num_rows == 2
+
+        # The second (paginated) request hit the nextPageLink with each query
+        # param appearing exactly once -- nothing re-appended.
+        paginated_request = m.request_history[-1]
+        assert "$skip" in paginated_request.qs  # we followed the link
+        for key, values in paginated_request.qs.items():
+            assert len(values) == 1, f"param {key!r} was duplicated: {values}"
+
+    @requests_mock.Mocker()
     def test_get_event(self, m):
         event_id = 1062
 


### PR DESCRIPTION
VANConnector.get_request re-passed the caller's **kwargs (including `params`) to each `nextPageLink`. But `nextPageLink` is already has all the params, so we were accumulating params, breaking pagination.

## What is this change?

- Fixes pagination in the VANConnector

## How to test the changes (if needed)

I added a unit test for this

## Breaking Changes

No breaking changes. Just a bugfix.

