### PR TITLE
Add Redshift distkey & sortkey helper methods

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1236,6 +1236,11 @@ class Redshift(
         return RedshiftTable(self, table_name)
 
     def get_search_path(self):
+        """Returns the schema search_path for the current user.
+
+        Returns:
+            Table|None: The user's "search_path".
+        """
         sql_searchpath = """SHOW search_path;"""
 
         with self.connection() as connection:
@@ -1245,7 +1250,7 @@ class Redshift(
         return tbl
 
     def get_distkey(self, schema: str, table: str) -> Table | None:
-        """Get the table's distkey information from redshift internals.
+        """Get a table's distkey information from redshift internals.
 
         For more information on the Redshift distkey, see
         [Data distribution for query optimization: Amazon Redshift Database Developer Guide](https://docs.aws.amazon.com/redshift/latest/dg/t_Distributing_data.html).
@@ -1253,7 +1258,6 @@ class Redshift(
         Args:
             schema (str): The schema containing the table.
             table (str): The name of the table to get distkey information for.
-
 
         Returns:
             Table|None: Distkey information for your table.
@@ -1292,7 +1296,7 @@ class Redshift(
         return tbl
 
     def get_sortkey(self, schema: str, table: str) -> Table | None:
-        """Get the table's sortkey information from svv_table_info.
+        """Get a table's sortkey information from svv_table_info.
 
         For more information, see:
         + [Sort keys: Amazon Redshift Database Developer Guide](https://docs.aws.amazon.com/redshift/latest/dg/t_Sorting_data.html)
@@ -1306,12 +1310,16 @@ class Redshift(
             Table: Table containing sortkey information.
 
         Columns returned:
+            schema: The schema name.
+            table: The table name.
             sortkey1: First column in the sort key, if a sort key is defined. Possible values include column, AUTO(SORTKEY), and AUTO(SORTKEY(column)).
             sortkey1_enc: Compression encoding of the first column in the sort key, if a sort key is defined.
             sortkey_num: Number of columns defined as sort keys.
         """
         sql_sortkey = """
             select
+                "schema",
+                "table",
                 sortkey1,
                 sortkey1_enc,
                 sortkey_num

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1247,7 +1247,29 @@ class Redshift(
             connection.set_session(autocommit=True)
             tbl = self.query_with_connection(sql_searchpath, connection)
 
-        return tbl
+        if tbl is None:
+            raise ValueError("Search path not found.")
+
+        search_path_str: str = tbl.first
+        search_paths = [item.strip() for item in search_path_str.split(",")]
+        return search_paths
+
+    def set_search_path(self, schema: list[str], permanent: bool = False):
+        # schema $user included in search path must be single-quoted when set
+        schema = [f"'{s}'" if s.startswith("$") else s for s in schema]
+
+        new_path_schema_str = ", ".join(schema)
+        permanent_statement = f"alter user {self.username} " if permanent else ""
+        statement = f"{permanent_statement} set search_path to {new_path_schema_str};"
+        with self.connection() as connection:
+            connection.set_session(autocommit=True)
+            self.query_with_connection(statement, connection)
+
+    def add_schema_to_search_path(self, schema: str, permanent: bool = False):
+        path_schema: list[str] = self.get_search_path()
+        if schema not in path_schema:
+            path_schema.append(schema)
+        self.set_search_path(path_schema, permanent=permanent)
 
     def get_distkey(
         self, schema: str, table: str, errors: Literal["ignore", "raise"] = "raise"
@@ -1268,8 +1290,12 @@ class Redshift(
                 and ``raise`` will throw a ValueError.
 
         Returns:
-            Table
+            Table or None
                 Distkey information for the table. If ``errors='ignore'`` and the table name does not exist, will return ``None``.
+
+        Raises:
+            ValueError
+                If ``errors='raise'`` and the table could not be found.
 
         Columns returned:
             schema_name:
@@ -1314,7 +1340,9 @@ class Redshift(
             tbl = None
 
         if errors == "raise" and tbl is None:
-            raise ValueError(f"The table {schema}.{table} was not found.")
+            raise ValueError(
+                "The table name was not found in pg_class. Did you spell the schema and table name correctly?"
+            )
 
         return tbl
 
@@ -1323,6 +1351,8 @@ class Redshift(
     ) -> Table | None:
         """
         Get a table's sortkey information from svv_table_info.
+
+        Sortkey information is only available if the schema is in the user's search_path and the table has at least one row.
 
         For more information, see:
         `Sort keys: Amazon Redshift Database Developer Guide <https://docs.aws.amazon.com/redshift/latest/dg/t_Sorting_data.html>`__
@@ -1339,8 +1369,12 @@ class Redshift(
                 and ``raise`` will throw a ValueError.
 
         Returns:
-            Table
+            Table or None
                 Table containing sortkey information. If ``errors='ignore'`` and the table name does not exist, will return ``None``.
+
+        Raises:
+            ValueError
+                If ``errors='raise'`` and the table could not be found.
 
         Columns returned:
 
@@ -1380,7 +1414,9 @@ class Redshift(
             tbl = None
 
         if errors == "raise" and tbl is None:
-            raise ValueError(f"The table {schema}.{table} was not found.")
+            raise ValueError(
+                "There was no such table in svv_table_info. The table must exist, be within the user's search_path, and have at least one row."
+            )
 
         return tbl
 

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1247,6 +1247,9 @@ class Redshift(
     def get_distkey(self, schema: str, table: str) -> Table | None:
         """Get the table's distkey information from redshift internals.
 
+        For more information on the Redshift distkey, see
+        [Data distribution for query optimization: Amazon Redshift Database Developer Guide](https://docs.aws.amazon.com/redshift/latest/dg/t_Distributing_data.html).
+
         Args:
             schema (str): The schema containing the table.
             table (str): The name of the table to get distkey information for.
@@ -1254,6 +1257,10 @@ class Redshift(
 
         Returns:
             Table|None: Distkey information for your table.
+
+        Columns returned:
+            diststyle: Distribution style or distribution key column, if key distribution is defined.
+            distkey_column: Distribution key column.
         """
         sql_distkey = """SELECT
             n.nspname AS schema_name,
@@ -1297,6 +1304,11 @@ class Redshift(
 
         Returns:
             Table: Table containing sortkey information.
+
+        Columns returned:
+            sortkey1: First column in the sort key, if a sort key is defined. Possible values include column, AUTO(SORTKEY), and AUTO(SORTKEY(column)).
+            sortkey1_enc: Compression encoding of the first column in the sort key, if a sort key is defined.
+            sortkey_num: Number of columns defined as sort keys.
         """
         sql_sortkey = """
             select

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1252,22 +1252,34 @@ class Redshift(
     def get_distkey(
         self, schema: str, table: str, errors: Literal["ignore", "raise"] = "raise"
     ) -> Table | None:
-        """Get a table's distkey information from redshift internals.
+        """
+        Get a table's distkey information from Redshift internals.
 
-        For more information on the Redshift distkey, see
-        [Data distribution for query optimization: Amazon Redshift Database Developer Guide](https://docs.aws.amazon.com/redshift/latest/dg/t_Distributing_data.html).
+        For more information, see:
+        `Data distribution for query optimization: Amazon Redshift Database Developer Guide <https://docs.aws.amazon.com/redshift/latest/dg/t_Distributing_data.html>`__
 
         Args:
-            schema (str): The schema containing the table.
-            table (str): The name of the table to get distkey information for.
-            errors (str, 'ignore' or 'raise'): If the table does not exist, `'ignore'` will make the method return None, and `'raise'` will throw a ValueError.
+            schema: str
+                The schema containing the table.
+            table: str
+                The table to retrieve the distkey for.
+            errors: str
+                If the table does not exist, ``ignore`` will make the method return ``None``,
+                and ``raise`` will throw a ValueError.
 
         Returns:
-            Table|None: Distkey information for your table. If `errors='ignore'` and the table name does not exist, will return None.
+            Table
+                Distkey information for the table. If ``errors='ignore'`` and the table name does not exist, will return ``None``.
 
         Columns returned:
-            diststyle: Distribution style or distribution key column, if key distribution is defined.
-            distkey_column: Distribution key column.
+            schema_name:
+                The schema name.
+            table_name:
+                The table name.
+            diststyle:
+                Distribution style or distribution key column, if key distribution is defined.
+            distkey_column:
+                Distribution key column.
         """
         sql_distkey = """SELECT
             n.nspname AS schema_name,
@@ -1304,26 +1316,40 @@ class Redshift(
     def get_sortkey(
         self, schema: str, table: str, errors: Literal["ignore", "raise"] = "raise"
     ) -> Table | None:
-        """Get a table's sortkey information from svv_table_info.
+        """
+        Get a table's sortkey information from svv_table_info.
 
         For more information, see:
-        + [Sort keys: Amazon Redshift Database Developer Guide](https://docs.aws.amazon.com/redshift/latest/dg/t_Sorting_data.html)
-        + [Choose the best sort key: Amazon Redshift Database Developer Guide](https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-sort-key.html)
+        `Sort keys: Amazon Redshift Database Developer Guide <https://docs.aws.amazon.com/redshift/latest/dg/t_Sorting_data.html>`__
+
+        `Choose the best sort key: Amazon Redshift Database Developer Guide <https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-sort-key.html>`__
 
         Args:
-            schema (str): The schema containing the table.
-            table (str): The table to retrieve the sortkey for.
-            errors (str, 'ignore' or 'raise'): If the table does not exist, `'ignore'` will make the method return None, and `'raise'` will throw a ValueError.
+            schema: str
+                The schema containing the table.
+            table: str
+                The table to retrieve the sortkey for.
+            errors: str
+                If the table does not exist, ``ignore`` will make the method return ``None``,
+                and ``raise`` will throw a ValueError.
 
         Returns:
-            Table: Table containing sortkey information. If `errors='ignore'` and the table name does not exist, will return None.
+            Table
+                Table containing sortkey information. If ``errors='ignore'`` and the table name does not exist, will return ``None``.
 
         Columns returned:
-            schema: The schema name.
-            table: The table name.
-            sortkey1: First column in the sort key, if a sort key is defined. Possible values include column, AUTO(SORTKEY), and AUTO(SORTKEY(column)).
-            sortkey1_enc: Compression encoding of the first column in the sort key, if a sort key is defined.
-            sortkey_num: Number of columns defined as sort keys.
+
+            schema:
+                The schema name.
+            table:
+                The table name.
+            sortkey1:
+                First column in the sort key, if a sort key is defined. Possible values include column, AUTO(SORTKEY), and AUTO(SORTKEY(column)).
+            sortkey1_enc:
+                Compression encoding of the first column in the sort key, if a sort key is defined.
+            sortkey_num:
+                Number of columns defined as sort keys.
+
         """
         sql_sortkey = """
             select

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1239,7 +1239,7 @@ class Redshift(
         """Returns the schema search_path for the current user.
 
         Returns:
-            Table|None: The user's "search_path".
+            list[str]: The list of schema in the user's "search_path".
         """
         sql_searchpath = """SHOW search_path;"""
 
@@ -1250,11 +1250,18 @@ class Redshift(
         if tbl is None:
             raise ValueError("Search path not found.")
 
-        search_path_str: str = tbl.first
+        search_path_str: str = tbl.first  # type: ignore # this should always be a string
         search_paths = [item.strip() for item in search_path_str.split(",")]
         return search_paths
 
-    def set_search_path(self, schema: list[str], permanent: bool = False):
+    def set_search_path(self, schema: list[str], permanent: bool = True):
+        """Set the schema in the user's search_path.
+
+        Must double or single quote (within the string) any schema names containing non-identifier characters. If the schema name starts with a ``$`` (e.g. ``$user``), it will be automatically single quoted.
+        Args:
+            schema (list[str]): List of schema to set.
+            permanent (bool, optional): True if the change should persist beyond the given session. Defaults to True.
+        """
         # schema $user included in search path must be single-quoted when set
         schema = [f"'{s}'" if s.startswith("$") else s for s in schema]
 
@@ -1265,7 +1272,13 @@ class Redshift(
             connection.set_session(autocommit=True)
             self.query_with_connection(statement, connection)
 
-    def add_schema_to_search_path(self, schema: str, permanent: bool = False):
+    def add_schema_to_search_path(self, schema: str, permanent: bool = True):
+        """Add a single schema to the user's search_path.
+
+        Args:
+            schema (str): The name of the schema to add.
+            permanent (bool, optional): True if the change should persist beyond the given session. Defaults to True.
+        """
         path_schema: list[str] = self.get_search_path()
         if schema not in path_schema:
             path_schema.append(schema)

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1235,16 +1235,12 @@ class Redshift(
 
         return RedshiftTable(self, table_name)
 
-    def get_distkey(self, schema, table):
-        sql_distkey = """
-            select
-
-            ;
-        """
+    def get_search_path(self):
+        sql_searchpath = """SHOW search_path;"""
 
         with self.connection() as connection:
             connection.set_session(autocommit=True)
-            tbl = self.query_with_connection(sql_distkey, connection)
+            tbl = self.query_with_connection(sql_searchpath, connection)
 
         return tbl
 

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1235,6 +1235,51 @@ class Redshift(
 
         return RedshiftTable(self, table_name)
 
+    def get_distkey(self, schema, table):
+        sql_distkey = """
+            select
+
+            ;
+        """
+
+        with self.connection() as connection:
+            connection.set_session(autocommit=True)
+            tbl = self.query_with_connection(sql_distkey, connection)
+
+        return tbl
+
+    def get_sortkey(self, schema: str, table: str) -> Table | None:
+        """Get the table's sortkey information from svv_table_info.
+
+        For more information, see:
+        + [Sort keys: Amazon Redshift Database Developer Guide](https://docs.aws.amazon.com/redshift/latest/dg/t_Sorting_data.html)
+        + [Choose the best sort key: Amazon Redshift Database Developer Guide](https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-sort-key.html)
+
+        Args:
+            schema (str): The schema containing the table.
+            table (str): The table to retrieve the sortkey for.
+
+        Returns:
+            Table: Table containing sortkey information.
+        """
+        sql_sortkey = """
+            select
+                sortkey1,
+                sortkey1_enc,
+                sortkey_num
+            from
+                svv_table_info
+            where
+                "schema" = %s and "table" = %s
+            ;
+        """
+
+        with self.connection() as connection:
+            connection.set_session(autocommit=True)
+            tbl = self.query_with_connection(sql_sortkey, connection, parameters=[schema, table])
+
+        return tbl
+
 
 class RedshiftTable(BaseTable):
     # Redshift table object.

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1244,6 +1244,46 @@ class Redshift(
 
         return tbl
 
+    def get_distkey(self, schema: str, table: str) -> Table | None:
+        """Get the table's distkey information from redshift internals.
+
+        Args:
+            schema (str): The schema containing the table.
+            table (str): The name of the table to get distkey information for.
+
+
+        Returns:
+            Table|None: Distkey information for your table.
+        """
+        sql_distkey = """SELECT
+            n.nspname AS schema_name,
+            c.relname AS table_name,
+            CASE c.reldiststyle
+                WHEN 0 THEN 'EVEN'
+                WHEN 1 THEN 'KEY'
+                WHEN 8 THEN 'ALL'
+                WHEN 9 THEN 'AUTO(EVEN)'
+                WHEN 10 THEN 'AUTO(ALL)'
+                WHEN 11 THEN 'AUTO(KEY)'
+                ELSE 'UNKNOWN'
+            END AS diststyle,
+            a.attname AS distkey_column
+        FROM pg_class c
+        JOIN pg_namespace n
+            ON n.oid = c.relnamespace
+        LEFT JOIN pg_attribute a
+            ON a.attrelid = c.oid
+        AND a.attisdistkey = true
+        WHERE n.nspname = %s
+        AND
+        c.relname = %s;"""
+
+        with self.connection() as connection:
+            connection.set_session(autocommit=True)
+            tbl = self.query_with_connection(sql_distkey, connection, parameters=[schema, table])
+
+        return tbl
+
     def get_sortkey(self, schema: str, table: str) -> Table | None:
         """Get the table's sortkey information from svv_table_info.
 

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1308,6 +1308,11 @@ class Redshift(
             connection.set_session(autocommit=True)
             tbl = self.query_with_connection(sql_distkey, connection, parameters=[schema, table])
 
+        # requested table wasn't found
+        if tbl is not None and tbl.num_rows == 0:
+            # if there's an empty table just return None unless errors=='raise'
+            tbl = None
+
         if errors == "raise" and tbl is None:
             raise ValueError(f"The table {schema}.{table} was not found.")
 
@@ -1368,6 +1373,11 @@ class Redshift(
         with self.connection() as connection:
             connection.set_session(autocommit=True)
             tbl = self.query_with_connection(sql_sortkey, connection, parameters=[schema, table])
+
+        # requested table wasn't found
+        if tbl is not None and tbl.num_rows == 0:
+            # if there's an empty table just return None unless errors=='raise'
+            tbl = None
 
         if errors == "raise" and tbl is None:
             raise ValueError(f"The table {schema}.{table} was not found.")

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -1249,7 +1249,9 @@ class Redshift(
 
         return tbl
 
-    def get_distkey(self, schema: str, table: str) -> Table | None:
+    def get_distkey(
+        self, schema: str, table: str, errors: Literal["ignore", "raise"] = "raise"
+    ) -> Table | None:
         """Get a table's distkey information from redshift internals.
 
         For more information on the Redshift distkey, see
@@ -1258,9 +1260,10 @@ class Redshift(
         Args:
             schema (str): The schema containing the table.
             table (str): The name of the table to get distkey information for.
+            errors (str, 'ignore' or 'raise'): If the table does not exist, `'ignore'` will make the method return None, and `'raise'` will throw a ValueError.
 
         Returns:
-            Table|None: Distkey information for your table.
+            Table|None: Distkey information for your table. If `errors='ignore'` and the table name does not exist, will return None.
 
         Columns returned:
             diststyle: Distribution style or distribution key column, if key distribution is defined.
@@ -1293,9 +1296,14 @@ class Redshift(
             connection.set_session(autocommit=True)
             tbl = self.query_with_connection(sql_distkey, connection, parameters=[schema, table])
 
+        if errors == "raise" and tbl is None:
+            raise ValueError(f"The table {schema}.{table} was not found.")
+
         return tbl
 
-    def get_sortkey(self, schema: str, table: str) -> Table | None:
+    def get_sortkey(
+        self, schema: str, table: str, errors: Literal["ignore", "raise"] = "raise"
+    ) -> Table | None:
         """Get a table's sortkey information from svv_table_info.
 
         For more information, see:
@@ -1305,9 +1313,10 @@ class Redshift(
         Args:
             schema (str): The schema containing the table.
             table (str): The table to retrieve the sortkey for.
+            errors (str, 'ignore' or 'raise'): If the table does not exist, `'ignore'` will make the method return None, and `'raise'` will throw a ValueError.
 
         Returns:
-            Table: Table containing sortkey information.
+            Table: Table containing sortkey information. If `errors='ignore'` and the table name does not exist, will return None.
 
         Columns returned:
             schema: The schema name.
@@ -1333,6 +1342,9 @@ class Redshift(
         with self.connection() as connection:
             connection.set_session(autocommit=True)
             tbl = self.query_with_connection(sql_sortkey, connection, parameters=[schema, table])
+
+        if errors == "raise" and tbl is None:
+            raise ValueError(f"The table {schema}.{table} was not found.")
 
         return tbl
 

--- a/test/test_redshift/test_redshift.py
+++ b/test/test_redshift/test_redshift.py
@@ -11,6 +11,13 @@ from test.conftest import assert_matching_tables, validate_list
 # The name of the schema and will be temporarily created for the tests
 TEMP_SCHEMA = "parsons_test2"
 
+# try not to create these in the redshift test environment :)
+# they are used to determine correct error handling in distkey/sortkey
+SCHEMA_THAT_DNE = "schema_that_does_not_exist"
+TABLE_THAT_DNE = "table_that_does_not_exist"
+
+DISTKEY_SORTKEY_TABLE = "test_distkey_sortkey"
+
 # These tests do not interact with the Redshift Database directly, and don't need real credentials
 
 
@@ -403,9 +410,24 @@ class TestRedshiftDB(unittest.TestCase):
             );
             """
 
+        # MUST create at least one row or sortkey doesn't appear.
+        sortdist_query = f"""
+            CREATE TABLE {self.temp_schema}.{DISTKEY_SORTKEY_TABLE}
+            (
+                id INT,
+                name VARCHAR(5)
+            )
+            DISTKEY(id)
+            SORTKEY(name);
+            insert into {self.temp_schema}.{DISTKEY_SORTKEY_TABLE} values (1, 'test');
+            """
+
         self.rs.query(setup_sql)
 
         self.rs.query(other_sql)
+        self.rs.query(sortdist_query)
+        # thought this was needed per AWS docs on svv_table_info on distkey/sortkey, no longer sure.
+        # self.rs.add_schema_to_search_path(self.temp_schema, permanent=True)
 
         self.s3 = S3()
 
@@ -1066,3 +1088,47 @@ class TestRedshiftDB(unittest.TestCase):
         # Base table 'Name' column has a width of 5. This should expand it to 6.
         self.rs.alter_varchar_column_widths(append_tbl, f"{self.temp_schema}.test")
         assert self.rs.get_columns(self.temp_schema, "test")["name"]["max_length"] == 6
+
+    def test_get_search_path(self):
+        # returns a list of strings
+        result = self.rs.get_search_path()
+        assert isinstance(result, list)
+
+    def test_get_add_set_search_path(self):
+        # add a schema to the end of the search path, then remove it
+        # assumes self.temp_schema isn't already part of search path
+        search_path = self.rs.get_search_path()
+
+        self.rs.add_schema_to_search_path(self.temp_schema, permanent=True)
+        search_path2 = self.rs.get_search_path()
+        assert search_path + [self.temp_schema] == search_path2
+
+        self.rs.set_search_path(search_path, permanent=True)
+        search_path3 = self.rs.get_search_path()
+        assert search_path == search_path3
+
+    def test_get_distkey(self):
+        assert self.rs.get_distkey(SCHEMA_THAT_DNE, TABLE_THAT_DNE, errors="ignore") is None
+
+        with pytest.raises(
+            ValueError,
+            match="The table name was not found in pg_class. Did you spell the schema and table name correctly?",
+        ):
+            self.rs.get_distkey(SCHEMA_THAT_DNE, TABLE_THAT_DNE, errors="raise")
+
+        real_distkey = self.rs.get_distkey(self.temp_schema, DISTKEY_SORTKEY_TABLE, errors="ignore")
+        assert isinstance(real_distkey, Table)
+        assert real_distkey["distkey_column"][0] == "id"
+
+    def test_get_sortkey(self):
+        assert self.rs.get_sortkey(SCHEMA_THAT_DNE, TABLE_THAT_DNE, errors="ignore") is None
+
+        with pytest.raises(
+            ValueError,
+            match="There was no such table in svv_table_info. The table must exist, be within the user's search_path, and have at least one row.",
+        ):
+            self.rs.get_sortkey(SCHEMA_THAT_DNE, TABLE_THAT_DNE, errors="raise")
+
+        real_sortkey = self.rs.get_sortkey(self.temp_schema, DISTKEY_SORTKEY_TABLE, errors="ignore")
+        assert isinstance(real_sortkey, Table)
+        assert real_sortkey["sortkey1"][0] == "name"


### PR DESCRIPTION
## What is this change?

Adds methods requested in #364 plus some other helper functions for search path management.

+ `get_search_path`
+ `set_search_path`
+ `add_schema_to_search_path`
+ `get_distkey`
+ `get_sortkey`

## Considerations for discussion

+ If the table could not be found in the internals, sortkey and distkey methods return `None` instead of a blank table. Setting `errors='raise'` will force it to raise a ValueError instead of return None. I'm not 100% sure "None instead of Table" was the right call but it seemed like it might confuse users to get a blank table. None (or some kind of error) is a little more expected.
+ I've gotten some mixed signals between the docs and the actual testing if having the schema in the `search_path` is actually required to the the distkey and sortkey. Kept those methods in just in case, because I used them while troubleshooting and they have other uses as well.

## How to test the changes (if needed)
1. set up redshift test environment
2. 
```bash
pytest test/test_redshift/test_redshift.py::TestRedshiftDB --live
```

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
