### PR TITLE
fix: Preserve completed chunks when a batch geocoding chunk fails (closes #1932)

### DIFF
--- a/parsons/geocode/census_geocoder.py
+++ b/parsons/geocode/census_geocoder.py
@@ -122,7 +122,12 @@ class CensusGeocoder:
 
         geocoded_tbl = Table([[]])
         for tbl in chunked_tables:
-            geocoded_tbl.concat(Table(petl.fromdicts(self.cg.addressbatch(tbl))))
+            try:
+                chunk_result = Table(petl.fromdicts(self.cg.addressbatch(tbl)))
+            except Exception as e:
+                logger.warning(f"Failed to geocode chunk starting at record {records_processed+1}: {e}. Returning partial results.")
+                break
+            geocoded_tbl.concat(chunk_result)
             records_processed += tbl.num_rows
             logger.info(f"{records_processed} of {table.num_rows} records processed.")
 


### PR DESCRIPTION
## What
Previously, `geocode_address_batch` would lose all successfully geocoded chunks if any subsequent chunk raised an exception (e.g., a transient network error). On large tables this could mean hours of work lost.

## Fix
Wrap each chunk's geocoding call in a try/except. On failure, log a warning and return the partial results collected so far instead of raising and discarding everything. This preserves the completed portion and lets the caller decide how to handle incomplete data.

Closes #1932