### PR TITLE
Add a request timeout to CensusGeocoder

### DIFF
--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -25,11 +25,16 @@ class CensusGeocoder:
         vintage: str
             The US Census vintage file to utilize. By default the current vintage is used, but
             other options can be found `here <https://geocoding.geo.census.gov/geocoder/vintages?form>`__.
+        timeout: float
+            Seconds to wait for a response from the Census API before raising
+            ``requests.exceptions.Timeout``. Applies to every request this class makes.
+            By default no timeout is set, and a request can block indefinitely.
 
     """
 
-    def __init__(self, benchmark="Public_AR_Current", vintage="Current_Current"):
+    def __init__(self, benchmark="Public_AR_Current", vintage="Current_Current", timeout=None):
         self.cg = censusgeocode.CensusGeocode(benchmark=benchmark, vintage=vintage)
+        self.timeout = timeout
 
     def geocode_onelineaddress(self, address, return_type="geographies"):
         """
@@ -48,7 +53,7 @@ class CensusGeocoder:
             dict
 
         """
-        geo = self.cg.onelineaddress(address, returntype=return_type)
+        geo = self.cg.onelineaddress(address, returntype=return_type, timeout=self.timeout)
         self._log_result(geo)
         return geo
 
@@ -81,7 +86,9 @@ class CensusGeocoder:
             dict
 
         """
-        geo = self.cg.address(address_line, city=city, state=state, zipcode=zipcode)
+        geo = self.cg.address(
+            address_line, city=city, state=state, zipcode=zipcode, timeout=self.timeout
+        )
         self._log_result(geo)
         return geo
 
@@ -122,7 +129,9 @@ class CensusGeocoder:
 
         geocoded_tbl = Table([[]])
         for tbl in chunked_tables:
-            geocoded_tbl.concat(Table(petl.fromdicts(self.cg.addressbatch(tbl))))
+            geocoded_tbl.concat(
+                Table(petl.fromdicts(self.cg.addressbatch(tbl, timeout=self.timeout)))
+            )
             records_processed += tbl.num_rows
             logger.info(f"{records_processed} of {table.num_rows} records processed.")
 
@@ -145,7 +154,7 @@ class CensusGeocoder:
             longitude: A valid longitude in the United States
 
         """
-        geo = self.cg.coordinates(x=longitude, y=latitude)
+        geo = self.cg.coordinates(x=longitude, y=latitude, timeout=self.timeout)
         if len(geo["States"]) == 0:
             logger.info("Coordinate not found.")
         else:

--- a/test/test_geocode/test_census_geocoder.py
+++ b/test/test_geocode/test_census_geocoder.py
@@ -22,13 +22,13 @@ def test_geocode_onelineaddress(cg):
     # Assert one line with geographies parameter returns expected
     cg.cg.onelineaddress = mock.MagicMock(return_value=geographies_resp)
     geo = cg.geocode_onelineaddress(address, return_type="geographies")
-    cg.cg.onelineaddress.assert_called_with(address, returntype="geographies")
+    cg.cg.onelineaddress.assert_called_with(address, returntype="geographies", timeout=None)
     assert geo == geographies_resp
 
     # Assert one line with locations parameter returns expected
     cg.cg.onelineaddress = mock.MagicMock(return_value=locations_resp)
     geo = cg.geocode_onelineaddress(address, return_type="locations")
-    cg.cg.onelineaddress.assert_called_with(address, returntype="locations")
+    cg.cg.onelineaddress.assert_called_with(address, returntype="locations", timeout=None)
     assert geo == locations_resp
 
 
@@ -74,3 +74,31 @@ def test_coordinates(cg):
     cg.cg.address = mock.MagicMock(return_value=coord_resp)
     geo = cg.get_coordinates_data("38.8884212", "-77.0441907")
     assert geo == coord_resp
+
+
+def test_timeout_forwarded_to_every_request():
+    cg = CensusGeocoder(timeout=30)
+    cg.cg = mock.MagicMock()
+    cg.cg.onelineaddress = mock.MagicMock(return_value=geographies_resp)
+    cg.cg.address = mock.MagicMock(return_value=geographies_resp)
+    cg.cg.coordinates = mock.MagicMock(return_value={"States": [{}]})
+    cg.cg.addressbatch = mock.MagicMock(return_value=batch_resp)
+
+    cg.geocode_onelineaddress("1600 Pennsylvania Avenue, Washington, DC")
+    assert cg.cg.onelineaddress.call_args.kwargs["timeout"] == 30
+
+    cg.geocode_address("1600 Pennsylvania Avenue", city="Washington", state="DC")
+    assert cg.cg.address.call_args.kwargs["timeout"] == 30
+
+    cg.get_coordinates_data("38.8884212", "-77.0441907")
+    assert cg.cg.coordinates.call_args.kwargs["timeout"] == 30
+
+    cg.geocode_address_batch(
+        Table(
+            [
+                ["id", "street", "city", "state", "zip"],
+                ["1", "908 N Washtenaw", "Chicago", "IL", "60622"],
+            ]
+        )
+    )
+    assert cg.cg.addressbatch.call_args.kwargs["timeout"] == 30


### PR DESCRIPTION
## What is this change?

- `CensusGeocoder` made every request with no timeout. `censusgeocode` passes
  `timeout=kwargs.get("timeout")` through to `requests`, and Parsons never supplied one, so all
  four public methods reached `requests` with `timeout=None`. A stalled Census endpoint blocks the
  caller indefinitely with no way to opt out.
- Adds a `timeout` constructor argument and forwards it to `onelineaddress`, `address`,
  `addressbatch` and `coordinates`.
- Fixes #1930.

## Considerations for discussion

- **The default is `None`, which preserves today's behavior exactly** -- `timeout=None` is
  precisely what `requests` already received, so nothing changes for existing callers. The
  parameter makes it possible to set a timeout, which is currently impossible.
- Other connectors ship a real default instead (`Redshift`, `Postgres` and `MySQL` use
  `timeout=10`; `Braintree` uses 200). I did not pick one here because a batch of up to
  `BATCH_SIZE` addresses can legitimately run long and I have no data on a safe ceiling. If you
  would rather this shipped with a real default, say the number and I will change it.
- Put on the constructor rather than each method, matching those same connectors.

## How to test the changes (if needed)

```
uv run --no-default-groups --group test --extra geocode pytest test/test_geocode
```

`test_timeout_forwarded_to_every_request` covers all four methods. To confirm at the wire, patch
`requests.get` / `requests.post` and check the `timeout` keyword: `CensusGeocoder()` sends
`None` as before, `CensusGeocoder(timeout=30)` sends `30`.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- New optional keyword argument with a default that reproduces the previous call exactly. No
  signature change for existing callers, no return-type change.
