### PR TITLE
Remove unused variable in census_geocoder

### DIFF
--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -118,7 +118,6 @@ class CensusGeocoder:
             raise ValueError(msg)
 
         chunked_tables = table.chunk(BATCH_SIZE)
-        batch_count = 1
         records_processed = 0
 
         geocoded_tbl = Table([[]])
@@ -126,7 +125,6 @@ class CensusGeocoder:
             geocoded_tbl.concat(Table(petl.fromdicts(self.cg.addressbatch(tbl))))
             records_processed += tbl.num_rows
             logger.info(f"{records_processed} of {table.num_rows} records processed.")
-            batch_count += 1
 
         return geocoded_tbl
 


### PR DESCRIPTION
## What is this change?

- Remove an unused variable in census_geocoder.py

## Considerations for discussion

- This variable doesn't do anything and has been in the codebase since its earliest commit.
- I recommend merging #1892 first so that this will not have 0% test coverage.

## How to test the changes (if needed)

- CI tests do not cover this, but you can see it's not used.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
