### PR TITLE
Bigquery get_table_ref doesn't ignore project_id

### DIFF
--- a/parsons/google/google_bigquery.py
+++ b/parsons/google/google_bigquery.py
@@ -11,10 +11,10 @@ from typing import Literal
 import google
 import petl
 from google.api_core import exceptions
+from google.auth.credentials import Credentials
 from google.cloud import bigquery
 from google.cloud.bigquery import ExtractJob, dbapi, job
 from google.cloud.bigquery.job import ExtractJobConfig, LoadJobConfig, QueryJobConfig
-from google.oauth2.credentials import Credentials
 
 from parsons import Table
 from parsons.databases.database_connector import DatabaseConnector
@@ -1400,7 +1400,9 @@ class GoogleBigQuery(DatabaseConnector):
     def get_table_ref(self, table_name):
         # Helper function to build a TableReference for our table
         parsed = parse_table_name(table_name)
-        dataset_ref = self.client.dataset(parsed["dataset"])
+        dataset_ref = bigquery.DatasetReference(
+            parsed["project"] or self.client.project, parsed["dataset"]
+        )
         return dataset_ref.table(parsed["table"])
 
     def _get_job_config_schema(

--- a/test/test_bigquery/test_bigquery.py
+++ b/test/test_bigquery/test_bigquery.py
@@ -611,6 +611,7 @@ class TestGoogleBigQuery(FakeCredentialTest):
         self, table_exists=True, app_creds: str | dict | None = None
     ):
         bq_client = mock.MagicMock()
+        bq_client.project = "project"
         if not table_exists:
             bq_client.get_table.side_effect = exceptions.NotFound("not found")
         bq = BigQuery(app_creds=app_creds)
@@ -619,6 +620,7 @@ class TestGoogleBigQuery(FakeCredentialTest):
 
     def _build_mock_base_client(self, app_creds: str | dict | None = None):
         bq_client = mock.MagicMock()
+        bq_client.project = "project"
         bq = BigQuery(app_creds=app_creds)
         bq._client = bq_client
         return bq


### PR DESCRIPTION
prior behavior would ignore a project_id in a table ref, defaulting to the project_id of the whole BigQuery connector. This update ensures that the project_id included in a table ref will not be ignored

## What is this change?

In parsons as-is, this operation: 
```
BigQuery(project_id='project_A').copy(tbl, 'project_B.some_dataset.some_table')
```
would load into `project_A.some_dataset.some_table` - or more likely, simply fail because `project_A.some_dataset` doesn't exist

This bug occurs because `get_table_ref` ignores the project_id. This PR fixes that so that the project_id is used if specified.

## Considerations for discussion

- (List out any significant design decisions that were made and why.)

## How to test the changes (if needed)

- (How should a reviewer test this functionality.)

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
