### PR TITLE
Add connection timeout to MySQL connector (#452)

### DIFF
--- a/parsons/databases/mysql/mysql.py
+++ b/parsons/databases/mysql/mysql.py
@@ -38,10 +38,12 @@ class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
         port: int
             If omitted or ``None``, uses ``MYSQL_PORT`` when set, otherwise 3306. If passed
             (including ``3306``), the argument takes precedence over ``MYSQL_PORT``.
+        timeout: int
+            Seconds to timeout if connection not established. Defaults to 10.
 
     """
 
-    def __init__(self, host=None, username=None, password=None, db=None, port=None):
+    def __init__(self, host=None, username=None, password=None, db=None, port=None, timeout=10):
         super().__init__()
 
         self.username = check_env.check("MYSQL_USERNAME", username)
@@ -53,6 +55,8 @@ class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
         else:
             env_port = check_env.check("MYSQL_PORT", None, optional=True)
             self.port = int(env_port) if env_port is not None else 3306
+
+        self.timeout = timeout
 
     @contextmanager
     def connection(self):
@@ -76,6 +80,7 @@ class MySQL(DatabaseConnector, MySQLCreateTable, Alchemy):
             passwd=self.password,
             database=self.db,
             port=self.port,
+            connection_timeout=self.timeout,
         )
 
         try:

--- a/test/test_mysql/test_mysql.py
+++ b/test/test_mysql/test_mysql.py
@@ -53,6 +53,41 @@ class TestMySQLPortPrecedence(unittest.TestCase):
             assert mysql.port == 3306
 
 
+class TestMySQLConnectionTimeout(unittest.TestCase):
+    """
+    Connection timeout for MySQL:
+
+    - ``timeout`` defaults to 10 seconds, matching the Postgres and Redshift connectors.
+    - An explicit ``timeout=`` argument is respected.
+    - The resolved timeout is forwarded to ``mysql.connector.connect`` as
+      ``connection_timeout``.
+    """
+
+    def test_default_timeout(self):
+        mysql = MySQL(**_MYSQL_CONN_KWARGS)
+        assert mysql.timeout == 10
+
+    def test_explicit_timeout_kwarg(self):
+        mysql = MySQL(**_MYSQL_CONN_KWARGS, timeout=30)
+        assert mysql.timeout == 30
+
+    @mock.patch("parsons.databases.mysql.mysql.mysql.connect")
+    def test_default_timeout_forwarded_to_connect(self, mock_connect):
+        mysql = MySQL(**_MYSQL_CONN_KWARGS)
+        with mysql.connection():
+            pass
+        _, kwargs = mock_connect.call_args
+        assert kwargs["connection_timeout"] == 10
+
+    @mock.patch("parsons.databases.mysql.mysql.mysql.connect")
+    def test_explicit_timeout_forwarded_to_connect(self, mock_connect):
+        mysql = MySQL(**_MYSQL_CONN_KWARGS, timeout=42)
+        with mysql.connection():
+            pass
+        _, kwargs = mock_connect.call_args
+        assert kwargs["connection_timeout"] == 42
+
+
 # These tests interact directly with the MySQL database. To run, set env variable "LIVE_TEST=True"
 @pytest.mark.live
 class TestMySQLLive(unittest.TestCase):


### PR DESCRIPTION
Closes #452.

The MySQL connector had no way to set a connection timeout, unlike the Postgres and Redshift connectors, which both accept `timeout=10` and forward it to the driver. This adds a `timeout` argument to `MySQL` and forwards it to `mysql.connector.connect` as `connection_timeout`, matching that convention.

- Matches the existing 10s default of the Postgres and Redshift connectors (previously, no timeout was explicitly set, defaulting to OS TCP defaults). If users on very slow links require the previous behavior, they can pass an explicit/larger `timeout` value.
- Added `TestMySQLConnectionTimeout` covering the default, an explicit value, and that the resolved timeout is forwarded to the connect call (mocked, no live DB).
- `ruff check` / `ruff format` clean.

- [ ] label: Breaking change
- [x] label: Non-breaking change
