### PR TITLE
Clarify implicit string concatenation in collections

### DIFF
--- a/parsons/databases/redshift/rs_create_table.py
+++ b/parsons/databases/redshift/rs_create_table.py
@@ -208,8 +208,10 @@ class RedshiftCreateTable(DatabaseCreateStatement):
             (
                 distkey,
                 "DIST",
-                "https://aws.amazon.com/about-aws/whats-new/2019/08/amazon-redshift-"
-                "now-recommends-distribution-keys-for-improved-query-performance/",
+                (
+                    "https://aws.amazon.com/about-aws/whats-new/2019/08/amazon-redshift-"
+                    "now-recommends-distribution-keys-for-improved-query-performance/"
+                ),
             ),
             (
                 sortkey,

--- a/test/test_redshift/test_redshift.py
+++ b/test/test_redshift/test_redshift.py
@@ -139,17 +139,21 @@ class TestRedshift(unittest.TestCase):
             "a",
             "",
             "SELECT",
-            "asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasj"
-            "dfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjklasdfjklasjkl"
-            "dfakljsdfjalsdkfjklasjdfklasjdfklasdkljf",
+            (
+                "asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaksdfjklasj"
+                "dfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjklasdfjklasjkl"
+                "dfakljsdfjalsdkfjklasjdfklasjdfklasdkljf"
+            ),
         ]
         fixed_cols = [
             "a",
             "a_1",
             "col_2",
             "col_3",
-            "asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaks"
-            "dfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjkl",
+            (
+                "asdfjkasjdfklasjdfklajskdfljaskldfjaklsdfjlaks"
+                "dfjklasjdfklasjdkfljaskldfljkasjdkfasjlkdfjklasdfjklakjsfasjkdfljaslkdfjkl"
+            ),
         ]
         assert self.rs.column_name_validate(bad_cols) == fixed_cols
 


### PR DESCRIPTION
## What is this change?

- Wrap implicit string concatenations in parentheses when used in collections.

## Considerations for discussion

- In collection literals, implicit string concatenation can be mistaken as additional items. Wrapping them in parentheses better communicates function/intent.

## How to test the changes (if needed)

- CI tests are adequate. No functional changes.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
