### PR TITLE
Fix typo in datetime.py

### DIFF
--- a/parsons/utilities/datetime.py
+++ b/parsons/utilities/datetime.py
@@ -29,10 +29,9 @@ def date_to_timestamp(value, tzinfo=datetime.timezone.utc):
 
 def convert_unix_to_readable(ts):
     """Converts UNIX timestamps to readable timestamps."""
-    ts = datetime.utcfromtimestamp(int(ts) / 1000)
-    ts = ts.strftime("%Y-%m-%d %H:%M:%S UTC")
+    ts = datetime.datetime.fromtimestamp(int(ts) / 1000, tz=datetime.timezone.utc)
 
-    return ts
+    return ts.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
 def parse_date(value: int | str | datetime.datetime, tzinfo=datetime.timezone.utc):

--- a/parsons/utilities/datetime.py
+++ b/parsons/utilities/datetime.py
@@ -3,14 +3,15 @@ import datetime
 from dateutil.parser import parse
 
 
-def date_to_timestamp(value, tzinfo=datetime.timezone.utc):
+def date_to_timestamp(value, tzinfo: datetime.timezone = datetime.timezone.utc) -> int | None:
     """Convert any date value into a Unix timestamp.
 
     Args:
-        value: int or str or datetime
+        value:
             Value to parse
-        tzinfo: datetime.timezone
-            `Optional`: Timezone for the datetime; defaults to UTC.
+        tzinfo:
+            Timezone for the datetime.
+            Defaults to UTC.
 
     Returns:
         Unix timestamp (int)
@@ -27,27 +28,32 @@ def date_to_timestamp(value, tzinfo=datetime.timezone.utc):
     return int(parsed_date.timestamp())
 
 
-def convert_unix_to_readable(ts):
+def convert_unix_to_readable(ts) -> str:
     """Converts UNIX timestamps to readable timestamps."""
     ts = datetime.datetime.fromtimestamp(int(ts) / 1000, tz=datetime.timezone.utc)
 
     return ts.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
-def parse_date(value: int | str | datetime.datetime, tzinfo=datetime.timezone.utc):
-    """Parse an arbitrary date value into a Python datetime.
+def parse_date(
+    value: int | str | datetime.datetime, tzinfo: datetime.timezone = datetime.timezone.utc
+) -> datetime.datetime | None:
+    """
+    Parse an arbitrary date value into a Python datetime.
 
-    If no value is provided (i.e., the value is None or empty), then the return value will be
-    None.
+    If no value is provided (i.e., the value is None or empty),
+    then the return value will be None.
 
     Args:
-        value: int or str or datetime
+        value:
             Value to parse
-        tzinfo: datetime.timezone
-            `Optional`: Timezone for the datetime; defaults to UTC.
+        tzinfo:
+            Timezone for the datetime.
+            Defaults to UTC.
 
-    Returns:
-        datetime.datetime or None
+    Raises:
+        TypeError:
+            If the value is not a string, int, or datetime.
 
     """
     if not value:


### PR DESCRIPTION
## What is this change?

- A call in datetime.py was written `datetime.utcfromtimestamp` but needs to be `datetime.datetime.utcfromtimestamp`
- I took the opportunity to improve type hinting and documentation
- I also switched from `datetime.utcfromtimestamp(n)` to `datetime.fromtimestamp(n, tz=timezone.utc)` [which is preferred](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp)

## Considerations for discussion

- (List out any significant design decisions that were made and why.)

## How to test the changes (if needed)

- (How should a reviewer test this functionality.)

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
