### PR TITLE
Add optional retry for transient CensusGeocoder failures

### DIFF
--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -1,8 +1,10 @@
 import logging
+import time
 
 import censusgeocode
 import petl
 from censusgeocode.censusgeocode import GeographyResult
+from requests.exceptions import RequestException
 
 from parsons import Table
 
@@ -25,11 +27,35 @@ class CensusGeocoder:
         vintage: str
             The US Census vintage file to utilize. By default the current vintage is used, but
             other options can be found `here <https://geocoding.geo.census.gov/geocoder/vintages?form>`__.
+        retries: int
+            Number of additional attempts to make when a request fails with a transient
+            network error, waiting ``2 ** attempt`` seconds in between. Only connection-level
+            failures are retried; the Census API's own error responses do not raise. By
+            default no retry is attempted.
 
     """
 
-    def __init__(self, benchmark="Public_AR_Current", vintage="Current_Current"):
+    def __init__(self, benchmark="Public_AR_Current", vintage="Current_Current", retries=0):
+        if retries < 0:
+            msg = f"retries must be 0 or greater, got {retries}"
+            raise ValueError(msg)
         self.cg = censusgeocode.CensusGeocode(benchmark=benchmark, vintage=vintage)
+        self.retries = retries
+
+    def _request(self, func, *args, **kwargs):
+        # Retries transient network failures only; see the class docstring for the limits.
+        for attempt in range(self.retries + 1):
+            try:
+                return func(*args, **kwargs)
+            except RequestException as error:
+                if attempt == self.retries:
+                    raise
+                wait = 2**attempt
+                logger.warning(
+                    f"Census request failed with {type(error).__name__}; retrying in "
+                    f"{wait}s ({attempt + 1} of {self.retries})."
+                )
+                time.sleep(wait)
 
     def geocode_onelineaddress(self, address, return_type="geographies"):
         """
@@ -48,7 +74,7 @@ class CensusGeocoder:
             dict
 
         """
-        geo = self.cg.onelineaddress(address, returntype=return_type)
+        geo = self._request(self.cg.onelineaddress, address, returntype=return_type)
         self._log_result(geo)
         return geo
 
@@ -81,7 +107,7 @@ class CensusGeocoder:
             dict
 
         """
-        geo = self.cg.address(address_line, city=city, state=state, zipcode=zipcode)
+        geo = self._request(self.cg.address, address_line, city=city, state=state, zipcode=zipcode)
         self._log_result(geo)
         return geo
 
@@ -122,7 +148,7 @@ class CensusGeocoder:
 
         geocoded_tbl = Table([[]])
         for tbl in chunked_tables:
-            geocoded_tbl.concat(Table(petl.fromdicts(self.cg.addressbatch(tbl))))
+            geocoded_tbl.concat(Table(petl.fromdicts(self._request(self.cg.addressbatch, tbl))))
             records_processed += tbl.num_rows
             logger.info(f"{records_processed} of {table.num_rows} records processed.")
 
@@ -145,7 +171,7 @@ class CensusGeocoder:
             longitude: A valid longitude in the United States
 
         """
-        geo = self.cg.coordinates(x=longitude, y=latitude)
+        geo = self._request(self.cg.coordinates, x=longitude, y=latitude)
         if len(geo["States"]) == 0:
             logger.info("Coordinate not found.")
         else:

--- a/test/test_geocode/test_census_geocoder.py
+++ b/test/test_geocode/test_census_geocoder.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import petl
 import pytest
+import requests
 
 from parsons import CensusGeocoder, Table
 from test.conftest import assert_matching_tables
@@ -74,3 +75,86 @@ def test_coordinates(cg):
     cg.cg.address = mock.MagicMock(return_value=coord_resp)
     geo = cg.get_coordinates_data("38.8884212", "-77.0441907")
     assert geo == coord_resp
+
+
+def test_retry_recovers_from_transient_failure():
+    cg = CensusGeocoder(retries=3)
+    cg.cg = mock.MagicMock()
+    cg.cg.onelineaddress = mock.MagicMock(
+        side_effect=[
+            requests.exceptions.ConnectionError("reset"),
+            requests.exceptions.Timeout("slow"),
+            geographies_resp,
+        ]
+    )
+
+    with mock.patch("parsons.geocode.census_geocoder.time.sleep") as sleep:
+        geo = cg.geocode_onelineaddress("1600 Pennsylvania Avenue, Washington, DC")
+
+    assert geo == geographies_resp
+    assert cg.cg.onelineaddress.call_count == 3
+    # exponential backoff: 2 ** attempt
+    assert [call.args[0] for call in sleep.call_args_list] == [1, 2]
+
+
+def test_retry_reraises_once_exhausted():
+    cg = CensusGeocoder(retries=2)
+    cg.cg = mock.MagicMock()
+    cg.cg.onelineaddress = mock.MagicMock(side_effect=requests.exceptions.ConnectionError("down"))
+
+    with (
+        mock.patch("parsons.geocode.census_geocoder.time.sleep"),
+        pytest.raises(requests.exceptions.ConnectionError),
+    ):
+        cg.geocode_onelineaddress("1600 Pennsylvania Avenue, Washington, DC")
+
+    assert cg.cg.onelineaddress.call_count == 3
+
+
+def test_no_retry_by_default(cg):
+    cg.cg = mock.MagicMock()
+    cg.cg.onelineaddress = mock.MagicMock(side_effect=requests.exceptions.ConnectionError("down"))
+
+    with (
+        mock.patch("parsons.geocode.census_geocoder.time.sleep") as sleep,
+        pytest.raises(requests.exceptions.ConnectionError),
+    ):
+        cg.geocode_onelineaddress("1600 Pennsylvania Avenue, Washington, DC")
+
+    assert cg.cg.onelineaddress.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_retry_applies_to_every_method():
+    cg = CensusGeocoder(retries=1)
+    cg.cg = mock.MagicMock()
+    cg.cg.address = mock.MagicMock(
+        side_effect=[requests.exceptions.ConnectionError("x"), geographies_resp]
+    )
+    cg.cg.coordinates = mock.MagicMock(
+        side_effect=[requests.exceptions.ConnectionError("x"), {"States": [{}]}]
+    )
+    cg.cg.addressbatch = mock.MagicMock(
+        side_effect=[requests.exceptions.ConnectionError("x"), batch_resp]
+    )
+
+    with mock.patch("parsons.geocode.census_geocoder.time.sleep"):
+        cg.geocode_address("1600 Pennsylvania Avenue", city="Washington", state="DC")
+        cg.get_coordinates_data("38.8884212", "-77.0441907")
+        cg.geocode_address_batch(
+            Table(
+                [
+                    ["id", "street", "city", "state", "zip"],
+                    ["1", "908 N Washtenaw", "Chicago", "IL", "60622"],
+                ]
+            )
+        )
+
+    assert cg.cg.address.call_count == 2
+    assert cg.cg.coordinates.call_count == 2
+    assert cg.cg.addressbatch.call_count == 2
+
+
+def test_negative_retries_rejected():
+    with pytest.raises(ValueError, match="retries must be 0 or greater"):
+        CensusGeocoder(retries=-1)


### PR DESCRIPTION
## What is this change?

- `censusgeocode` re-raises `RequestException` and `CensusGeocoder` never caught it, so a single
  connection reset or timeout ended the whole call. For `geocode_address_batch` that means a long
  job dies partway through its chunks.
- Adds a `retries` constructor argument and a `_request` helper that retries connection-level
  failures with `2 ** attempt` backoff. The retry wraps the **per-chunk** call in
  `geocode_address_batch`, so completed chunks are never re-sent.
- Fixes #1931.

## Considerations for discussion

- **The default is `0`, which preserves today's behavior exactly.** Retrying by default would
  change request timing for every existing user and could multiply load on a government endpoint,
  so it seemed wrong to opt everyone in. `Newmode` defaults to 2 retries if you would rather this
  matched that.
- **Only `RequestException` is retried, and that is a real limit worth naming.** `censusgeocode`
  never calls `raise_for_status()`, so the Census API's own error responses do not raise: a 5xx
  reaches `_fetch` as a JSON decode failure and surfaces as
  `ValueError("Unable to parse response from Census")`, which is indistinguishable from a genuine
  parse problem. Retrying `ValueError` would therefore also retry real bugs, so I left it alone.
  Making HTTP status failures visible is a separate change and I have filed it separately.
- Put on the constructor rather than each method, matching `Redshift`, `Postgres`, `MySQL` and
  `Braintree`.

## How to test the changes (if needed)

```
uv run --no-default-groups --group test --extra geocode pytest test/test_geocode
```

Four new tests cover recovery after transient failures, re-raising once retries are exhausted,
the no-retry default, and that all four public methods are wrapped.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- New optional keyword argument defaulting to `0`, which makes exactly one attempt and never
  sleeps -- identical to current behavior. No signature or return-type change.
