### PR TITLE
Forward return_type in CensusGeocoder.geocode_address

### DIFF
--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -81,7 +81,9 @@ class CensusGeocoder:
             dict
 
         """
-        geo = self.cg.address(address_line, city=city, state=state, zipcode=zipcode)
+        geo = self.cg.address(
+            address_line, city=city, state=state, zipcode=zipcode, returntype=return_type
+        )
         self._log_result(geo)
         return geo
 

--- a/test/test_geocode/test_census_geocoder.py
+++ b/test/test_geocode/test_census_geocoder.py
@@ -43,11 +43,25 @@ def test_geocode_address(cg):
     # Assert one line with geographies parameter returns expected
     cg.cg.address = mock.MagicMock(return_value=geographies_resp)
     geo = cg.geocode_address(**passed_address, return_type="geographies")
+    cg.cg.address.assert_called_with(
+        passed_address["address_line"],
+        city=passed_address["city"],
+        state=passed_address["state"],
+        zipcode=None,
+        returntype="geographies",
+    )
     assert geo == geographies_resp
 
     # Assert one line with locations parameter returns expected
     cg.cg.address = mock.MagicMock(return_value=locations_resp)
     geo = cg.geocode_address(**passed_address, return_type="locations")
+    cg.cg.address.assert_called_with(
+        passed_address["address_line"],
+        city=passed_address["city"],
+        state=passed_address["state"],
+        zipcode=None,
+        returntype="locations",
+    )
     assert geo == locations_resp
 
 


### PR DESCRIPTION
## What is this change?

- `CensusGeocoder.geocode_address` accepted a `return_type` argument and never passed it on, so
  `censusgeocode` always fell back to its `"geographies"` default and a caller asking for
  `"locations"` silently received geographies data. The sibling `geocode_onelineaddress` already
  forwards it.
- `test_geocode_address` now asserts the call arguments as well as the return value, which is what
  the sibling test already did and why this went unnoticed.
- Fixes #1929.

## Considerations for discussion

- No change to the return type. Both return types produce `result.addressMatches` for the
  `address` searchtype, so `censusgeocode` builds an `AddressResult` either way -- only the
  presence of the nested `geographies` key on each match differs. `GeographyResult` is returned
  only by the `coordinates` searchtype, which this PR does not touch.
- The one behavior change is that `return_type="locations"` now returns matches without that
  nested `geographies` key, which is what the parameter has always been documented to do.

## How to test the changes (if needed)

```
uv run --no-default-groups --group test --extra geocode pytest test/test_geocode
```

To confirm against the live API, `geocode_address(..., return_type="locations")` should now return
matches with no `"geographies"` key, matching `geocode_onelineaddress` with the same argument.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- No signature or return-type change. Code passing `return_type="geographies"` (the default) is
  unaffected. Only code that passed `"locations"` and then read the nested `"geographies"` key --
  i.e. code relying on the bug -- would need to switch to `"geographies"` explicitly.
