### PR TITLE
fix(airmeet): send session-recordings sessionIds as a query param

### DIFF
--- a/parsons/airmeet/airmeet.py
+++ b/parsons/airmeet/airmeet.py
@@ -419,10 +419,12 @@ class Airmeet:
                 List of session recordings
 
         """
-        kwargs = {}
+        params = {}
         if session_id:
-            kwargs["sessionIds"] = session_id
-        response = self.client.get_request(url=f"airmeet/{airmeet_id}/session-recordings", **kwargs)
+            params["sessionIds"] = session_id
+        response = self.client.get_request(
+            url=f"airmeet/{airmeet_id}/session-recordings", params=params
+        )
         return Table(response["recordings"])
 
     def fetch_event_replay_attendance(self, airmeet_id, session_id=None) -> Table:

--- a/test/test_airmeet.py
+++ b/test/test_airmeet.py
@@ -472,7 +472,7 @@ class TestAirmeet(unittest.TestCase):
 
         self.airmeet.client.get_request.assert_called_once_with(
             url="airmeet/test_airmeet_id/session-recordings",
-            sessionIds="test_session_id",
+            params={"sessionIds": "test_session_id"},
         )
         assert isinstance(result, Table), "The result should be a Table"
         assert len(result) == 1, "The result should contain exactly one record"


### PR DESCRIPTION
## Problem

`Airmeet.download_session_recordings(airmeet_id, session_id=...)` forwarded `sessionIds` to `APIConnector.get_request` as a **keyword argument** instead of a query parameter:

```python
kwargs["sessionIds"] = session_id
self.client.get_request(url=..., **kwargs)
```

`get_request` passes unknown kwargs straight down to `requests`, so calling the method **with** a `session_id` raises `TypeError: Session.request() got an unexpected keyword argument 'sessionIds'` — the per-session filter never worked. The existing unit test masked this by mocking the entire client method, so it only checked the call shape, not real behavior.

## Fix

Pass it as a query param, matching every other method in the connector (`_get_all_pages` already uses `params=`):

```python
params["sessionIds"] = session_id
self.client.get_request(url=..., params=params)
```

Updated the existing unit test to assert the corrected call.

## Context

Surfaced while migrating the Parsons test suite (#1907). Kept as its own small PR so that migration stays test-only.

## Breaking Changes

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.
