### PR TITLE
Improved useful_examples code

### DIFF
--- a/useful_resources/sample_code/apply_activist_code.py
+++ b/useful_resources/sample_code/apply_activist_code.py
@@ -26,7 +26,7 @@ config_vars = {
 
 # ### CODE
 
-from parsons import Table, Redshift, VAN  # noqa E402 module-import-not-at-top-of-file
+from parsons import Redshift, VAN  # noqa E402 module-import-not-at-top-of-file
 from parsons import logger  # noqa E402 module-import-not-at-top-of-file
 import os  # noqa E402 module-import-not-at-top-of-file
 

--- a/useful_resources/sample_code/civis_job_status_slack_alert.py
+++ b/useful_resources/sample_code/civis_job_status_slack_alert.py
@@ -3,6 +3,7 @@
 
 import datetime
 import logging
+import os
 
 import civis
 
@@ -18,8 +19,10 @@ slack = Slack()
 # https://move-coop.github.io/parsons/html/use_cases/contribute_use_cases.html#sensitive-information
 
 # Configuration variables
-SLACK_CHANNEL = ""  # Slack channel where the alert will post.
-CIVIS_PROJECT = ""  # ID of the Civis project with jobs and workflows you want to see the status of.
+SLACK_CHANNEL: str = os.environ["SLACK_ALERT_CHANNEL"]  # Slack channel where the alert will post.
+CIVIS_PROJECT: int = int(
+    os.environ["CIVIS_PROJECT_ID"]
+)  # ID of the Civis project with jobs and workflows you want to see the status of.
 
 logger = logging.getLogger(__name__)
 _handler = logging.StreamHandler()
@@ -109,9 +112,7 @@ def get_last_success(object_id, object_type):
 
 def main():
     project_name = client.projects.get(CIVIS_PROJECT)["name"]
-
     scripts_table = get_workflows_and_jobs(CIVIS_PROJECT).sort(columns=["state", "name"])
-
     logger.info(f"Found {scripts_table.num_rows} jobs and workflows in {project_name} project.")
 
     # This is a list of strings we will build with each job's status
@@ -128,8 +129,9 @@ def main():
     # Combine the list of statuses into one string
     line_items = "\n".join(output_lines)
     message = f"*{project_name} Status*\n{line_items}"
-    logger.info(f"Posting message to Slack channel {SLACK_CHANNEL}")
+
     # Post message
+    logger.info(f"Posting message to Slack channel {SLACK_CHANNEL}")
     slack.message_channel(SLACK_CHANNEL, message)
     logger.info("Slack message posted")
 

--- a/useful_resources/sample_code/opt_outs_everyaction.py
+++ b/useful_resources/sample_code/opt_outs_everyaction.py
@@ -57,7 +57,6 @@ rs = Redshift()
 def attempt_optout(
     every_action: EveryAction,
     row: dict[str, Any],
-    applied_at: str,
     committeeid: str,
     success_log: list[dict[str, Any]],
     error_log: list[dict[str, Any]],
@@ -69,6 +68,7 @@ def attempt_optout(
     # Documentation on this json construction is here
     # https://docs.ngpvan.com/reference/common-models
     match_json = {"phones": [{"phoneNumber": phone, "phoneOptInStatus": "O"}]}
+    timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
 
     try:
         response = every_action.update_person_json(id=vanid, match_json=match_json)
@@ -80,7 +80,7 @@ def attempt_optout(
                     "vanid": response.get("vanId"),
                     "phone": phone,
                     "committeeid": committeeid,
-                    "applied_at": applied_at,
+                    "applied_at": timestamp,
                 }
             )
 
@@ -95,7 +95,7 @@ def attempt_optout(
                 "vanid": vanid,
                 "phone": phone,
                 "committeeid": committeeid,
-                "errored_at": applied_at,
+                "errored_at": timestamp,
                 "error": error_message,
             }
         )
@@ -111,9 +111,7 @@ def attempt_optout(
 
             # Wait 10 seconds, then try again
             time.sleep(10)
-            attempt_optout(
-                every_action, row, applied_at, committeeid, success_log, error_log, attempts_left
-            )
+            attempt_optout(every_action, row, committeeid, success_log, error_log, attempts_left)
 
         else:
             # If we are still getting a connection error after our maximum number of attempts
@@ -126,7 +124,7 @@ def attempt_optout(
                     "vanid": vanid,
                     "phone": phone,
                     "committeeid": committeeid,
-                    "errored_at": applied_at,
+                    "errored_at": timestamp,
                     "error": connection_error_message,
                 }
             )
@@ -186,11 +184,9 @@ def main():
 
         if opt_outs.num_rows > 0:
             for opt_out in opt_outs:
-                applied_at = str(datetime.datetime.now(tz=datetime.timezone.utc)).split(".")[0]
                 attempt_optout(
                     every_action,
                     opt_out,
-                    applied_at,
                     committeeid,
                     success_log,
                     error_log,

--- a/useful_resources/sample_code/opt_outs_everyaction.py
+++ b/useful_resources/sample_code/opt_outs_everyaction.py
@@ -104,7 +104,9 @@ def attempt_optout(
 
             # Wait 10 seconds, then try again
             time.sleep(10)
-            attempt_optout(every_action, row, attempts_left)
+            attempt_optout(
+                every_action, row, applied_at, committeeid, success_log, error_log, attempts_left
+            )
 
         else:
             # If we are still getting a connection error after our maximum number of attempts

--- a/useful_resources/sample_code/opt_outs_everyaction.py
+++ b/useful_resources/sample_code/opt_outs_everyaction.py
@@ -3,10 +3,11 @@ import json
 import logging
 import os
 import time
+from typing import Any
 
 import requests
 
-from parsons import VAN, Redshift, Table
+from parsons import VAN, EveryAction, Redshift, Table
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,13 @@ rs = Redshift()
 
 
 def attempt_optout(
-    every_action, row, applied_at, committeeid, success_log, error_log, attempts_left: bool = 3
+    every_action: EveryAction,
+    row: dict[str, Any],
+    applied_at: str,
+    committeeid: str,
+    success_log: list[dict[str, Any]],
+    error_log: list[dict[str, Any]],
+    attempts_left: int = 3,
 ):
     vanid = row["vanid"]
     phone = row["phone"]


### PR DESCRIPTION
## What is this change?

- opt_outs_everyaction.py
  - Adds type hinting for function `attempt_optout`
  - Fix recursion in `attempt_optout` which was missing some parameters in its call signature (it was passing `attempts_left` to `applied_at`)
  - obtain timestamp within retry loop, so that times shown in log will be more accurate
- civis_job_status_slack_alert.py
  - Corrects mis-labeled type of constant CIVIS_PROJECT
  - Adds type hint to constant SLACK_CHANNEL
  - Allows configuration of CIVIS_PROJECT and SLACK_CHANNEL via CIVIS_PROJECT_ID and SLACK_ALERT_CHANNEL environment variables

## How to test the changes (if needed)

- you could try running them, but if you look at the code changes you can see the issues with the before code

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
