### PR TITLE
Redshift Query Method Support for Dictionary Params

### DIFF
--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -5,7 +5,7 @@ import pickle
 import random
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import petl
 import psycopg2
@@ -152,13 +152,13 @@ class Redshift(
         finally:
             cur.close()
 
-    def query(self, sql: str, parameters: list | None = None) -> Table | None:
+    def query(self, sql: str, parameters: list[Any] | dict[str, Any] | None = None) -> Table | None:
         """
         Execute a query against the Redshift database. Will return ``None``
         if the query returns zero rows.
 
         To include python variables in your query, it is recommended to pass them as parameters,
-        following the `psycopg style <http://initd.org/psycopg/docs/usage.html#passing-parameters-to-sql-queries>`_.
+        following the `https://www.psycopg.org/docs/usage.html#passing-parameters-to-sql-queries`.
         Using the ``parameters`` argument ensures that values are escaped properly, and avoids SQL
         injection attacks.
 
@@ -179,11 +179,18 @@ class Redshift(
             sql = f"SELECT * FROM my_table WHERE name IN ({placeholders})"
             rs.query(sql, parameters=names)
 
-        Args:
+        .. code-block:: python
+
+            name = "Beatrice O'Brady"
+            sql = "SELECT * FROM my_table WHERE name = %(name)s"
+            rs.query(sql, parameters={"name": name})
+
+        `Args:`
             sql: str
                 A valid SQL statement
-            parameters: list
-                A list of python variables to be converted into SQL values in your query
+            parameters: list | dict[str, Any]
+                A list of python variables to be converted into SQL values in your query.
+                Or a dict.
 
         Returns:
             Table
@@ -193,7 +200,13 @@ class Redshift(
         with self.connection() as connection:
             return self.query_with_connection(sql, connection, parameters=parameters)
 
-    def query_with_connection(self, sql, connection, parameters=None, commit=True):
+    def query_with_connection(
+        self,
+        sql,
+        connection,
+        parameters: list[Any] | dict[str, Any] | None = None,
+        commit=True,
+    ):
         """
         Execute a query against the Redshift database, with an existing connection.
         Useful for batching queries together. Will return ``None`` if the query
@@ -204,8 +217,8 @@ class Redshift(
                 A valid SQL statement
             connection: obj
                 A connection object obtained from ``redshift.connection()``
-            parameters: list
-                A list of python variables to be converted into SQL values in your query
+            parameters: list | dict
+                A list of python variables to be converted into SQL values in your query.
             commit: boolean
                 Whether to commit the transaction immediately. If ``False`` the transaction will
                 be committed when the connection goes out of scope and is closed (or you can

--- a/parsons/databases/redshift/redshift.py
+++ b/parsons/databases/redshift/redshift.py
@@ -158,7 +158,7 @@ class Redshift(
         if the query returns zero rows.
 
         To include python variables in your query, it is recommended to pass them as parameters,
-        following the `https://www.psycopg.org/docs/usage.html#passing-parameters-to-sql-queries`.
+        following the documentation for `passing parameters to SQL queries <https://www.psycopg.org/docs/usage.html#passing-parameters-to-sql-queries>`__.
         Using the ``parameters`` argument ensures that values are escaped properly, and avoids SQL
         injection attacks.
 

--- a/test/test_redshift/test_redshift.py
+++ b/test/test_redshift/test_redshift.py
@@ -468,6 +468,11 @@ class TestRedshiftDB(unittest.TestCase):
         r = self.rs.query(sql, parameters=names)
         assert r.num_rows == 2
 
+        sql = f"select * from {table_name} where name = %s"
+        name = "Sarah"
+        r = self.rs.query(sql, parameters={"name": name})
+        assert r[0]["name"] == name
+
     def test_schema_exists(self):
         assert self.rs.schema_exists(self.temp_schema)
         assert not self.rs.schema_exists("nonsense")


### PR DESCRIPTION
## What is this change?

- Adding support for `dict`-type params for the Parsons Redshift.query method.

## Considerations for discussion

- Psycopg supports these param types: https://www.psycopg.org/docs/usage.html#passing-parameters-to-sql-queries

## How to test the changes (if needed)

- Use the method to query against a Redshift instance.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- n/a
