### PR TITLE
Run all Census Geocoder tests without network access (no more live test requirement!)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,7 @@ test = [
     "pytest~=9.0.3",
     "pytest-datadir~=1.8.0",
     "pytest-mock~=3.15.1",
+    "pytest-recording~=0.13.4",
     "pytest-xdist~=3.8.0",
     "requests-mock~=1.12.1",
     "testfixtures~=8.3.0;python_version<'3.11'",

--- a/test/test_geocode/cassettes/test_census_geocoder/test_coordinates.yaml
+++ b/test/test_geocode/cassettes/test_census_geocoder/test_coordinates.yaml
@@ -1,0 +1,70 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+    method: GET
+    uri: https://geocoding.geo.census.gov/geocoder/geographies/coordinates?x=-77.0441907&y=38.8884212&vintage=Current_Current&benchmark=Public_AR_Current&format=json
+  response:
+    body:
+      string: '{"result":{"geographies":{"States":[{"STATENS":"01702382","GEOID":"11","CENTLAT":"+38.9047586","AREAWATER":"18707004","STATE":"11","BASENAME":"District
+        of Columbia","STUSAB":"DC","OID":"27490331294090","LSADC":"00","FUNCSTAT":"A","INTPTLAT":"+38.9042429","DIVISION":"5","NAME":"District
+        of Columbia","REGION":"3","OBJECTID":42,"CENTLON":"-077.0162860","AREALAND":"158318974","INTPTLON":"-077.0165243","MTFCC":"G4000"}],"Combined
+        Statistical Areas":[{"POP100":"","GEOID":"548","CENTLAT":"+38.9848368","AREAWATER":"5218513808","BASENAME":"Washington-Baltimore-Arlington,
+        DC-MD-VA-WV-PA","OID":"2619034687908147","LSADC":"M0","FUNCSTAT":"S","INTPTLAT":"+38.9901097","NAME":"Washington-Baltimore-Arlington,
+        DC-MD-VA-WV-PA CSA","OBJECTID":141,"CSA":"548","CENTLON":"-077.2239743","INTPTLON":"-077.2234092","AREALAND":"34187354537","HU100":"","MTFCC":"G3100"}],"County
+        Subdivisions":[{"COUSUB":"50000","GEOID":"1100150000","CENTLAT":"+38.9047586","AREAWATER":"18707004","STATE":"11","BASENAME":"Washington","OID":"27690331274806","LSADC":"25","FUNCSTAT":"F","INTPTLAT":"+38.9042429","NAME":"Washington
+        city","OBJECTID":33108,"CENTLON":"-077.0162860","COUSUBCC":"C5","AREALAND":"158318974","INTPTLON":"-077.0165243","MTFCC":"G4040","COUSUBNS":"02390665","COUNTY":"001"}],"Urban
+        Areas":[{"GEOID":"92242","CENTLAT":"+38.8953259","AREAWATER":"67696922","BASENAME":"Washington--Arlington,
+        DC--VA--MD","OID":"27021158105937","UA":"92242","LSADC":"67","FUNCSTAT":"S","INTPTLAT":"+38.8959429","NAME":"Washington--Arlington,
+        DC--VA--MD Urban Area","OBJECTID":1574,"CENTLON":"-077.1822243","AREALAND":"3352467065","INTPTLON":"-077.1830768","MTFCC":"G3500"}],"Incorporated
+        Places":[{"DISP_CLR":3,"NECTAPCI":"N","GEOID":"1150000","CENTLAT":"+38.9047586","AREAWATER":"18707004","BASENAME":"Washington","STATE":"11","OID":"27890331283927","LSADC":"25","PLACE":"50000","FUNCSTAT":"N","INTPTLAT":"+38.9042429","NAME":"Washington
+        city","OBJECTID":32234,"PLACECC":"C5","CENTLON":"-077.0162860","CBSAPCI":"Y","AREALAND":"158318974","INTPTLON":"-077.0165243","PLACENS":"02390665","MTFCC":"G4110"}],"Counties":[{"GEOID":"11001","CENTLAT":"+38.9047586","AREAWATER":"18707004","STATE":"11","BASENAME":"District
+        of Columbia","OID":"27590331264532","LSADC":"00","FUNCSTAT":"F","INTPTLAT":"+38.9042429","NAME":"District
+        of Columbia","OBJECTID":1959,"CENTLON":"-077.0162860","COUNTYCC":"H6","COUNTYNS":"01702382","AREALAND":"158318974","INTPTLON":"-077.0165243","MTFCC":"G4020","COUNTY":"001"}],"2024
+        State Legislative Districts - Upper":[{"GEOID":"11002","CENTLAT":"+38.9000370","AREAWATER":"3029412","STATE":"11","BASENAME":"2","OID":"2129035951821144","SLDU":"002","LSADC":"L1","FUNCSTAT":"N","INTPTLAT":"+38.9001359","NAME":"Ward
+        2","OBJECTID":1845,"CENTLON":"-077.0463477","LSY":"2024","AREALAND":"15330267","INTPTLON":"-077.0457772","MTFCC":"G5210","LDTYP":"O"}],"2020
+        Census Blocks":[{"SUFFIX":"","GEOID":"110019800001124","CENTLAT":"+38.8884516","BLOCK":"1124","AREAWATER":"30352","STATE":"11","BASENAME":"1124","OID":"210701008444199","LSADC":"BK","FUNCSTAT":"S","INTPTLAT":"+38.8882139","NAME":"Block
+        1124","OBJECTID":858997,"TRACT":"980000","CENTLON":"-077.0453980","BLKGRP":"1","AREALAND":"171705","INTPTLON":"-077.0449823","MTFCC":"G5040","LWBLKTYP":"B","UR":"U","COUNTY":"001"}],"Census
+        Tracts":[{"GEOID":"11001980000","CENTLAT":"+38.8801546","AREAWATER":"4996397","STATE":"11","BASENAME":"9800","OID":"2079015504267431","LSADC":"CT","FUNCSTAT":"S","INTPTLAT":"+38.8809933","NAME":"Census
+        Tract 9800","OBJECTID":35043,"TRACT":"980000","CENTLON":"-077.0352173","AREALAND":"6514231","INTPTLON":"-077.0363219","MTFCC":"G5020","COUNTY":"001"}],"119th
+        Congressional Districts":[{"GEOID":"1198","CENTLAT":"+38.9047586","CDSESSN":"119","AREAWATER":"18707004","BASENAME":"Delegate
+        District (at Large)","STATE":"11","OID":"2119035963374576","LSADC":"C4","FUNCSTAT":"N","INTPTLAT":"+38.9042429","NAME":"Delegate
+        District (at Large)","OBJECTID":409,"CENTLON":"-077.0162860","CD119":"98","AREALAND":"158318974","INTPTLON":"-077.0165243","MTFCC":"G5200"}]},"input":{"vintage":{"isDefault":true,"id":"4","vintageName":"Current_Current","vintageDescription":"Current
+        Vintage - Current Benchmark"},"location":{"x":-77.0441907,"y":38.8884212},"benchmark":{"isDefault":true,"benchmarkDescription":"Public
+        Address Ranges - Current Benchmark","id":"4","benchmarkName":"Public_AR_Current"}}}}'
+    headers:
+      Cache-Control:
+      - private, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4352'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 01 Jul 2026 01:27:30 GMT
+      Set-Cookie:
+      - TS0193e6a1=01283c52a4f156a93567dcd81893ae3ca2a947cc734345a604b278dceaec3bce96a002d43cb5dc05461aa606e99a8db42f2d8afd97;
+        Path=/; Domain=.geocoding.geo.census.gov; Secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1;mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/test/test_geocode/test_census_geocoder.py
+++ b/test/test_geocode/test_census_geocoder.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 import petl
@@ -10,64 +9,71 @@ from test.conftest import assert_matching_tables
 from .test_responses import batch_resp, coord_resp, geographies_resp, locations_resp
 
 
+@pytest.fixture
+def cg():
+    """Provides a fresh CensusGeocoder instance for each test."""
+    return CensusGeocoder()
+
+
 @pytest.mark.live
-class TestCensusGeocoder(unittest.TestCase):
-    def setUp(self):
-        self.cg = CensusGeocoder()
+def test_geocode_onelineaddress(cg):
+    cg.cg = mock.MagicMock()
+    address = "1600 Pennsylvania Avenue, Washington, DC"
 
-    def test_geocode_onelineaddress(self):
-        self.cg.cg = mock.MagicMock()
-        address = "1600 Pennsylvania Avenue, Washington, DC"
+    # Assert one line with geographies parameter returns expected
+    cg.cg.onelineaddress = mock.MagicMock(return_value=geographies_resp)
+    geo = cg.geocode_onelineaddress(address, return_type="geographies")
+    cg.cg.onelineaddress.assert_called_with(address, returntype="geographies")
+    assert geo == geographies_resp
 
-        # Assert one line with geographies parameter returns expected
-        self.cg.cg.onelineaddress = mock.MagicMock(return_value=geographies_resp)
-        geo = self.cg.geocode_onelineaddress(address, return_type="geographies")
-        self.cg.cg.onelineaddress.assert_called_with(address, returntype="geographies")
-        assert geo == geographies_resp
+    # Assert one line with locations parameter returns expected
+    cg.cg.onelineaddress = mock.MagicMock(return_value=locations_resp)
+    geo = cg.geocode_onelineaddress(address, return_type="locations")
+    cg.cg.onelineaddress.assert_called_with(address, returntype="locations")
+    assert geo == locations_resp
 
-        # Assert one line with locations parameter returns expected
-        self.cg.cg.onelineaddress = mock.MagicMock(return_value=locations_resp)
-        geo = self.cg.geocode_onelineaddress(address, return_type="locations")
-        self.cg.cg.onelineaddress.assert_called_with(address, returntype="locations")
-        assert geo == locations_resp
 
-    def test_geocode_address(self):
-        self.cg.cg = mock.MagicMock()
-        passed_address = {
-            "address_line": "1600 Pennsylvania Avenue",
-            "city": "Washington",
-            "state": "DC",
-        }
+@pytest.mark.live
+def test_geocode_address(cg):
+    cg.cg = mock.MagicMock()
+    passed_address = {
+        "address_line": "1600 Pennsylvania Avenue",
+        "city": "Washington",
+        "state": "DC",
+    }
 
-        # Assert one line with geographies parameter returns expected
-        self.cg.cg.address = mock.MagicMock(return_value=geographies_resp)
-        geo = self.cg.geocode_address(**passed_address, return_type="geographies")
-        assert geo == geographies_resp
+    # Assert one line with geographies parameter returns expected
+    cg.cg.address = mock.MagicMock(return_value=geographies_resp)
+    geo = cg.geocode_address(**passed_address, return_type="geographies")
+    assert geo == geographies_resp
 
-        # Assert one line with locations parameter returns expected
-        self.cg.cg.address = mock.MagicMock(return_value=locations_resp)
-        geo = self.cg.geocode_address(**passed_address, return_type="locations")
-        assert geo == locations_resp
+    # Assert one line with locations parameter returns expected
+    cg.cg.address = mock.MagicMock(return_value=locations_resp)
+    geo = cg.geocode_address(**passed_address, return_type="locations")
+    assert geo == locations_resp
 
-    def test_geocode_address_batch(self):
-        batch = [
-            ["id", "street", "city", "state", "zip"],
-            ["1", "908 N Washtenaw", "Chicago", "IL", "60622"],
-            ["2", "1405 Wilshire Blvd", "Austin", "TX", "78722"],
-            ["3", "908 N Washtenaw", "Chicago", "IL", "60622"],
-            ["4", "1405 Wilshire Blvd", "Austin", "TX", "78722"],
-            ["5", "908 N Washtenaw", "Chicago", "IL", "60622"],
-        ]
 
-        tbl = Table(batch)
+@pytest.mark.live
+def test_geocode_address_batch(cg):
+    batch = [
+        ["id", "street", "city", "state", "zip"],
+        ["1", "908 N Washtenaw", "Chicago", "IL", "60622"],
+        ["2", "1405 Wilshire Blvd", "Austin", "TX", "78722"],
+        ["3", "908 N Washtenaw", "Chicago", "IL", "60622"],
+        ["4", "1405 Wilshire Blvd", "Austin", "TX", "78722"],
+        ["5", "908 N Washtenaw", "Chicago", "IL", "60622"],
+    ]
 
-        self.cg.cg.addressbatch = mock.MagicMock(return_value=batch_resp)
-        geo = self.cg.geocode_address_batch(tbl)
-        assert_matching_tables(geo, Table(petl.fromdicts(batch_resp)))
+    tbl = Table(batch)
 
-    @pytest.mark.live
-    def test_coordinates(self):
-        # Assert coordinates data returns expected response.
-        self.cg.cg.address = mock.MagicMock(return_value=coord_resp)
-        geo = self.cg.get_coordinates_data("38.8884212", "-77.0441907")
-        assert geo == coord_resp
+    cg.cg.addressbatch = mock.MagicMock(return_value=batch_resp)
+    geo = cg.geocode_address_batch(tbl)
+    assert_matching_tables(geo, Table(petl.fromdicts(batch_resp)))
+
+
+@pytest.mark.live
+def test_coordinates(cg):
+    # Assert coordinates data returns expected response.
+    cg.cg.address = mock.MagicMock(return_value=coord_resp)
+    geo = cg.get_coordinates_data("38.8884212", "-77.0441907")
+    assert geo == coord_resp

--- a/test/test_geocode/test_census_geocoder.py
+++ b/test/test_geocode/test_census_geocoder.py
@@ -15,7 +15,6 @@ def cg():
     return CensusGeocoder()
 
 
-@pytest.mark.live
 def test_geocode_onelineaddress(cg):
     cg.cg = mock.MagicMock()
     address = "1600 Pennsylvania Avenue, Washington, DC"
@@ -33,7 +32,6 @@ def test_geocode_onelineaddress(cg):
     assert geo == locations_resp
 
 
-@pytest.mark.live
 def test_geocode_address(cg):
     cg.cg = mock.MagicMock()
     passed_address = {
@@ -53,7 +51,6 @@ def test_geocode_address(cg):
     assert geo == locations_resp
 
 
-@pytest.mark.live
 def test_geocode_address_batch(cg):
     batch = [
         ["id", "street", "city", "state", "zip"],
@@ -71,7 +68,7 @@ def test_geocode_address_batch(cg):
     assert_matching_tables(geo, Table(petl.fromdicts(batch_resp)))
 
 
-@pytest.mark.live
+@pytest.mark.vcr
 def test_coordinates(cg):
     # Assert coordinates data returns expected response.
     cg.cg.address = mock.MagicMock(return_value=coord_resp)

--- a/test/test_geocode/test_responses.py
+++ b/test/test_geocode/test_responses.py
@@ -287,9 +287,10 @@ locations_resp = [
 coord_resp = {
     "119th Congressional Districts": [
         {
-            "AREALAND": "158318961",
-            "AREAWATER": "18706999",
+            "AREALAND": "158318974",
+            "AREAWATER": "18707004",
             "BASENAME": "Delegate District (at Large)",
+            "CD119": "98",
             "CDSESSN": "119",
             "CENT": (
                 -77.016286,
@@ -308,7 +309,7 @@ coord_resp = {
             "LSADC": "C4",
             "MTFCC": "G5200",
             "NAME": "Delegate District (at Large)",
-            "OBJECTID": 314,
+            "OBJECTID": 409,
             "OID": "2119035963374576",
             "STATE": "11",
         },
@@ -330,16 +331,16 @@ coord_resp = {
             "FUNCSTAT": "S",
             "GEOID": "110019800001124",
             "INTPT": (
-                -77.0452079,
-                38.8886931,
+                -77.0449823,
+                38.8882139,
             ),
-            "INTPTLAT": "+38.8886931",
-            "INTPTLON": "-077.0452079",
+            "INTPTLAT": "+38.8882139",
+            "INTPTLON": "-077.0449823",
             "LSADC": "BK",
             "LWBLKTYP": "B",
             "MTFCC": "G5040",
             "NAME": "Block 1124",
-            "OBJECTID": 4675104,
+            "OBJECTID": 858997,
             "OID": "210701008444199",
             "STATE": "11",
             "SUFFIX": "",
@@ -349,8 +350,8 @@ coord_resp = {
     ],
     "2024 State Legislative Districts - Upper": [
         {
-            "AREALAND": "15330264",
-            "AREAWATER": "3029411",
+            "AREALAND": "15330267",
+            "AREAWATER": "3029412",
             "BASENAME": "2",
             "CENT": (
                 -77.0463477,
@@ -371,7 +372,7 @@ coord_resp = {
             "LSY": "2024",
             "MTFCC": "G5210",
             "NAME": "Ward 2",
-            "OBJECTID": 1343,
+            "OBJECTID": 1845,
             "OID": "2129035951821144",
             "SLDU": "002",
             "STATE": "11",
@@ -379,8 +380,8 @@ coord_resp = {
     ],
     "Census Tracts": [
         {
-            "AREALAND": "6514228",
-            "AREAWATER": "4996396",
+            "AREALAND": "6514231",
+            "AREAWATER": "4996397",
             "BASENAME": "9800",
             "CENT": (
                 -77.0352173,
@@ -400,7 +401,7 @@ coord_resp = {
             "LSADC": "CT",
             "MTFCC": "G5020",
             "NAME": "Census Tract 9800",
-            "OBJECTID": 35127,
+            "OBJECTID": 35043,
             "OID": "2079015504267431",
             "STATE": "11",
             "TRACT": "980000",
@@ -408,8 +409,8 @@ coord_resp = {
     ],
     "Combined Statistical Areas": [
         {
-            "AREALAND": "34187347070",
-            "AREAWATER": "5218521415",
+            "AREALAND": "34187354537",
+            "AREAWATER": "5218513808",
             "BASENAME": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
             "CENT": (
                 -77.2239743,
@@ -422,23 +423,23 @@ coord_resp = {
             "GEOID": "548",
             "HU100": "",
             "INTPT": (
-                -77.2228175,
-                38.9854484,
+                -77.2234092,
+                38.9901097,
             ),
-            "INTPTLAT": "+38.9854484",
-            "INTPTLON": "-077.2228175",
+            "INTPTLAT": "+38.9901097",
+            "INTPTLON": "-077.2234092",
             "LSADC": "M0",
             "MTFCC": "G3100",
             "NAME": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA CSA",
-            "OBJECTID": 156,
+            "OBJECTID": 141,
             "OID": "2619034687908147",
             "POP100": "",
         },
     ],
     "Counties": [
         {
-            "AREALAND": "158318961",
-            "AREAWATER": "18706999",
+            "AREALAND": "158318974",
+            "AREAWATER": "18707004",
             "BASENAME": "District of Columbia",
             "CENT": (
                 -77.016286,
@@ -460,15 +461,15 @@ coord_resp = {
             "LSADC": "00",
             "MTFCC": "G4020",
             "NAME": "District of Columbia",
-            "OBJECTID": 1530,
+            "OBJECTID": 1959,
             "OID": "27590331264532",
             "STATE": "11",
         },
     ],
     "County Subdivisions": [
         {
-            "AREALAND": "158318961",
-            "AREAWATER": "18706999",
+            "AREALAND": "158318974",
+            "AREAWATER": "18707004",
             "BASENAME": "Washington",
             "CENT": (
                 -77.016286,
@@ -491,15 +492,15 @@ coord_resp = {
             "LSADC": "25",
             "MTFCC": "G4040",
             "NAME": "Washington city",
-            "OBJECTID": 33046,
+            "OBJECTID": 33108,
             "OID": "27690331274806",
             "STATE": "11",
         },
     ],
     "Incorporated Places": [
         {
-            "AREALAND": "158318961",
-            "AREAWATER": "18706999",
+            "AREALAND": "158318974",
+            "AREAWATER": "18707004",
             "BASENAME": "Washington",
             "CBSAPCI": "Y",
             "CENT": (
@@ -521,20 +522,18 @@ coord_resp = {
             "MTFCC": "G4110",
             "NAME": "Washington city",
             "NECTAPCI": "N",
-            "OBJECTID": 32590,
+            "OBJECTID": 32234,
             "OID": "27890331283927",
             "PLACE": "50000",
             "PLACECC": "C5",
             "PLACENS": "02390665",
             "STATE": "11",
-            "STGEOMETRY_Area": 292742530.9541352,
-            "STGEOMETRY_Length": 86300.89857680116,
         },
     ],
     "States": [
         {
-            "AREALAND": "158318961",
-            "AREAWATER": "18706999",
+            "AREALAND": "158318974",
+            "AREAWATER": "18707004",
             "BASENAME": "District of Columbia",
             "CENT": (
                 -77.016286,
@@ -554,7 +553,7 @@ coord_resp = {
             "LSADC": "00",
             "MTFCC": "G4000",
             "NAME": "District of Columbia",
-            "OBJECTID": 51,
+            "OBJECTID": 42,
             "OID": "27490331294090",
             "REGION": "3",
             "STATE": "11",
@@ -564,15 +563,15 @@ coord_resp = {
     ],
     "Urban Areas": [
         {
-            "AREALAND": "3352475823",
-            "AREAWATER": "67696923",
+            "AREALAND": "3352467065",
+            "AREAWATER": "67696922",
             "BASENAME": "Washington--Arlington, DC--VA--MD",
             "CENT": (
-                -77.182224,
-                38.8953266,
+                -77.1822243,
+                38.8953259,
             ),
-            "CENTLAT": "+38.8953266",
-            "CENTLON": "-077.1822240",
+            "CENTLAT": "+38.8953259",
+            "CENTLON": "-077.1822243",
             "FUNCSTAT": "S",
             "GEOID": "92242",
             "INTPT": (
@@ -584,7 +583,7 @@ coord_resp = {
             "LSADC": "67",
             "MTFCC": "G3500",
             "NAME": "Washington--Arlington, DC--VA--MD Urban Area",
-            "OBJECTID": 1460,
+            "OBJECTID": 1574,
             "OID": "27021158105937",
             "UA": "92242",
         },


### PR DESCRIPTION
## What is this change?

- Refactor censusgeocode tests to use pytest fixture instead of unittest framework
- Always run any censusgeocode tests that don't require network access
- Add [pytest-recording](https://pypi.org/project/pytest-recording/) to dev dependencies
- Use pytest-recording to always run the live test without requiring network access (re-using response data I captured locally)
- Update expected response from API as census data has changed since the tests were added and ran (another reason to use recorded responses)

## Considerations for discussion

- Census Geocode tests didn't run because it was all marked as a live test.

## How to test the changes (if needed)

- Run `pytest .\test\test_geocode`
- View CI logs

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
