### PR TITLE
Allow geocode_address_batch to send chunks in parallel

### DIFF
--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -1,4 +1,5 @@
 import logging
+from concurrent.futures import ThreadPoolExecutor
 
 import censusgeocode
 import petl
@@ -25,11 +26,19 @@ class CensusGeocoder:
         vintage: str
             The US Census vintage file to utilize. By default the current vintage is used, but
             other options can be found `here <https://geocoding.geo.census.gov/geocoder/vintages?form>`__.
+        workers: int
+            Number of batch chunks to geocode in parallel. Defaults to 1, which sends chunks
+            one at a time as before. Raising it increases the load placed on the Census API,
+            so leave it at 1 unless you have confirmed a higher rate is acceptable.
 
     """
 
-    def __init__(self, benchmark="Public_AR_Current", vintage="Current_Current"):
+    def __init__(self, benchmark="Public_AR_Current", vintage="Current_Current", workers=1):
+        if workers < 1:
+            msg = f"workers must be 1 or greater, got {workers}"
+            raise ValueError(msg)
         self.cg = censusgeocode.CensusGeocode(benchmark=benchmark, vintage=vintage)
+        self.workers = workers
 
     def geocode_onelineaddress(self, address, return_type="geographies"):
         """
@@ -120,9 +129,16 @@ class CensusGeocoder:
         chunked_tables = table.chunk(BATCH_SIZE)
         records_processed = 0
 
+        if self.workers > 1:
+            with ThreadPoolExecutor(max_workers=self.workers) as executor:
+                # map preserves input order, so the output row order is unchanged
+                results = list(executor.map(self.cg.addressbatch, chunked_tables))
+        else:
+            results = (self.cg.addressbatch(tbl) for tbl in chunked_tables)
+
         geocoded_tbl = Table([[]])
-        for tbl in chunked_tables:
-            geocoded_tbl.concat(Table(petl.fromdicts(self.cg.addressbatch(tbl))))
+        for tbl, result in zip(chunked_tables, results, strict=True):
+            geocoded_tbl.concat(Table(petl.fromdicts(result)))
             records_processed += tbl.num_rows
             logger.info(f"{records_processed} of {table.num_rows} records processed.")
 

--- a/test/test_geocode/test_census_geocoder.py
+++ b/test/test_geocode/test_census_geocoder.py
@@ -1,9 +1,11 @@
+import threading
 from unittest import mock
 
 import petl
 import pytest
 
 from parsons import CensusGeocoder, Table
+from parsons.geocode import census_geocoder
 from test.conftest import assert_matching_tables
 
 from .test_responses import batch_resp, coord_resp, geographies_resp, locations_resp
@@ -74,3 +76,67 @@ def test_coordinates(cg):
     cg.cg.address = mock.MagicMock(return_value=coord_resp)
     geo = cg.get_coordinates_data("38.8884212", "-77.0441907")
     assert geo == coord_resp
+
+
+def _batch_table(n):
+    return Table(
+        [["id", "street", "city", "state", "zip"]]
+        + [[str(i), f"{i} Main St", "Chicago", "IL", "60622"] for i in range(1, n + 1)]
+    )
+
+
+def test_default_is_sequential(cg):
+    assert cg.workers == 1
+    threads = set()
+
+    def record(tbl, **kwargs):
+        threads.add(threading.current_thread().name)
+        return batch_resp
+
+    cg.cg.addressbatch = record
+    with mock.patch.object(census_geocoder, "BATCH_SIZE", 2):
+        cg.geocode_address_batch(_batch_table(6))
+
+    assert threads == {threading.current_thread().name}
+
+
+def test_workers_run_chunks_in_parallel():
+    cg = CensusGeocoder(workers=3)
+    cg.cg = mock.MagicMock()
+    # every chunk must reach the barrier before any is released, so this only
+    # completes if the three chunks are genuinely in flight at the same time
+    barrier = threading.Barrier(3, timeout=10)
+    threads = set()
+
+    def blocking(tbl, **kwargs):
+        threads.add(threading.current_thread().name)
+        barrier.wait()
+        return batch_resp
+
+    cg.cg.addressbatch = blocking
+    with mock.patch.object(census_geocoder, "BATCH_SIZE", 2):
+        cg.geocode_address_batch(_batch_table(6))
+
+    assert threading.current_thread().name not in threads
+    assert len(threads) == 3
+
+
+def test_worker_output_preserves_input_order():
+    cg = CensusGeocoder(workers=3)
+    cg.cg = mock.MagicMock()
+
+    def per_chunk(tbl, **kwargs):
+        # echo the chunk's own ids back so ordering is observable
+        return [{"id": row["id"], "match": True} for row in tbl]
+
+    cg.cg.addressbatch = per_chunk
+    with mock.patch.object(census_geocoder, "BATCH_SIZE", 2):
+        geo = cg.geocode_address_batch(_batch_table(6))
+
+    assert [row["id"] for row in geo] == ["1", "2", "3", "4", "5", "6"]
+
+
+@pytest.mark.parametrize("count", [0, -1])
+def test_non_positive_workers_rejected(count):
+    with pytest.raises(ValueError, match="workers must be 1 or greater"):
+        CensusGeocoder(workers=count)


### PR DESCRIPTION
## What is this change?

- `geocode_address_batch` sent every chunk sequentially, so a large table waits on one round trip
  at a time.
- Adds a `workers` constructor argument. Above 1, chunks are sent through a `ThreadPoolExecutor`.
- Fixes #1934.

## Considerations for discussion

- **The default is 1 and I would argue it should stay 1.** Raising it increases the load Parsons
  places on a government API. That is a decision for whoever operates a given pipeline, not
  something users should inherit by upgrading.
- **The default path is unchanged, not merely equivalent.** With `workers=1` chunks are still
  requested lazily through a generator, one immediately before its result is concatenated, so
  request timing and interleaving with the progress log are identical to today.
- **Row order is preserved.** `Executor.map` yields results in input order, so the output table
  matches the input regardless of completion order.
- One behavior difference worth naming: with `workers > 1` all chunks are submitted before any
  result is consumed, so a failing chunk surfaces before any rows are concatenated. With
  `workers=1` the existing behavior is kept.

## How to test the changes (if needed)

```
uv run --no-default-groups --group test --extra geocode pytest test/test_geocode
```

Three new tests: the default runs entirely on the calling thread, `workers=3` genuinely runs three
chunks concurrently (enforced with a `threading.Barrier`, so it cannot pass by accident), and
output order matches input order.

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- New optional keyword argument defaulting to 1, which preserves the current sequential path. No
  signature or return-type change, and no change to output row order.
