### PR TITLE
check_env.check overload improvement

### DIFF
--- a/parsons/actblue/actblue.py
+++ b/parsons/actblue/actblue.py
@@ -48,10 +48,8 @@ class ActBlue:
         actblue_uri=None,
         max_retries=None,
     ):
-        self.actblue_client_uuid: str = check_env.check("ACTBLUE_CLIENT_UUID", actblue_client_uuid)
-        self.actblue_client_secret: str = check_env.check(
-            "ACTBLUE_CLIENT_SECRET", actblue_client_secret
-        )
+        self.actblue_client_uuid = check_env.check("ACTBLUE_CLIENT_UUID", actblue_client_uuid)
+        self.actblue_client_secret = check_env.check("ACTBLUE_CLIENT_SECRET", actblue_client_secret)
         self.uri = (
             check_env.check("ACTBLUE_URI", actblue_uri, optional=True) or ACTBLUE_API_ENDPOINT
         )

--- a/parsons/capitol_canary/capitol_canary.py
+++ b/parsons/capitol_canary/capitol_canary.py
@@ -35,8 +35,8 @@ class CapitolCanary:
         cc_app_id = check_env.check("CAPITOLCANARY_APP_ID", None, optional=True)
         cc_app_key = check_env.check("CAPITOLCANARY_APP_KEY", None, optional=True)
 
-        self.app_id: str = cc_app_id or check_env.check("PHONE2ACTION_APP_ID", app_id)
-        self.app_key: str = cc_app_key or check_env.check("PHONE2ACTION_APP_KEY", app_key)
+        self.app_id = cc_app_id or check_env.check("PHONE2ACTION_APP_ID", app_id)
+        self.app_key = cc_app_key or check_env.check("PHONE2ACTION_APP_KEY", app_key)
         self.auth = HTTPBasicAuth(self.app_id, self.app_key)
         self.client = APIConnector(CAPITOL_CANARY_URI, auth=self.auth)
 

--- a/parsons/donorbox/donorbox.py
+++ b/parsons/donorbox/donorbox.py
@@ -27,8 +27,8 @@ class Donorbox:
     """
 
     def __init__(self, email=None, api_key=None):
-        self.email: str = check_env.check("DONORBOX_ACCOUNT_EMAIL", email)
-        self.api_key: str = check_env.check("DONORBOX_API_KEY", api_key)
+        self.email = check_env.check("DONORBOX_ACCOUNT_EMAIL", email)
+        self.api_key = check_env.check("DONORBOX_API_KEY", api_key)
         self.uri = URI
         self.client = APIConnector(self.uri, auth=HTTPBasicAuth(self.email, self.api_key))
 

--- a/parsons/freshdesk/freshdesk.py
+++ b/parsons/freshdesk/freshdesk.py
@@ -30,8 +30,8 @@ class Freshdesk:
     """
 
     def __init__(self, domain, api_key):
-        self.api_key: str = check_env.check("FRESHDESK_API_KEY", api_key)
-        self.domain: str = check_env.check("FRESHDESK_DOMAIN", domain)
+        self.api_key = check_env.check("FRESHDESK_API_KEY", api_key)
+        self.domain = check_env.check("FRESHDESK_DOMAIN", domain)
         self.uri = f"https://{self.domain}.freshdesk.com/api/v2/"
         self.client = APIConnector(self.uri, auth=HTTPBasicAuth(self.api_key, "x"))
 

--- a/parsons/mailchimp/mailchimp.py
+++ b/parsons/mailchimp/mailchimp.py
@@ -26,7 +26,7 @@ class Mailchimp:
     """
 
     def __init__(self, api_key=None):
-        self.api_key: str = check_env.check("MAILCHIMP_API_KEY", api_key)
+        self.api_key = check_env.check("MAILCHIMP_API_KEY", api_key)
         self.domain = re.findall("(?<=-).+$", self.api_key)[0]
         self.uri = f"https://{self.domain}.api.mailchimp.com/3.0/"
         self.client = APIConnector(self.uri, auth=HTTPBasicAuth("x", self.api_key))

--- a/parsons/newmode/newmode.py
+++ b/parsons/newmode/newmode.py
@@ -48,8 +48,8 @@ class NewmodeV1:
         logger.warning(
             "Newmode V1 API will be sunset in Feburary 28th, 2025. To use V2, set api_version=v2.1"
         )
-        self.api_user: str = check_env.check("NEWMODE_API_USER", api_user)
-        self.api_password: str = check_env.check("NEWMODE_API_PASSWORD", api_password)
+        self.api_user = check_env.check("NEWMODE_API_USER", api_user)
+        self.api_password = check_env.check("NEWMODE_API_PASSWORD", api_password)
         self.api_version: str | None = api_version
         self.client: Client = Client(api_user, api_password, api_version)
 
@@ -463,8 +463,8 @@ class NewmodeV2:
         """
         self.api_version: str = api_version
         self.base_url: str = V2_API_URL
-        self.client_id: str = check_env.check("NEWMODE_API_CLIENT_ID", client_id)
-        self.client_secret: str = check_env.check("NEWMODE_API_CLIENT_SECRET", client_secret)
+        self.client_id = check_env.check("NEWMODE_API_CLIENT_ID", client_id)
+        self.client_secret = check_env.check("NEWMODE_API_CLIENT_SECRET", client_secret)
         self.headers: dict[str, str] = {"content-type": "application/json"}
         self.default_client: OAuth2APIConnector = self.get_default_oauth_client()
         self.campaigns_client: OAuth2APIConnector = self.get_campaigns_oauth_client()

--- a/parsons/ngpvan/van_connector.py
+++ b/parsons/ngpvan/van_connector.py
@@ -20,7 +20,7 @@ class VANConnector:
         auth_name="default",
         db: Literal["MyVoters", "MyCampaign", "MyMembers", "EveryAction"] | None = None,
     ):
-        self.api_key: str = check_env.check("VAN_API_KEY", api_key)
+        self.api_key = check_env.check("VAN_API_KEY", api_key)
 
         if db == "MyVoters":
             self.db_code = 0

--- a/parsons/shopify/shopify.py
+++ b/parsons/shopify/shopify.py
@@ -45,8 +45,8 @@ class Shopify:
     ):
         self.subdomain = check_env.check("SHOPIFY_SUBDOMAIN", subdomain)
         self.access_token = check_env.check("SHOPIFY_ACCESS_TOKEN", access_token, optional=True)
-        self.password: str = check_env.check("SHOPIFY_PASSWORD", password, optional=True)
-        self.api_key: str = check_env.check("SHOPIFY_API_KEY", api_key, optional=True)
+        self.password = check_env.check("SHOPIFY_PASSWORD", password, optional=True)
+        self.api_key = check_env.check("SHOPIFY_API_KEY", api_key, optional=True)
         self.api_version = check_env.check("SHOPIFY_API_VERSION", api_version)
         self.base_url = f"https://{self.subdomain}.myshopify.com/admin/api/{self.api_version}/"
         if self.access_token is None and (self.password is None or self.api_key is None):

--- a/parsons/utilities/check_env.py
+++ b/parsons/utilities/check_env.py
@@ -8,17 +8,6 @@ T = TypeVar("T")
 @overload
 def check(
     env: str,
-    value: T,
-    opt: bool | None = ...,
-    *,
-    optional: bool = ...,
-    field: T | None = ...,
-) -> T: ...
-
-
-@overload
-def check(
-    env: str,
     value: None = None,
     opt: bool | None = ...,
     *,
@@ -36,6 +25,28 @@ def check(
     optional: Literal[False] = False,
     field: None = None,
 ) -> str: ...
+
+
+@overload
+def check(
+    env: str,
+    value: T | None = ...,
+    opt: bool | None = ...,
+    *,
+    optional: Literal[False] = False,
+    field: T | None = ...,
+) -> T | str: ...
+
+
+@overload
+def check(
+    env: str,
+    value: T | None = ...,
+    opt: bool | None = ...,
+    *,
+    optional: Literal[True],
+    field: T | None = ...,
+) -> T | str | None: ...
 
 
 def check(


### PR DESCRIPTION
## What is this change?

- Add additional overload signature and change overload order to provide more helpful return type hinting by making it clear that the value returned will **always** match the value passed in, if provided.
- Remove str type hints that had been added in connectors to work around this issue.

## Considerations for discussion

- #1826 got pretty close with the type hinting of `check_env.check`, but type checkers still had a hard time understanding what type to expect when it was optional/not-optional AND supplied with a value.

## How to test the changes (if needed)

- This is only used in static code analysis

## Breaking Changes

Breaking changes are changes to our public API which may require existing users to change their code. If there are no breaking changes, any existing parsons user should not need to do anything after updating their parsons version.

<details open>

<summary>Does this PR introduce breaking changes?</summary>

<!-- Pick only one. [x] is selected, [ ] is not -->

- [ ] label: Breaking change — This PR introduces one or more breaking changes.
- [x] label: Non-breaking change — This PR does not introduce one or more breaking changes.

</details>

### Details (if needed)

- (List out any changes to the API that may cause breaks for developer implementation.)
