### PR TITLE
test(ngpvan): fix leaked Table.from_csv mock in test_changed_entities

### DIFF
--- a/test/test_ngpvan/test_changed_entities.py
+++ b/test/test_ngpvan/test_changed_entities.py
@@ -86,9 +86,11 @@ class TestNGPVAN(unittest.TestCase):
         m.post(self.van.connection.uri + "changedEntityExportJobs", json=json)
         m.get(self.van.connection.uri + "changedEntityExportJobs/2170181229", json=json2)
 
-        Table.from_csv = mock.MagicMock()
-        Table.from_csv.return_value = tbl
-
-        out_tbl = self.van.get_changed_entities("ContactHistory", "2021-10-10")
+        # Use patch.object (not a bare ``Table.from_csv = MagicMock()``) so the class
+        # attribute is restored when the block exits. A bare assignment leaks the mock
+        # into every later test in the same pytest-xdist worker, breaking any that call
+        # the real Table.from_csv (e.g. SFTP.get_table).
+        with mock.patch.object(Table, "from_csv", return_value=tbl):
+            out_tbl = self.van.get_changed_entities("ContactHistory", "2021-10-10")
 
         assert_matching_tables(out_tbl, tbl)


### PR DESCRIPTION
## Problem

`test/test_ngpvan/test_changed_entities.py::test_get_changed_entities` replaces the class attribute `Table.from_csv` with a bare `MagicMock()` and never restores it:

```python
Table.from_csv = mock.MagicMock()
Table.from_csv.return_value = tbl
```

Once this test runs, `Table.from_csv` stays globally mocked (returning `Table([{"a": 1, "b": 2}])`) for **every later test in the same pytest-xdist worker**. Any later test that calls the real `Table.from_csv` then silently gets `a,b / 1,2` instead of real data — an order- and worker-dependent flake.

It's dormant in the current suite (nothing else calls the real `Table.from_csv` after it in the same worker), but it's a latent trap.

## Fix

Wrap the mock in `mock.patch.object`, which restores the attribute on block exit.

## Context

Surfaced while migrating the Parsons test suite (#1907): a new SFTP test that exercises the real `Table.from_csv` flaked intermittently because of this leak. Kept as its own small PR.

## Breaking Changes

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.
