### PR TITLE
Accept extra columns in geocode_address_batch

### DIFF
--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -13,6 +13,10 @@ logger = logging.getLogger(__name__)
 # the recommendation is less than 1K records.
 BATCH_SIZE = 999
 
+# The only columns the batch endpoint accepts. Anything else is dropped before sending,
+# since the underlying CSV writer rejects unknown fields.
+REQUIRED_BATCH_COLUMNS = ["id", "street", "city", "state", "zip"]
+
 
 class CensusGeocoder:
     """
@@ -89,7 +93,8 @@ class CensusGeocoder:
         """
         Geocode multiple addresses from a parsons table.
 
-        The table must **only** include the following columns in the following order.
+        The table must include the following columns. Any others are ignored, so a table can be
+        passed in whole rather than cut down first, and column order does not matter.
 
         .. list-table::
             :widths: 40
@@ -110,13 +115,15 @@ class CensusGeocoder:
 
         """
         logger.info(f"Geocoding {table.num_rows} records.")
-        if set(table.columns) != {"id", "street", "city", "state", "zip"}:
+        missing = [column for column in REQUIRED_BATCH_COLUMNS if column not in table.columns]
+        if missing:
             msg = (
-                "Table must ONLY include `['id', 'street', 'city', 'state', 'zip']` as"
-                "columns. Tip: try using `table.cut()`"
+                f"Table is missing required columns: {missing}. It must include "
+                f"{REQUIRED_BATCH_COLUMNS}; any other columns are ignored."
             )
             raise ValueError(msg)
 
+        table = table.cut(*REQUIRED_BATCH_COLUMNS)
         chunked_tables = table.chunk(BATCH_SIZE)
         records_processed = 0
 

--- a/test/test_geocode/test_census_geocoder.py
+++ b/test/test_geocode/test_census_geocoder.py
@@ -4,6 +4,7 @@ import petl
 import pytest
 
 from parsons import CensusGeocoder, Table
+from parsons.geocode.census_geocoder import REQUIRED_BATCH_COLUMNS
 from test.conftest import assert_matching_tables
 
 from .test_responses import batch_resp, coord_resp, geographies_resp, locations_resp
@@ -74,3 +75,50 @@ def test_coordinates(cg):
     cg.cg.address = mock.MagicMock(return_value=coord_resp)
     geo = cg.get_coordinates_data("38.8884212", "-77.0441907")
     assert geo == coord_resp
+
+
+def test_batch_accepts_extra_columns_and_drops_them(cg):
+    """Extra columns are ignored, so callers need not cut their source table."""
+    sent = []
+
+    def capture(tbl, **kwargs):
+        sent.append(tbl.columns)
+        return batch_resp
+
+    cg.cg.addressbatch = capture
+    source = Table(
+        [
+            ["id", "street", "city", "state", "zip", "voterid", "notes"],
+            ["1", "908 N Washtenaw", "Chicago", "IL", "60622", "V9", "keep me"],
+        ]
+    )
+
+    cg.geocode_address_batch(source)
+
+    assert sent == [REQUIRED_BATCH_COLUMNS]
+    # the caller's table is untouched, so the join back to source rows survives
+    assert source.columns == ["id", "street", "city", "state", "zip", "voterid", "notes"]
+
+
+def test_batch_accepts_columns_in_any_order(cg):
+    sent = []
+
+    def capture(tbl, **kwargs):
+        sent.append(tbl.columns)
+        return batch_resp
+
+    cg.cg.addressbatch = capture
+    cg.geocode_address_batch(
+        Table([["zip", "state", "city", "street", "id"], ["60622", "IL", "Chicago", "908 N", "1"]])
+    )
+
+    assert sent == [REQUIRED_BATCH_COLUMNS]
+
+
+def test_batch_still_rejects_missing_columns(cg):
+    cg.cg.addressbatch = mock.MagicMock(return_value=batch_resp)
+
+    with pytest.raises(ValueError, match="missing required columns"):
+        cg.geocode_address_batch(Table([["id", "street", "city"], ["1", "908 N", "Chicago"]]))
+
+    cg.cg.addressbatch.assert_not_called()


### PR DESCRIPTION
## What is this change?

- `geocode_address_batch` rejected any table whose columns were not *exactly*
  `['id', 'street', 'city', 'state', 'zip']`, with the error suggesting `table.cut()`. Cutting
  discards every other column, which is usually how a caller joins the geocoded output back to
  their source rows.
- The five columns are still required; anything else is now dropped internally before the request
  instead of being rejected. The caller's table is not modified.
- Also corrects the docstring's claim that columns must be "in the following order" -- see below.
- Fixes #1935, and addresses #729.

## Considerations for discussion

- **Extra columns are dropped, not passed through to the output.** The output schema is therefore
  unchanged. Passing extras through would be more useful but changes the returned column set, so
  it seemed better to agree that separately rather than fold it in here.
- **Why the drop is needed at all:** the batch request is built by a `csv.DictWriter` with fixed
  `fieldnames`, so an unknown key raises `ValueError: dict contains fields not in fieldnames`.
  Parsons has to cut before sending; the change is only about who is made to do it.
- **The documented column order was never real.** `DictWriter` writes by field name, and a table
  with the five columns shuffled produces byte-identical CSV. The docstring said otherwise, so it
  is corrected here.
- A missing required column still raises, now naming which ones are missing.

## How to test the changes (if needed)

```
uv run --no-default-groups --group test --extra geocode pytest test/test_geocode
```

Three new tests: extra columns are dropped before the request and the caller's table is left
intact, the five columns are accepted in any order, and a table missing a required column still
raises without making a request.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- Strictly more permissive: every table accepted before is still accepted and produces identical
  output. Only the set of inputs that previously raised `ValueError` has shrunk. No signature or
  return-type change.
