### PR TITLE
Make the geocode batch size configurable

### DIFF
--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -9,8 +9,9 @@ from parsons import Table
 logger = logging.getLogger(__name__)
 
 
-# The size of batches to send to the batch geocode endpoint. Currently
-# the recommendation is less than 1K records.
+# Default number of records sent per batch geocode request. The Census documents an upper limit
+# of 10,000 records per batch file, and censusgeocode does no chunking of its own, so this
+# default is deliberately conservative. Override it with the ``batch_size`` argument.
 BATCH_SIZE = 999
 
 
@@ -25,11 +26,21 @@ class CensusGeocoder:
         vintage: str
             The US Census vintage file to utilize. By default the current vintage is used, but
             other options can be found `here <https://geocoding.geo.census.gov/geocoder/vintages?form>`__.
+        batch_size: int
+            Number of records sent per request by :meth:`geocode_address_batch`. The Census
+            documents an upper limit of 10,000 records per batch file. Defaults to
+            ``BATCH_SIZE``.
 
     """
 
-    def __init__(self, benchmark="Public_AR_Current", vintage="Current_Current"):
+    def __init__(
+        self, benchmark="Public_AR_Current", vintage="Current_Current", batch_size=BATCH_SIZE
+    ):
+        if batch_size < 1:
+            msg = f"batch_size must be 1 or greater, got {batch_size}"
+            raise ValueError(msg)
         self.cg = censusgeocode.CensusGeocode(benchmark=benchmark, vintage=vintage)
+        self.batch_size = batch_size
 
     def geocode_onelineaddress(self, address, return_type="geographies"):
         """
@@ -117,7 +128,7 @@ class CensusGeocoder:
             )
             raise ValueError(msg)
 
-        chunked_tables = table.chunk(BATCH_SIZE)
+        chunked_tables = table.chunk(self.batch_size)
         records_processed = 0
 
         geocoded_tbl = Table([[]])

--- a/test/test_geocode/test_census_geocoder.py
+++ b/test/test_geocode/test_census_geocoder.py
@@ -4,6 +4,7 @@ import petl
 import pytest
 
 from parsons import CensusGeocoder, Table
+from parsons.geocode.census_geocoder import BATCH_SIZE
 from test.conftest import assert_matching_tables
 
 from .test_responses import batch_resp, coord_resp, geographies_resp, locations_resp
@@ -74,3 +75,38 @@ def test_coordinates(cg):
     cg.cg.address = mock.MagicMock(return_value=coord_resp)
     geo = cg.get_coordinates_data("38.8884212", "-77.0441907")
     assert geo == coord_resp
+
+
+def _batch_table(n):
+    return Table(
+        [["id", "street", "city", "state", "zip"]]
+        + [[str(i), f"{i} Main St", "Chicago", "IL", "60622"] for i in range(1, n + 1)]
+    )
+
+
+def test_batch_size_defaults_to_module_constant(cg):
+    assert cg.batch_size == BATCH_SIZE
+
+    cg.cg.addressbatch = mock.MagicMock(return_value=batch_resp)
+    cg.geocode_address_batch(_batch_table(5))
+
+    # one chunk, because 5 records fit inside the default
+    assert cg.cg.addressbatch.call_count == 1
+
+
+def test_batch_size_controls_chunking():
+    cg = CensusGeocoder(batch_size=2)
+    cg.cg = mock.MagicMock()
+    cg.cg.addressbatch = mock.MagicMock(return_value=batch_resp)
+
+    cg.geocode_address_batch(_batch_table(5))
+
+    # 5 records at 2 per request -> 3 chunks
+    assert cg.cg.addressbatch.call_count == 3
+    assert [call.args[0].num_rows for call in cg.cg.addressbatch.call_args_list] == [2, 2, 1]
+
+
+@pytest.mark.parametrize("size", [0, -1])
+def test_non_positive_batch_size_rejected(size):
+    with pytest.raises(ValueError, match="batch_size must be 1 or greater"):
+        CensusGeocoder(batch_size=size)


### PR DESCRIPTION
## What is this change?

- `geocode_address_batch` chunked at a hardcoded `BATCH_SIZE = 999`, above a comment claiming
  "the recommendation is less than 1K records" with no source given.
- The Census documents an upper limit of **10,000** records per batch file. `censusgeocode` quotes
  that figure verbatim in `addressbatch`'s docstring ("there is currently an upper limit of 10,000
  records per batch file"), warns only above 10,001, and does no chunking of its own. So Parsons
  sends roughly ten times as many requests as the API requires.
- Adds a `batch_size` constructor argument and corrects the comment to cite the documented limit.
- Fixes #1933.

## Considerations for discussion

- **The default stays at `999`, so request volume is unchanged** unless a caller opts in. Whether
  that default should move toward 10,000 is your call, not mine -- I have no data on how the
  endpoint behaves near the limit, and the existing comment suggests someone may have had a reason
  that predates the current API docs. Happy to change it in this PR if you want it moved.
- Put on the constructor rather than on `geocode_address_batch`, matching `Redshift`, `Postgres`,
  `MySQL` and `Braintree`. A per-call argument would also be reasonable if you prefer that.
- `BATCH_SIZE` stays exported as the default, so anything importing it is unaffected.

## How to test the changes (if needed)

```
uv run --no-default-groups --group test --extra geocode pytest test/test_geocode
```

Two new tests: the default still equals `BATCH_SIZE` and chunks as before, and a configured
`batch_size` produces the expected chunk sizes.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- New optional keyword argument defaulting to the existing `BATCH_SIZE` constant. Same chunking,
  same request count, same output for every existing caller.
