### PR TITLE
Optionally return completed chunks when a batch geocode fails

### DIFF
--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -85,7 +85,7 @@ class CensusGeocoder:
         self._log_result(geo)
         return geo
 
-    def geocode_address_batch(self, table):
+    def geocode_address_batch(self, table, return_partial_on_error=False):
         """
         Geocode multiple addresses from a parsons table.
 
@@ -105,6 +105,12 @@ class CensusGeocoder:
         Args:
             table: Parsons Table
                 A Parsons table
+            return_partial_on_error: bool
+                If ``True``, a chunk that fails ends the run and returns the rows geocoded up to
+                that point instead of raising. The failed chunk and every chunk after it are
+                absent from the result, so compare the row count against the input. By default
+                the error is raised and all completed work is discarded.
+
         Returns:
             A Parsons table
 
@@ -122,7 +128,16 @@ class CensusGeocoder:
 
         geocoded_tbl = Table([[]])
         for tbl in chunked_tables:
-            geocoded_tbl.concat(Table(petl.fromdicts(self.cg.addressbatch(tbl))))
+            try:
+                geocoded_tbl.concat(Table(petl.fromdicts(self.cg.addressbatch(tbl))))
+            except Exception as error:
+                if not return_partial_on_error:
+                    raise
+                logger.error(
+                    f"Geocoding failed after {records_processed} of {table.num_rows} records "
+                    f"({error}). Returning the records geocoded so far."
+                )
+                return geocoded_tbl
             records_processed += tbl.num_rows
             logger.info(f"{records_processed} of {table.num_rows} records processed.")
 

--- a/test/test_geocode/test_census_geocoder.py
+++ b/test/test_geocode/test_census_geocoder.py
@@ -2,8 +2,10 @@ from unittest import mock
 
 import petl
 import pytest
+import requests
 
 from parsons import CensusGeocoder, Table
+from parsons.geocode import census_geocoder
 from test.conftest import assert_matching_tables
 
 from .test_responses import batch_resp, coord_resp, geographies_resp, locations_resp
@@ -74,3 +76,64 @@ def test_coordinates(cg):
     cg.cg.address = mock.MagicMock(return_value=coord_resp)
     geo = cg.get_coordinates_data("38.8884212", "-77.0441907")
     assert geo == coord_resp
+
+
+BATCH_HEADER = ["id", "street", "city", "state", "zip"]
+
+
+def _batch_table(n):
+    return Table(
+        [BATCH_HEADER]
+        + [[str(i), f"{i} Main St", "Chicago", "IL", "60622"] for i in range(1, n + 1)]
+    )
+
+
+def test_batch_raises_and_loses_work_by_default(cg):
+    calls = {"n": 0}
+
+    def flaky(tbl, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise requests.exceptions.ConnectionError("chunk 3 died")
+        return batch_resp
+
+    cg.cg.addressbatch = flaky
+
+    with (
+        mock.patch.object(census_geocoder, "BATCH_SIZE", 2),
+        pytest.raises(requests.exceptions.ConnectionError),
+    ):
+        cg.geocode_address_batch(_batch_table(6))
+
+    assert calls["n"] == 3
+
+
+def test_batch_returns_completed_chunks_when_opted_in(cg):
+    calls = {"n": 0}
+
+    def flaky(tbl, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise requests.exceptions.ConnectionError("chunk 3 died")
+        return batch_resp
+
+    cg.cg.addressbatch = flaky
+
+    with mock.patch.object(census_geocoder, "BATCH_SIZE", 2):
+        geo = cg.geocode_address_batch(_batch_table(6), return_partial_on_error=True)
+
+    # two chunks completed before the failure, each returning the full batch fixture
+    assert geo.num_rows == 2 * len(batch_resp)
+    assert calls["n"] == 3
+
+
+def test_batch_partial_covers_non_request_errors(cg):
+    # A 5xx surfaces from censusgeocode as ValueError, not RequestException.
+    cg.cg.addressbatch = mock.MagicMock(
+        side_effect=[batch_resp, ValueError("Unable to parse response from Census")]
+    )
+
+    with mock.patch.object(census_geocoder, "BATCH_SIZE", 2):
+        geo = cg.geocode_address_batch(_batch_table(4), return_partial_on_error=True)
+
+    assert geo.num_rows == len(batch_resp)


### PR DESCRIPTION
## What is this change?

- `geocode_address_batch` accumulates into a local variable and lets any chunk failure propagate,
  so a job that dies on chunk N discards everything chunks 1..N-1 already geocoded. On a large
  table that is hours of work thrown away for one transient error.
- Adds `return_partial_on_error`, which logs the failure and returns the rows geocoded so far
  instead of raising.
- Fixes #1932.

## Considerations for discussion

- **The default is `False`, which preserves today's behavior exactly** -- the error is raised and
  completed work is discarded, as now. Callers opt in.
- **The catch is deliberately broad.** A Census 5xx does not arrive as a `RequestException`:
  `censusgeocode` never calls `raise_for_status()`, so it surfaces as
  `ValueError("Unable to parse response from Census")`. Catching only `RequestException` would
  miss the most common failure, so this catches `Exception` and re-raises when not opted in.
- **What is deliberately not decided here:** the returned table carries no marker separating
  "not attempted" from "Census found no match". Rows in the failed chunk and after are simply
  absent, so a caller compares the row count against the input. Reusing the existing `match`
  column would conflate a failed request with a genuine no-match, and a new status column changes
  the output schema. I would rather agree that shape with maintainers than pick one here.

## How to test the changes (if needed)

```
uv run --no-default-groups --group test --extra geocode pytest test/test_geocode
```

Three new tests: the default still raises and loses work, opting in returns the completed chunks,
and the opt-in path also covers the `ValueError` shape a 5xx takes.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- New optional keyword argument defaulting to `False`, which reproduces the current control flow
  exactly. No signature or return-type change for existing callers.
