### PR TITLE
Fix google issues after recent cryptography release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,10 @@ dbt-postgres = [
     "rich >= 14.0"
 ]
 dbt-snowflake = [
-    "dbt-snowflake >= 1.8,<1.12;python_version < '3.11'",
-    "dbt-snowflake >= 1.8;python_version >= '3.11'",
+    "dbt-snowflake >= 1.8",
     "dbt-core >= 1.8;python_version < '3.14'",
     "dbt-core >= 1.12;python_version >= '3.14'",
+    "cryptography < 50;python_version < '3.11'",
     "rich >= 14.0"
 ]
 facebook = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,34 +51,34 @@ catalist = ["paramiko >= 3.0"]
 civis = ["civis >= 2.0"]
 dbt-duckdb = [
     "dbt-duckdb >= 1.8",
-    "dbt-core>=1.8;python_version<'3.14'",
-    "dbt-core>=1.12;python_version>='3.14'",
+    "dbt-core >= 1.8;python_version < '3.14'",
+    "dbt-core >= 1.12;python_version >= '3.14'",
     "rich >= 14.0"
 ]
 dbt-redshift = [
     "dbt-redshift >= 1.8",
-    "dbt-core>=1.8;python_version<'3.14'",
-    "dbt-core>=1.12;python_version>='3.14'",
+    "dbt-core >= 1.8;python_version < '3.14'",
+    "dbt-core >= 1.12;python_version >= '3.14'",
     "lxml >= 6.0.1",
     "rich >= 14.0",
 ]
 dbt-bigquery = [
     "dbt-bigquery >= 1.8",
-    "dbt-core>=1.8;python_version<'3.14'",
-    "dbt-core>=1.12;python_version>='3.14'",
+    "dbt-core >= 1.8;python_version < '3.14'",
+    "dbt-core >= 1.12;python_version >= '3.14'",
     "rich >= 14.0"
 ]
 dbt-postgres = [
     "dbt-postgres >= 1.8",
-    "dbt-core>=1.8;python_version<'3.14'",
-    "dbt-core>=1.12;python_version>='3.14'",
+    "dbt-core >= 1.8;python_version < '3.14'",
+    "dbt-core >= 1.12;python_version >= '3.14'",
     "rich >= 14.0"
 ]
 dbt-snowflake = [
-    "dbt-snowflake >= 1.8,<1.12;python_version<'3.11'",
-    "dbt-snowflake >= 1.8;python_version>='3.11'",
-    "dbt-core>=1.8;python_version<'3.14'",
-    "dbt-core>=1.12;python_version>='3.14'",
+    "dbt-snowflake >= 1.8,<1.12;python_version < '3.11'",
+    "dbt-snowflake >= 1.8;python_version >= '3.11'",
+    "dbt-core >= 1.8;python_version < '3.14'",
+    "dbt-core >= 1.12;python_version >= '3.14'",
     "rich >= 14.0"
 ]
 facebook = [
@@ -193,42 +193,42 @@ dev = [
     {include-group = "test-coverage"},
 ]
 ci = [
-    "build>=1.4",
+    "build >= 1.4",
 ]
 docs = [
-    "furo~=2025.12.19",
-    "myst-parser~=4.0.1",
-    "packaging~=26.0",
-    "sphinxcontrib-googleanalytics~=0.5",
-    "sphinx-lint==1.0.2",
-    "sphinx-multiversion~=0.2.4",
-    "Sphinx~=7.4.7;python_version<'3.11'",
-    "Sphinx~=8.2.3;python_version>='3.11'",
+    "furo ~= 2025.12.19",
+    "myst-parser ~= 4.0.1",
+    "packaging ~= 26.0",
+    "sphinxcontrib-googleanalytics ~= 0.5",
+    "sphinx-lint == 1.0.2",
+    "sphinx-multiversion ~= 0.2.4",
+    "Sphinx ~= 7.4.7;python_version < '3.11'",
+    "Sphinx ~= 8.2.3;python_version >= '3.11'",
 ]
 lint = [
-    "ruff==0.15.14",
+    "ruff == 0.15.14",
 ]
 pre-commit = [
-    "pre-commit~=4.6.0",
+    "pre-commit ~= 4.6.0",
 ]
 security = [
-    "bandit[sarif]==1.9.4",
+    "bandit[sarif] == 1.9.4",
 ]
 test-coverage = [
-    "coverage>=7.13.3,<7.15.0",
-    "pytest-cov>=7.0,<7.2",
+    "coverage >= 7.13.3, <7.15.0",
+    "pytest-cov >= 7.0, <7.2",
     {include-group = "test"},
 ]
 test = [
-    "pytest>=9.0.3,<9.2.0",
-    "pytest-datadir~=1.8.0",
-    "pytest-mock~=3.15.1",
-    "pytest-recording~=0.13.4",
-    "pytest-xdist~=3.8.0",
-    "requests-mock~=1.12.1",
-    "testfixtures~=8.3.0;python_version<'3.11'",
-    "testfixtures~=9.1.0;python_version>='3.11'",
-    "dbt-duckdb>=1.8,<1.11",
+    "pytest >= 9.0.3, <9.2.0",
+    "pytest-datadir ~= 1.8.0",
+    "pytest-mock ~= 3.15.1",
+    "pytest-recording ~= 0.13.4",
+    "pytest-xdist ~= 3.8.0",
+    "requests-mock ~= 1.12.1",
+    "testfixtures ~= 8.3.0;python_version < '3.11'",
+    "testfixtures ~= 9.1.0;python_version >= '3.11'",
+    "dbt-duckdb >= 1.8, <1.11",
 ]
 
 [tool]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,34 +51,34 @@ catalist = ["paramiko >= 3.0"]
 civis = ["civis >= 2.0"]
 dbt-duckdb = [
     "dbt-duckdb >= 1.8",
-    "dbt-core >= 1.8;python_version < '3.14'",
-    "dbt-core >= 1.12;python_version >= '3.14'",
+    "dbt-core >= 1.8; python_version < '3.14'",
+    "dbt-core >= 1.12; python_version >= '3.14'",
     "rich >= 14.0"
 ]
 dbt-redshift = [
     "dbt-redshift >= 1.8",
-    "dbt-core >= 1.8;python_version < '3.14'",
-    "dbt-core >= 1.12;python_version >= '3.14'",
+    "dbt-core >= 1.8; python_version < '3.14'",
+    "dbt-core >= 1.12; python_version >= '3.14'",
     "lxml >= 6.0.1",
     "rich >= 14.0",
 ]
 dbt-bigquery = [
     "dbt-bigquery >= 1.8",
-    "dbt-core >= 1.8;python_version < '3.14'",
-    "dbt-core >= 1.12;python_version >= '3.14'",
+    "dbt-core >= 1.8; python_version < '3.14'",
+    "dbt-core >= 1.12; python_version >= '3.14'",
     "rich >= 14.0"
 ]
 dbt-postgres = [
     "dbt-postgres >= 1.8",
-    "dbt-core >= 1.8;python_version < '3.14'",
-    "dbt-core >= 1.12;python_version >= '3.14'",
+    "dbt-core >= 1.8; python_version < '3.14'",
+    "dbt-core >= 1.12; python_version >= '3.14'",
     "rich >= 14.0"
 ]
 dbt-snowflake = [
     "dbt-snowflake >= 1.8",
-    "dbt-core >= 1.8;python_version < '3.14'",
-    "dbt-core >= 1.12;python_version >= '3.14'",
-    "cryptography < 50;python_version < '3.11'",
+    "dbt-core >= 1.8; python_version < '3.14'",
+    "dbt-core >= 1.12; python_version >= '3.14'",
+    "cryptography < 50; python_version < '3.11'",
     "rich >= 14.0"
 ]
 facebook = [
@@ -202,8 +202,8 @@ docs = [
     "sphinxcontrib-googleanalytics ~= 0.5",
     "sphinx-lint == 1.0.2",
     "sphinx-multiversion ~= 0.2.4",
-    "Sphinx ~= 7.4.7;python_version < '3.11'",
-    "Sphinx ~= 8.2.3;python_version >= '3.11'",
+    "Sphinx ~= 7.4.7; python_version < '3.11'",
+    "Sphinx ~= 8.2.3; python_version >= '3.11'",
 ]
 lint = [
     "ruff == 0.15.14",
@@ -226,8 +226,8 @@ test = [
     "pytest-recording ~= 0.13.4",
     "pytest-xdist ~= 3.8.0",
     "requests-mock ~= 1.12.1",
-    "testfixtures ~= 8.3.0;python_version < '3.11'",
-    "testfixtures ~= 9.1.0;python_version >= '3.11'",
+    "testfixtures ~= 8.3.0; python_version < '3.11'",
+    "testfixtures ~= 9.1.0; python_version >= '3.11'",
     "dbt-duckdb >= 1.8, <1.11",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ dbt-postgres = [
     "rich >= 14.0"
 ]
 dbt-snowflake = [
-    "dbt-snowflake >= 1.8",
+    "dbt-snowflake >= 1.8,<1.12;python_version<'3.11'",
+    "dbt-snowflake >= 1.8;python_version>='3.11'",
     "dbt-core>=1.8;python_version<'3.14'",
     "dbt-core>=1.12;python_version>='3.14'",
     "rich >= 14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dbt-snowflake = [
     "dbt-snowflake >= 1.8",
     "dbt-core >= 1.8; python_version < '3.14'",
     "dbt-core >= 1.12; python_version >= '3.14'",
-    "cryptography < 50; python_version < '3.11'",
+    "cryptography >= 38, < 50; python_version < '3.11'",
     "rich >= 14.0"
 ]
 facebook = [


### PR DESCRIPTION
Thanks to @matthewkrausse for pointing out the issue.

## What is this change?

- Installing the latest version of dbt-snowflake results in the installation of cryptography 50.0.0 which is causing issues with some Google connectors when using python 3.10 on all platforms and (on windows) python 3.14. I assume this is due to google-auth which relies on the cryptography package.
This PR restricts python 3.10 to `cryptography >=38, < 50`. As this incompatibility is not mentioned in any changelogs I have found, hopefully this will be resolved upstream and we can remove this constraint later.
- Improves consistency of dependency syntax with spaces around all operators

## Considerations for discussion

- An alternate solution is limiting dbt-snowflake to 1.11, but since cryptography is the actual culprit and it's breaking connectors that don't relate to dbt-snowflake, this seemed like a better solution.

## How to test the changes (if needed)

- ci tests pass

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
