### PR TITLE
google: use more generic Credentials base class for google auth

### DIFF
--- a/parsons/google/google_cloud_storage.py
+++ b/parsons/google/google_cloud_storage.py
@@ -10,7 +10,7 @@ from typing import Literal
 import google
 import petl
 from google.cloud import storage, storage_transfer
-from google.oauth2.credentials import Credentials
+from google.auth.credentials import Credentials
 
 from parsons.google.utilities import (
     load_google_application_credentials,
@@ -25,7 +25,7 @@ class GoogleCloudStorage:
     """Google Cloud Storage connector utility
 
     This class requires application credentials in the form of a
-    json or google oauth2 Credentials object. It can be passed in the
+    json or google.auth.credentials.Credentials object. It can be passed in the
     following ways:
 
     * Set an environmental variable named ``GOOGLE_APPLICATION_CREDENTIALS`` with the
@@ -51,10 +51,10 @@ class GoogleCloudStorage:
         gcs = GoogleCloudStorage(app_creds=app_creds)
 
     Args:
-        app_creds: str, dict, or google.oauth2.credentials.Credentials object
+        app_creds: str, dict, or google.auth.credentials.Credentials object
             A credentials json string or a path to a json file. Not required
             if ``GOOGLE_APPLICATION_CREDENTIALS`` env variable set. Can also
-            pass a google oauth2 Credentials object directly.
+            pass a google.auth.credentials.Credentials object directly.
         project: str
             The project which the client is acting on behalf of. If not passed
             then will use the default inferred environment.

--- a/parsons/google/google_cloud_storage.py
+++ b/parsons/google/google_cloud_storage.py
@@ -9,8 +9,8 @@ from typing import Literal
 
 import google
 import petl
-from google.cloud import storage, storage_transfer
 from google.auth.credentials import Credentials
+from google.cloud import storage, storage_transfer
 
 from parsons.google.utilities import (
     load_google_application_credentials,

--- a/parsons/google/google_docs.py
+++ b/parsons/google/google_docs.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 
-from google.oauth2.credentials import Credentials
+from google.auth.credentials import Credentials
 from googleapiclient.discovery import build
 
 from parsons.google.utilities import (
@@ -20,7 +20,7 @@ class GoogleDocs:
         app_creds: dict | str | Credentials
             Can be a dictionary of Google Drive API credentials, parsed from JSON provided
             by the Google Developer Console, or a path string pointing to credentials
-            saved on disk, or a google.oauth2.credentials.Credentials object. Required
+            saved on disk, or a google.auth.credentials.Credentials object. Required
             if env variable ``GOOGLE_DRIVE_CREDENTIALS`` is not populated.
 
     """

--- a/parsons/google/google_drive.py
+++ b/parsons/google/google_drive.py
@@ -4,7 +4,7 @@ import uuid
 from pathlib import Path
 from typing import Literal
 
-from google.oauth2.credentials import Credentials
+from google.auth.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 
@@ -24,7 +24,7 @@ class GoogleDrive:
         app_creds: dict | str | Credentials
             Can be a dictionary of Google Drive API credentials, parsed from JSON provided
             by the Google Developer Console, or a path string pointing to credentials
-            saved on disk, or a google.oauth2.credentials.Credentials object. Required
+            saved on disk, or a google.auth.credentials.Credentials object. Required
             if env variable ``GOOGLE_DRIVE_CREDENTIALS`` is not populated.
 
     """


### PR DESCRIPTION
Broadens credential type checking from the OAuth2-specific subclass to the abstract base class, so environments like Cloud Run that provide compute engine credentials are accepted without JSON file fallback.

## What is this change?
Broadens credential type checking from the OAuth2-specific subclass to the abstract base class, so environments like Cloud Run that provide compute engine credentials are accepted without JSON file fallback.

## Considerations for discussion
Prior implementation only worked with the oauth2 Credentials type for google connector auth, but there are several types of google Credentials objects that show up in different prod environments, e.g. Google Cloud Run has a different class type. This change will work in any environment now.

## How to test the changes (if needed)
Use the connector auth both in dev and prod environments

## Breaking Changes
No breaking changes, this method will simply now work in more environments.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

